### PR TITLE
Faster kirchoff cycle creation (define_passive_branch_flows_with_kirchhoff)

### DIFF
--- a/examples/build_model.py
+++ b/examples/build_model.py
@@ -1,0 +1,245 @@
+## Demonstrate PyPSA unit commitment with a one-bus two-generator example
+#
+#
+#To enable unit commitment on a generator, set its attribute committable = True.
+#
+#
+#Available as a Jupyter notebook at http://www.pypsa.org/examples/unit-commitment.ipynb.
+
+import pypsa
+
+from pypsa.opt import network_lopf_build_model as build_model
+
+### Minimum part load demonstration
+#
+#In final hour load goes below part-load limit of coal gen (30%), forcing gas to commit.
+
+for test_i in range(100):
+
+    nu = pypsa.Network()
+
+    nu.set_snapshots(range(4))
+
+    nu.add("Bus","bus")
+
+
+    nu.add("Generator","coal",bus="bus",
+           committable=True,
+           p_min_pu=0.3,
+           marginal_cost=20,
+           p_nom=10000)
+
+    nu.add("Generator","gas",bus="bus",
+           committable=True,
+           marginal_cost=70,
+           p_min_pu=0.1,
+           p_nom=1000)
+
+    nu.add("Load","load",bus="bus",p_set=[4000,6000,5000,800])
+
+    build_model( nu, nu.snapshots)
+
+    nu.generators_t.status
+
+    nu.generators_t.p
+
+    ### Minimum up time demonstration
+    #
+    #Gas has minimum up time, forcing it to be online longer
+
+    nu = pypsa.Network()
+
+    nu.set_snapshots(range(4))
+
+    nu.add("Bus","bus")
+
+
+    nu.add("Generator","coal",bus="bus",
+           committable=True,
+           p_min_pu=0.3,
+           marginal_cost=20,
+           p_nom=10000)
+
+    nu.add("Generator","gas",bus="bus",
+           committable=True,
+           marginal_cost=70,
+           p_min_pu=0.1,
+           initial_status=0,
+           min_up_time=3,
+           p_nom=1000)
+
+    nu.add("Load","load",bus="bus",p_set=[4000,800,5000,3000])
+
+    build_model( nu, nu.snapshots)
+
+    nu.generators_t.status
+
+    nu.generators_t.p
+
+    ### Minimum down time demonstration
+    #
+    #Coal has a minimum down time, forcing it to go off longer.
+
+    nu = pypsa.Network()
+
+    nu.set_snapshots(range(4))
+
+    nu.add("Bus","bus")
+
+
+    nu.add("Generator","coal",bus="bus",
+           committable=True,
+           p_min_pu=0.3,
+           marginal_cost=20,
+           min_down_time=2,
+           p_nom=10000)
+
+    nu.add("Generator","gas",bus="bus",
+           committable=True,
+           marginal_cost=70,
+           p_min_pu=0.1,
+           initial_status=0,
+           p_nom=4000)
+
+    nu.add("Load","load",bus="bus",p_set=[3000,800,3000,8000])
+
+    build_model( nu, nu.snapshots)
+
+    nu.objective
+
+    nu.generators_t.status
+
+    nu.generators_t.p
+
+    ### Start up and shut down costs
+    #
+    #Now there are associated costs for shutting down, etc
+
+
+
+    nu = pypsa.Network()
+
+    nu.set_snapshots(range(4))
+
+    nu.add("Bus","bus")
+
+
+    nu.add("Generator","coal",bus="bus",
+           committable=True,
+           p_min_pu=0.3,
+           marginal_cost=20,
+           min_down_time=2,
+           start_up_cost=5000,
+           p_nom=10000)
+
+    nu.add("Generator","gas",bus="bus",
+           committable=True,
+           marginal_cost=70,
+           p_min_pu=0.1,
+           initial_status=0,
+           shut_down_cost=25,
+           p_nom=4000)
+
+    nu.add("Load","load",bus="bus",p_set=[3000,800,3000,8000])
+
+    build_model( nu, nu.snapshots)
+
+    nu.objective
+
+    nu.generators_t.status
+
+    nu.generators_t.p
+
+    ## Ramp rate limits
+
+    import pypsa
+
+    nu = pypsa.Network()
+
+    nu.set_snapshots(range(6))
+
+    nu.add("Bus","bus")
+
+
+    nu.add("Generator","coal",bus="bus",
+           marginal_cost=20,
+           ramp_limit_up=0.1,
+           ramp_limit_down=0.2,
+           p_nom=10000)
+
+    nu.add("Generator","gas",bus="bus",
+           marginal_cost=70,
+           p_nom=4000)
+
+    nu.add("Load","load",bus="bus",p_set=[4000,7000,7000,7000,7000,3000])
+
+    build_model( nu, nu.snapshots)
+
+    nu.generators_t.p
+
+    import pypsa
+
+    nu = pypsa.Network()
+
+    nu.set_snapshots(range(6))
+
+    nu.add("Bus","bus")
+
+
+    nu.add("Generator","coal",bus="bus",
+           marginal_cost=20,
+           ramp_limit_up=0.1,
+           ramp_limit_down=0.2,
+           p_nom_extendable=True,
+           capital_cost=1e2)
+
+    nu.add("Generator","gas",bus="bus",
+           marginal_cost=70,
+           p_nom=4000)
+
+    nu.add("Load","load",bus="bus",p_set=[4000,7000,7000,7000,7000,3000])
+
+    build_model( nu, nu.snapshots)
+
+    nu.generators.p_nom_opt
+
+    nu.generators_t.p
+
+    import pypsa
+
+    nu = pypsa.Network()
+
+    nu.set_snapshots(range(7))
+
+    nu.add("Bus","bus")
+
+
+    #Can get bad interactions if SU > RU and p_min_pu; similarly if SD > RD
+
+
+    nu.add("Generator","coal",bus="bus",
+           marginal_cost=20,
+           committable=True,
+           p_min_pu=0.05,
+           initial_status=0,
+           ramp_limit_start_up=0.1,
+           ramp_limit_up=0.2,
+           ramp_limit_down=0.25,
+           ramp_limit_shut_down=0.15,
+           p_nom=10000.)
+
+    nu.add("Generator","gas",bus="bus",
+           marginal_cost=70,
+           p_nom=10000)
+
+    nu.add("Load","load",bus="bus",p_set=[0.,200.,7000,7000,7000,2000,0])
+
+    build_model( nu, nu.snapshots)
+
+    nu.generators_t.p
+
+    nu.generators_t.status
+
+    nu.generators.initial_status
+
+    nu.generators.loc["coal"]

