### PR TITLE
Copy with overridden components

### DIFF
--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -226,6 +226,9 @@ class Network(Basic):
             logger.warning("The argument csv_folder_name for initiating Network() is deprecated, please use import_name instead.")
             import_name = kwargs.pop('csv_folder_name')
 
+        # Initialise root logger and set its level, if this has not been done before
+        logging.basicConfig(level=logging.INFO)
+
         from . import __version__ as pypsa_version
 
         Basic.__init__(self, name)

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -226,9 +226,6 @@ class Network(Basic):
             logger.warning("The argument csv_folder_name for initiating Network() is deprecated, please use import_name instead.")
             import_name = kwargs.pop('csv_folder_name')
 
-        # Initialise root logger and set its level, if this has not been done before
-        logging.basicConfig(level=logging.INFO)
-
         from . import __version__ as pypsa_version
 
         Basic.__init__(self, name)
@@ -605,6 +602,28 @@ class Network(Basic):
             df.drop(df.columns.intersection(names), axis=1, inplace=True)
 
 
+    def _retrieve_overridden_components(self):
+        override_components = components.copy()
+        override_component_attrs = Dict({k: v.copy() for k, v in component_attrs.items()})
+
+        # add new components
+        new_components = {new_component: self.components[new_component] for new_component in
+                          (set(self.components.keys()) - set(components.index))}
+
+        for new_component in new_components.keys():
+            override_components.loc[new_component] = [new_components[new_component]['list_name'],
+                                                      new_components[new_component]['description'],
+                                                      new_components[new_component]['type']]
+            override_component_attrs[new_component] = self.component_attrs[new_component]
+
+        # override attributes of standard components
+        for component in self.all_components - set(new_components.keys()):
+            extra_attrs = self.component_attrs[component].index.difference(component_attrs[component].index)
+            if not extra_attrs.empty:
+                override_component_attrs[component] = self.component_attrs[component]
+
+        return override_components, override_component_attrs
+
 
     def copy(self, with_time=True, ignore_standard_types=False):
         """
@@ -628,7 +647,11 @@ class Network(Basic):
 
         """
 
-        network = self.__class__(ignore_standard_types=ignore_standard_types)
+        override_components, override_component_attrs = self._retrieve_overridden_components()
+
+        network = self.__class__(ignore_standard_types=ignore_standard_types,
+                                 override_components=override_components,
+                                 override_component_attrs=override_component_attrs)
 
         for component in self.iterate_components(["Bus", "Carrier"] + sorted(self.all_components - {"Bus","Carrier"})):
             df = component.df
@@ -684,7 +707,8 @@ class Network(Basic):
         else:
             time_i = slice(None)
 
-        n = self.__class__()
+        override_components, override_component_attrs = self._retrieve_overridden_components()
+        n = self.__class__(override_components=override_components, override_component_attrs=override_component_attrs)
         n.import_components_from_dataframe(
             pd.DataFrame(self.buses.ix[key]).assign(sub_network=""),
             "Bus"


### PR DESCRIPTION
The new functionality to override components and attributes is very useful but copying or slicing such a network fails.

I tested the changes with the following example:
`
import pypsa
import pandas as pd
from pypsa.descriptors import Dict
override_component_attrs = Dict({k : v.copy() for k,v in pypsa.components.component_attrs.items()})
override_component_attrs["Generator"].loc["new_gen_attr"] = ["static or series","MW","1","test","Input (optional)."]

override_components = pypsa.components.components.copy()
override_components.loc['NewComponent'] = ['new_component', 'test', np.nan]
override_component_attrs["NewComponent"] = pd.DataFrame(columns=["type","unit","default","description","status"])
override_component_attrs["NewComponent"].loc["name"] = ["string","n/a","n/a","name","Input (optional)"]
override_component_attrs["NewComponent"].loc["new_attr"] = ["static or series","MW","1","test","Output"]

n = pypsa.Network(override_components=override_components, override_component_attrs=override_component_attrs)
n2 = n.copy()
`