### PR TITLE
plot: Projection bugfix

### DIFF
--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -231,7 +231,7 @@ def plot(network, margin=0.05, ax=None, basemap=True, bus_colors='b',
                 "The WKT-encoded geometry in the 'geometry' column must be composed of LineStrings"
             segments = np.asarray(list(linestrings.map(np.asarray)))
             if basemap and basemap_present:
-                segments = np.transpose(bmap(*np.transpose(segments, (2, 0, 1))), (1, 2, 0))
+                segments = np.transpose(bmap(*np.transpose(segments, (2, 0, 1)), inverse=True), (1, 2, 0))
 
         l_collection = LineCollection(segments,
                                       linewidths=l_widths,

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -147,7 +147,7 @@ def plot(network, margin=0.05, ax=None, basemap=True, bus_colors='b',
         bmap.drawcountries()
         bmap.drawcoastlines()
 
-        x, y = bmap(x.values, y.values)
+        x, y = bmap(x.values, y.values, inverse=True)
         x = pd.Series(x, network.buses.index)
         y = pd.Series(y, network.buses.index)
 


### PR DESCRIPTION
`bmap( , )` projects lat/lon to SRID coordinates, not the other way around ([doc](https://matplotlib.org/basemap/users/mapcoords.html)). 

When using a dataset that does not use lat/lon coordinates, this should fix a projection issue. (But I am unable to test the code on such a dataset.)