--- a/examples/build_model.py
+++ b/examples/build_model.py
@@ -16,7 +16,7 @@ from pypsa.opf import network_lopf_build_model as build_model
 
 for test_i in range(1):
 
-    snapshots = range( 1, 1000)
+    snapshots = range( 1, 10000)
     p_set = [ p*20 for p in snapshots]
 
     nu = pypsa.Network()
@@ -40,7 +40,7 @@ for test_i in range(1):
 
     nu.add("Load","load",bus="bus",p_set= p_set )#[4000,6000,5000,800])
 
-    build_model( nu, nu.snapshots)
+    build_model( nu, nu.snapshots, formulation = "kirchoff")
 
     nu.generators_t.status
 
@@ -71,7 +71,7 @@ for test_i in range(1):
 
     nu.add("Load","load",bus="bus",p_set= p_set )#[4000,800,5000,3000])
 
-    build_model( nu, nu.snapshots)
+    build_model( nu, nu.snapshots, formulation = "kirchoff")
 
     nu.generators_t.status
 
@@ -104,7 +104,7 @@ for test_i in range(1):
 
     nu.add("Load","load",bus="bus",p_set= p_set )#[3000,800,3000,8000])
 
-    build_model( nu, nu.snapshots)
+    build_model( nu, nu.snapshots, formulation = "kirchoff")
 
     ### Start up and shut down costs
     #
@@ -137,7 +137,7 @@ for test_i in range(1):
 
     nu.add("Load","load",bus="bus",p_set= p_set )#[3000,800,3000,8000])
 
-    build_model( nu, nu.snapshots)
+    build_model( nu, nu.snapshots, formulation = "kirchoff")
 
 
     ## Ramp rate limits
@@ -163,7 +163,7 @@ for test_i in range(1):
 
     nu.add("Load","load",bus="bus",p_set= p_set )#[4000,7000,7000,7000,7000,3000])
 
-    build_model( nu, nu.snapshots)
+    build_model( nu, nu.snapshots, formulation = "kirchoff")
 
     nu.generators_t.p
 
@@ -189,7 +189,7 @@ for test_i in range(1):
 
     nu.add("Load","load",bus="bus",p_set= p_set )#[4000,7000,7000,7000,7000,3000])
 
-    build_model( nu, nu.snapshots)
+    build_model( nu, nu.snapshots, formulation = "kirchoff")
 
     import pypsa
 
@@ -220,4 +220,4 @@ for test_i in range(1):
 
     nu.add("Load","load",bus="bus",p_set= p_set )#[0.,200.,7000,7000,7000,2000,0])
 
-    build_model( nu, nu.snapshots)
+    build_model( nu, nu.snapshots, formulation = "kirchoff")

