### PR TITLE
components: consistency check now only prints necessary columns

### DIFF
--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -891,11 +891,11 @@ class Network(Basic):
 
                 # check for NaN values:
                 if max_pu.isnull().values.any():
-                    for col in max_pu.columns[max_pu.isna().any()].tolist():
+                    for col in max_pu.columns[max_pu.isnull().any()]:
                         logger.warning("The attribute %s of element %s of %s has NaN values for the following snapshots:\n%s",
                                        varying_attr[0][0] + "_max_pu", col, c.list_name, max_pu.index[max_pu[col].isnull()])
                 if min_pu.isnull().values.any():
-                    for col in min_pu.columns[min_pu.isna().any()].tolist():
+                    for col in min_pu.columns[min_pu.isnull().any()]:
                         logger.warning("The attribute %s of element %s of %s has NaN values for the following snapshots:\n%s",
                                        varying_attr[0][0] + "_min_pu", col, c.list_name, min_pu.index[min_pu[col].isnull()])
 

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -891,11 +891,11 @@ class Network(Basic):
 
                 # check for NaN values:
                 if max_pu.isnull().values.any():
-                    for col in max_pu.dropna(axis=1, how='any').columns:
+                    for col in max_pu.columns[max_pu.isna().any()].tolist():
                         logger.warning("The attribute %s of element %s of %s has NaN values for the following snapshots:\n%s",
                                        varying_attr[0][0] + "_max_pu", col, c.list_name, max_pu.index[max_pu[col].isnull()])
                 if min_pu.isnull().values.any():
-                    for col in min_pu.dropna(axis=1, how='any').columns:
+                    for col in min_pu.columns[min_pu.isna().any()].tolist():
                         logger.warning("The attribute %s of element %s of %s has NaN values for the following snapshots:\n%s",
                                        varying_attr[0][0] + "_min_pu", col, c.list_name, min_pu.index[min_pu[col].isnull()])
 


### PR DESCRIPTION
network.consistency_check() now only prints columns containing NaNs rather than all columns with an empty index.