--- a/examples/build_model.py
+++ b/examples/build_model.py
@@ -14,11 +14,14 @@ from pypsa.opf import network_lopf_build_model as build_model
 #
 #In final hour load goes below part-load limit of coal gen (30%), forcing gas to commit.
 
-for test_i in range(10):
+for test_i in range(1):
+
+    snapshots = range( 1, 1000)
+    p_set = [ p*20 for p in snapshots]
 
     nu = pypsa.Network()
 
-    nu.set_snapshots(range(4))
+    nu.set_snapshots(snapshots)
 
     nu.add("Bus","bus")
 
@@ -35,7 +38,7 @@ for test_i in range(10):
            p_min_pu=0.1,
            p_nom=1000)
 
-    nu.add("Load","load",bus="bus",p_set=[4000,6000,5000,800])
+    nu.add("Load","load",bus="bus",p_set= p_set )#[4000,6000,5000,800])
 
     build_model( nu, nu.snapshots)
 
@@ -49,10 +52,8 @@ for test_i in range(10):
 
     nu = pypsa.Network()
 
-    nu.set_snapshots(range(4))
-
+    nu.set_snapshots( snapshots)
     nu.add("Bus","bus")
-
 
     nu.add("Generator","coal",bus="bus",
            committable=True,
@@ -68,7 +69,7 @@ for test_i in range(10):
            min_up_time=3,
            p_nom=1000)
 
-    nu.add("Load","load",bus="bus",p_set=[4000,800,5000,3000])
+    nu.add("Load","load",bus="bus",p_set= p_set )#[4000,800,5000,3000])
 
     build_model( nu, nu.snapshots)
 
@@ -82,7 +83,7 @@ for test_i in range(10):
 
     nu = pypsa.Network()
 
-    nu.set_snapshots(range(4))
+    nu.set_snapshots( snapshots)
 
     nu.add("Bus","bus")
 
@@ -101,7 +102,7 @@ for test_i in range(10):
            initial_status=0,
            p_nom=4000)
 
-    nu.add("Load","load",bus="bus",p_set=[3000,800,3000,8000])
+    nu.add("Load","load",bus="bus",p_set= p_set )#[3000,800,3000,8000])
 
     build_model( nu, nu.snapshots)
 
@@ -113,7 +114,7 @@ for test_i in range(10):
 
     nu = pypsa.Network()
 
-    nu.set_snapshots(range(4))
+    nu.set_snapshots( snapshots)
 
     nu.add("Bus","bus")
 
@@ -134,7 +135,7 @@ for test_i in range(10):
            shut_down_cost=25,
            p_nom=4000)
 
-    nu.add("Load","load",bus="bus",p_set=[3000,800,3000,8000])
+    nu.add("Load","load",bus="bus",p_set= p_set )#[3000,800,3000,8000])
 
     build_model( nu, nu.snapshots)
 
@@ -145,7 +146,7 @@ for test_i in range(10):
 
     nu = pypsa.Network()
 
-    nu.set_snapshots(range(6))
+    nu.set_snapshots( snapshots)
 
     nu.add("Bus","bus")
 
@@ -160,7 +161,7 @@ for test_i in range(10):
            marginal_cost=70,
            p_nom=4000)
 
-    nu.add("Load","load",bus="bus",p_set=[4000,7000,7000,7000,7000,3000])
+    nu.add("Load","load",bus="bus",p_set= p_set )#[4000,7000,7000,7000,7000,3000])
 
     build_model( nu, nu.snapshots)
 
@@ -170,7 +171,7 @@ for test_i in range(10):
 
     nu = pypsa.Network()
 
-    nu.set_snapshots(range(6))
+    nu.set_snapshots( snapshots)
 
     nu.add("Bus","bus")
 
@@ -186,7 +187,7 @@ for test_i in range(10):
            marginal_cost=70,
            p_nom=4000)
 
-    nu.add("Load","load",bus="bus",p_set=[4000,7000,7000,7000,7000,3000])
+    nu.add("Load","load",bus="bus",p_set= p_set )#[4000,7000,7000,7000,7000,3000])
 
     build_model( nu, nu.snapshots)
 
@@ -194,7 +195,7 @@ for test_i in range(10):
 
     nu = pypsa.Network()
 
-    nu.set_snapshots(range(7))
+    nu.set_snapshots( snapshots)
 
     nu.add("Bus","bus")
 
@@ -217,6 +218,6 @@ for test_i in range(10):
            marginal_cost=70,
            p_nom=10000)
 
-    nu.add("Load","load",bus="bus",p_set=[0.,200.,7000,7000,7000,2000,0])
+    nu.add("Load","load",bus="bus",p_set= p_set )#[0.,200.,7000,7000,7000,2000,0])
 
     build_model( nu, nu.snapshots)

--- a/examples/build_model.py
+++ b/examples/build_model.py
@@ -14,6 +14,8 @@ import argparse
 import logging
 import random
 
+random.seed( 55)
+
 parser = argparse.ArgumentParser()
 
 parser.add_argument(

--- a/examples/build_model.py
+++ b/examples/build_model.py
@@ -8,13 +8,13 @@
 
 import pypsa
 
-from pypsa.opt import network_lopf_build_model as build_model
+from pypsa.opf import network_lopf_build_model as build_model
 
 ### Minimum part load demonstration
 #
 #In final hour load goes below part-load limit of coal gen (30%), forcing gas to commit.
 
-for test_i in range(100):
+for test_i in range(10):
 
     nu = pypsa.Network()
 
@@ -105,12 +105,6 @@ for test_i in range(100):
 
     build_model( nu, nu.snapshots)
 
-    nu.objective
-
-    nu.generators_t.status
-
-    nu.generators_t.p
-
     ### Start up and shut down costs
     #
     #Now there are associated costs for shutting down, etc
@@ -144,11 +138,6 @@ for test_i in range(100):
 
     build_model( nu, nu.snapshots)
 
-    nu.objective
-
-    nu.generators_t.status
-
-    nu.generators_t.p
 
     ## Ramp rate limits
 
@@ -201,10 +190,6 @@ for test_i in range(100):
 
     build_model( nu, nu.snapshots)
 
-    nu.generators.p_nom_opt
-
-    nu.generators_t.p
-
     import pypsa
 
     nu = pypsa.Network()
@@ -235,11 +220,3 @@ for test_i in range(100):
     nu.add("Load","load",bus="bus",p_set=[0.,200.,7000,7000,7000,2000,0])
 
     build_model( nu, nu.snapshots)
-
-    nu.generators_t.p
-
-    nu.generators_t.status
-
-    nu.generators.initial_status
-
-    nu.generators.loc["coal"]

--- a/examples/build_model.py
+++ b/examples/build_model.py
@@ -13,6 +13,7 @@ from pypsa.opf import network_lopf_build_model as build_model
 import argparse
 import logging
 import random
+import copy
 
 random.seed( 55)
 
@@ -80,39 +81,9 @@ for test_i in range(1):
                    x = .2,
                    r = .08)
 
-    print( nu.branches())
-
-    build_model( nu, nu.snapshots, formulation = "kirchhoff")
+    formulations = ["kirchhoff", "angles", "cycles"] #"ptdf"
+    for formulation in formulations:
+        nu_copy = copy.deepcopy(nu)
+        build_model( nu, nu.snapshots, formulation = formulation)
 #    build_model( nu, nu.snapshots, formulation = "angles")
 #    nu.lopf( nu.snapshots, formulation = "kirchhoff")
-
-    nu.generators_t.status
-
-    nu.generators_t.p
-
-    ### Minimum up time demonstration
-    #
-    #Gas has minimum up time, forcing it to be online longer
-
-    nu = pypsa.Network()
-
-    nu.set_snapshots( snapshots)
-    nu.add("Bus","bus")
-
-    nu.add("Generator","coal",bus="bus",
-           committable=True,
-           p_min_pu=0.3,
-           marginal_cost=20,
-           p_nom=10000)
-
-    nu.add("Generator","gas",bus="bus",
-           committable=True,
-           marginal_cost=70,
-           p_min_pu=0.1,
-           initial_status=0,
-           min_up_time=3,
-           p_nom=1000)
-
-    nu.add("Load","load",bus="bus",p_set= p_set )#[4000,800,5000,3000])
-
-    build_model( nu, nu.snapshots, formulation = "kirchhoff")

--- a/examples/build_model.py
+++ b/examples/build_model.py
@@ -12,6 +12,7 @@ from pypsa.opf import network_lopf_build_model as build_model
 
 import argparse
 import logging
+import random
 
 parser = argparse.ArgumentParser()
 
@@ -25,6 +26,7 @@ parser.add_argument(
     help="Print lots of debugging statements",
     action="store_const", dest="loglevel", const=logging.DEBUG,
     default=logging.WARNING,
+
 )
 args = parser.parse_args()
 logging.basicConfig( level=args.loglevel)
@@ -35,31 +37,52 @@ logging.basicConfig( level=args.loglevel)
 
 for test_i in range(1):
 
-    snapshots = range( 1, 1001)
+    snapshots = range( 1, 101)
     p_set = [ p*20 for p in snapshots]
 
     nu = pypsa.Network()
 
     nu.set_snapshots(snapshots)
 
-    nu.add("Bus","bus")
 
-    generator_p_nom = [ i for i in range( 100)]
-    generator_marginal_cost = [ 1000 - i for i in range(100) ]
+    n_gen = 100
+
+    generator_p_nom = [ i for i in range( n_gen)]
+    generator_marginal_cost = [ 1000 - i for i in range( n_gen)]
     p_min_pu = .3
 
     for gen_i, gen in enumerate( generator_p_nom):
+        nu.add("Bus","bus" + str(gen_i))
+        nu.add("Load","load" + str(gen_i),bus= "bus" + str(gen_i),
+               p_set= generator_p_nom[gen_i] / 2. )#[4000,6000,5000,800])
+
         nu.add( "Generator",
                 "gas_" + str(gen_i),
-                bus = "bus",
+                bus = "bus" + str(gen_i),
                 committable = True,
                 p_min_pu = p_min_pu,
                 marginal_cost = generator_marginal_cost[gen_i],
                 p_nom = generator_p_nom[gen_i],)
+        if gen_i > 0:
+            nu.add("Line",
+                   "{} - {} line".format( gen_i - 1, gen_i),
+                   bus0= "bus" + str(gen_i - 1),
+                   bus1= "bus" + str(gen_i),
+                   x=0.1,
+                   r=0.01)
+            random_gen_to_connect = random.randint( 0, n_gen - 1)
+            nu.add("Line",
+                   "{} - {} line".format( gen_i, random_gen_to_connect),
+                   bus0= "bus" + str(random_gen_to_connect),
+                   bus1= "bus" + str(gen_i),
+                   x = .2,
+                   r = .08)
 
-    nu.add("Load","load",bus="bus",p_set= p_set )#[4000,6000,5000,800])
+    print( nu.branches())
 
-    build_model( nu, nu.snapshots, formulation = "kirchoff")
+    build_model( nu, nu.snapshots, formulation = "kirchhoff")
+#    build_model( nu, nu.snapshots, formulation = "angles")
+#    nu.lopf( nu.snapshots, formulation = "kirchhoff")
 
     nu.generators_t.status
 
@@ -90,4 +113,4 @@ for test_i in range(1):
 
     nu.add("Load","load",bus="bus",p_set= p_set )#[4000,800,5000,3000])
 
-    build_model( nu, nu.snapshots, formulation = "kirchoff")
+    build_model( nu, nu.snapshots, formulation = "kirchhoff")

--- a/examples/minimal_example_lopf.py
+++ b/examples/minimal_example_lopf.py
@@ -6,7 +6,6 @@
 from __future__ import print_function, division
 import pypsa
 import numpy as np
-import pypsa.opf as opf
 
 network = pypsa.Network()
 
@@ -57,10 +56,7 @@ def my_f(network,snapshots):
     print(snapshots)
 
 
-network.set_snapshots(range(10000))
-
-opf.network_lopf_build_model( network, network.snapshots)
-#network.lopf(extra_functionality=my_f)
+network.lopf(extra_functionality=my_f)
 
 #Cheap generator 1 cannot be fully dispatched because of network constraints,
 #so expensive generator 0 also has to dispatch
@@ -82,3 +78,4 @@ print(network.buses_t.v_mag_pu)
 #it from expensive generator 0, also some dispatch from cheap generator 1 has to be substituted from generator0
 #to avoid overloading line 1.
 print(network.buses_t.marginal_price)
+

--- a/examples/minimal_example_lopf.py
+++ b/examples/minimal_example_lopf.py
@@ -6,6 +6,7 @@
 from __future__ import print_function, division
 import pypsa
 import numpy as np
+import pypsa.opf as opf
 
 network = pypsa.Network()
 
@@ -56,7 +57,10 @@ def my_f(network,snapshots):
     print(snapshots)
 
 
-network.lopf(extra_functionality=my_f)
+network.set_snapshots(range(10000))
+
+opf.network_lopf_build_model( network, network.snapshots)
+#network.lopf(extra_functionality=my_f)
 
 #Cheap generator 1 cannot be fully dispatched because of network constraints,
 #so expensive generator 0 also has to dispatch
@@ -78,4 +82,3 @@ print(network.buses_t.v_mag_pu)
 #it from expensive generator 0, also some dispatch from cheap generator 1 has to be substituted from generator0
 #to avoid overloading line 1.
 print(network.buses_t.marginal_price)
-

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -28,7 +28,6 @@ from six import iteritems, string_types
 __author__ = "Tom Brown (FIAS), Jonas Hoersch (FIAS), David Schlachtberger (FIAS)"
 __copyright__ = "Copyright 2015-2017 Tom Brown (FIAS), Jonas Hoersch (FIAS), David Schlachtberger (FIAS), GNU GPL 3"
 
-import itertools
 import numpy as np
 import pandas as pd
 from scipy.sparse.linalg import spsolve
@@ -802,23 +801,8 @@ def define_passive_branch_flows_with_cycles(network,snapshots):
                  list(passive_branches.index), snapshots)
 
 
-def using_tocoo_izip(x):
-    """ from https://stackoverflow.com/questions/4319014/iterating-through-a-scipy-sparse-vector-or-matrix,
-    to more quickly iterate the dok matrix.
-
-    Moved actual conversion into kirchhoff, to allow yield here
-    """
-
-    for i,j,v in itertools.izip(cx.row, cx.col, cx.data):
-        yield (i,j,v)
-
 def define_sub_network_cycle_constraints( subnetwork, snapshots, passive_branch_p, attribute):
     """ Constructs cycle_constraints for a particular subnetwork
-
-    Uses CSC matrix structure for faster iteration
-
-    Adapted from
-    https://stackoverflow.com/a/42625707/6753312
     """
 
     sub_network_cycle_constraints = {}
@@ -827,7 +811,6 @@ def define_sub_network_cycle_constraints( subnetwork, snapshots, passive_branch_
     matrix = subnetwork.C.tocsr()
     branches = subnetwork.branches()
 
-#    for cycle_i, col, matrix_data in itertools.izip( matrix.row, matrix.col, matrix.data):
     for col_j in range( matrix.shape[1] ):
         cycle_is = matrix.getcol(col_j).nonzero()[0]
 
@@ -881,7 +864,6 @@ def define_passive_branch_flows_with_kirchhoff(network,snapshots,skip_vars=False
 
         csc_rep = subnetwork.C.tocoo()
 
-        #TODO fix the inputs here
         sub_network_cycle_index, sub_network_cycle_constraints = define_sub_network_cycle_constraints( subnetwork,
                                                                                                        snapshots,
                                                                                                        network.model.passive_branch_p, attribute)

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -850,12 +850,13 @@ def define_passive_branch_flows_with_kirchhoff(network,snapshots,skip_vars=False
             cycle_index.append((subnetwork.name, j))
 
 
-
-            branch_idxs, time_ind_params = zip( *[ (
-                branches.index[cycle_i],
-                branches.at[branch_idx,attribute]*(branches.at[branch_idx,"tap_ratio"] \
-                                                   if branch_idx[0] == "Transformer" else 1.)*subnetwork.C[cycle_i, j]
-            ) for  itertools.product( branch_idxs, cycle_is)] )
+            branch_idxs = []
+            time_ind_params = []
+            for cycle_i in cycle_is:
+                branch_idx = branches.index[cycle_i]
+                branch_idxs.append(branch_idx)
+                time_ind_params.append(  branches.at[branch_idx,attribute]*(branches.at[branch_idx,"tap_ratio"] \
+                                                   if branch_idx[0] == "Transformer" else 1.)*subnetwork.C[cycle_i, j])
 
             # branch_idxs =    [ branches.index[cycle_i] for cycle_i in cycle_is ]
 

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -736,7 +736,7 @@ def define_sub_network_cycle_constraints( subnetwork, snapshots, passive_branch_
     sub_network_cycle_constraints = {}
     sub_network_cycle_index = []
 
-    matrix = subnetwork.C.tocsr()
+    matrix = subnetwork.C.tocsc()
     branches = subnetwork.branches()
 
     for col_j in range( matrix.shape[1] ):

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -838,30 +838,9 @@ def define_passive_branch_flows_with_kirchhoff(network,snapshots,skip_vars=False
         branches = subnetwork.branches()
         attribute = "r_pu" if network.sub_networks.at[subnetwork.name,"carrier"] == "DC" else "x_pu"
 
-        #https://stackoverflow.com/questions/4319014/iterating-through-a-scipy-sparse-vector-or-matrix
-#         cx = subnetwork.C.tocoo()
-#         for cycle_i,j,value in itertools.izip(cx.row, cx.col, cx.data):
-#             cycle_is
-#             for snapshot in snapshots:
-#                 lhs = LExpression([ (branches.at[branches.index[cycle_i],attribute]*
-#                                     (branches.at[branches.index[cycle_i],"tap_ratio"] if branches.index[cycle_i][0] == "Transformer" else 1.)*value,
-
-# #*subnetwork.C[cycle_i,j],
-#                                     network.model.passive_branch_p[branches.index[cycle_i][0], branches.index[cycle_i][1], snapshot])])
-
-#                 cycle_constraints[subnetwork.name, j, snapshot] = LConstraint( lhs, "==", LExpression())
-
-
-#lhs = LExpression([(branches.at[branches.index[i],attribute]*
-#                                    (branches.at[branches.index[i],"tap_ratio"] if branches.index[i][0] == "Transformer" else 1.)*sn.C[i,j],
-#                                    network.model.passive_branch_p[branches.index[i][0], branches.index[i][1], snapshot])
-#                   for i in cycle_is])
-
         for j in range(subnetwork.C.shape[1]):
 
-#             cycle_is = subnetwork.C.getcol(j)#subnetwork.C[:,j].nonzero()[0]
              cycle_is = subnetwork.C[:,j].nonzero()[0]
-#             print(cycle_is)
 
              if len(cycle_is) == 0: continue
 
@@ -869,15 +848,12 @@ def define_passive_branch_flows_with_kirchhoff(network,snapshots,skip_vars=False
 
              branch_idxs =    [ branches.index[cycle_i] for cycle_i in cycle_is ]
              time_ind_params = [ branches.at[branch_idx,attribute]*(branches.at[branch_idx,"tap_ratio"] \
-                                                                   if branch_idx[0] == "Transformer" else 1.)*subnetwork.C[cycle_i,j] for branch_idx in branch_idxs]
+                                                                   if branch_idx[0] == "Transformer" else 1.)*subnetwork.C[cycle_i, j] for branch_idx in branch_idxs]
              for snapshot in snapshots:
-                 print( time_ind_params)
-                 print( network.model.passive_branch_p[branch_idx[0], branch_idx[1], snapshot])
                  expression_list = [ (time_ind_param,
                                       network.model.passive_branch_p[branch_idx[0], branch_idx[1], snapshot]) for (branch_idx, time_ind_param) in zip(branch_idxs, time_ind_params)]
 
                  lhs = LExpression(expression_list)
-#                                    for cycle_i in cycle_is])
                  cycle_constraints[subnetwork.name,j,snapshot] = LConstraint(lhs,"==",LExpression())
 
     l_constraint(network.model, "cycle_constraints", cycle_constraints,

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -825,6 +825,9 @@ def define_passive_branch_flows_with_kirchhoff(network,snapshots,skip_vars=False
         if len(sub_network.branches_i()) > 0:
             calculate_B_H(sub_network)
 
+    print( sub_network.T)
+    print( sub_network.C)
+
     passive_branches = network.passive_branches()
 
     if not skip_vars:
@@ -833,28 +836,29 @@ def define_passive_branch_flows_with_kirchhoff(network,snapshots,skip_vars=False
     cycle_index = []
     cycle_constraints = {}
 
-    for subnetwork in network.sub_networks.obj:
+    for sn in network.sub_networks.obj:
 
-        branches = subnetwork.branches()
-        attribute = "r_pu" if network.sub_networks.at[subnetwork.name,"carrier"] == "DC" else "x_pu"
+        branches = sn.branches()
+        attribute = "r_pu" if network.sub_networks.at[sn.name,"carrier"] == "DC" else "x_pu"
 
-        for j in range(subnetwork.C.shape[1]):
+        for j in range(sn.C.shape[1]):
 
-             cycle_is = subnetwork.C[:,j].nonzero()[0]
+            cycle_is = sn.C[:,j].nonzero()[0]
 
-             if len(cycle_is) == 0: continue
+            if len(cycle_is) == 0: continue
 
-             cycle_index.append((subnetwork.name, j))
+            cycle_index.append((sn.name, j))
 
-             branch_idxs =    [ branches.index[cycle_i] for cycle_i in cycle_is ]
-             time_ind_params = [ branches.at[branch_idx,attribute]*(branches.at[branch_idx,"tap_ratio"] \
-                                                                   if branch_idx[0] == "Transformer" else 1.)*subnetwork.C[cycle_i, j] for branch_idx in branch_idxs]
-             for snapshot in snapshots:
-                 expression_list = [ (time_ind_param,
+            branch_idxs =    [ branches.index[cycle_i] for cycle_i in cycle_is ]
+            time_ind_params = [ -1 * branches.at[branch_idx,attribute]*(branches.at[branch_idx,"tap_ratio"] \
+                                                                   if branch_idx[0] == "Transformer" else 1.)*sn.C[cycle_i, j] for branch_idx in branch_idxs]
+
+            for snapshot in snapshots:
+                expression_list = [ (time_ind_param,
                                       network.model.passive_branch_p[branch_idx[0], branch_idx[1], snapshot]) for (branch_idx, time_ind_param) in zip(branch_idxs, time_ind_params)]
 
-                 lhs = LExpression(expression_list)
-                 cycle_constraints[subnetwork.name,j,snapshot] = LConstraint(lhs,"==",LExpression())
+                lhs = LExpression(expression_list)
+                cycle_constraints[sn.name,j,snapshot] = LConstraint(lhs,"==",LExpression())
 
     l_constraint(network.model, "cycle_constraints", cycle_constraints,
                  cycle_index, snapshots)

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -813,7 +813,9 @@ def using_tocoo_izip(x):
         yield (i,j,v)
 
 def define_passive_branch_flows_with_kirchhoff(network,snapshots,skip_vars=False):
+    """ define passive branch flows with the kirchoff method """
 
+    print( "running kirchoff passive branch flows")
     for sub_network in network.sub_networks.obj:
         find_tree(sub_network)
         find_cycles(sub_network)
@@ -869,6 +871,8 @@ def define_passive_branch_flows_with_kirchhoff(network,snapshots,skip_vars=False
              time_ind_params = [ branches.at[branch_idx,attribute]*(branches.at[branch_idx,"tap_ratio"] \
                                                                    if branch_idx[0] == "Transformer" else 1.)*subnetwork.C[cycle_i,j] for branch_idx in branch_idxs]
              for snapshot in snapshots:
+                 print( time_ind_params)
+                 print( network.model.passive_branch_p[branch_idx[0], branch_idx[1], snapshot])
                  expression_list = [ (time_ind_param,
                                       network.model.passive_branch_p[branch_idx[0], branch_idx[1], snapshot]) for (branch_idx, time_ind_param) in zip(branch_idxs, time_ind_params)]
 

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -519,12 +519,17 @@ def calculate_dependent_values(network):
     network.lines["r_pu"] = network.lines.r/(network.lines.v_nom**2)
     network.lines["b_pu"] = network.lines.b*network.lines.v_nom**2
     network.lines["g_pu"] = network.lines.g*network.lines.v_nom**2
+    network.lines["x_pu_eff"] = network.lines["x_pu"]
+    network.lines["r_pu_eff"] = network.lines["r_pu"]
+
 
     #convert transformer impedances from base power s_nom to base = 1 MVA
     network.transformers["x_pu"] = network.transformers.x/network.transformers.s_nom
     network.transformers["r_pu"] = network.transformers.r/network.transformers.s_nom
     network.transformers["b_pu"] = network.transformers.b*network.transformers.s_nom
     network.transformers["g_pu"] = network.transformers.g*network.transformers.s_nom
+    network.lines["x_pu_eff"] = network.transformers["x_pu"]* network.transformers["tap_ratio"]
+    network.lines["r_pu_eff"] = network.transformers["r_pu"]* network.transformers["tap_ratio"]
 
     apply_transformer_t_model(network)
 

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -528,8 +528,8 @@ def calculate_dependent_values(network):
     network.transformers["r_pu"] = network.transformers.r/network.transformers.s_nom
     network.transformers["b_pu"] = network.transformers.b*network.transformers.s_nom
     network.transformers["g_pu"] = network.transformers.g*network.transformers.s_nom
-    network.lines["x_pu_eff"] = network.transformers["x_pu"]* network.transformers["tap_ratio"]
-    network.lines["r_pu_eff"] = network.transformers["r_pu"]* network.transformers["tap_ratio"]
+    network.transformers["x_pu_eff"] = network.transformers["x_pu"]* network.transformers["tap_ratio"]
+    network.transformers["r_pu_eff"] = network.transformers["r_pu"]* network.transformers["tap_ratio"]
 
     apply_transformer_t_model(network)
 

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -619,15 +619,14 @@ def calculate_B_H(sub_network,skip_pre=False):
         find_bus_controls(sub_network)
 
     if network.sub_networks.at[sub_network.name,"carrier"] == "DC":
-        attribute="r_pu"
+        attribute="r_pu_eff"
     else:
-        attribute="x_pu"
+        attribute="x_pu_eff"
 
     #following leans heavily on pypower.makeBdc
 
     #susceptances
-    b = 1./np.concatenate([(c.df.loc[c.ind, attribute]*c.df.loc[c.ind, "tap_ratio"]).values if c.name == "Transformer"
-                           else c.df.loc[c.ind, attribute].values
+    b = 1./np.concatenate([(c.df.loc[c.ind, attribute]).values \
                            for c in sub_network.iterate_components(passive_branch_components)])
 
 


### PR DESCRIPTION
We have been using PyPSA, and we noticed that for larger numbers of snapshots and branches, the time to create the kirchhoff cycles was quite high.  This PR significantly reduces the time, primarily by moving the time-independent attribute calculations outside of the snapshots loop.

I have also added a new example ```build_model.py```, which can show the speed increase.  It simply creates a (randomized) larger network to induce cycles.  On my computer, the new build_model script runs about 50% faster on this branch than when I run it versus master.

Let me know if you would like any changes.  One easy additional change could be to use ```define_sub_network_cycle_constraints``` for the cycles formulation as well, but I haven't been using it, so I haven't been able to check for sure that that would be reasonable.