### PR TITLE
Update plot.py - Introduce cartopy

### DIFF
--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -288,6 +288,9 @@ def get_projection_from_crs(crs):
         return ccrs.PlateCarree()
     try:
         return ccrs.epsg(crs)
+    except requests.RequestException:
+        logger.warning("A connection to http://epsg.io/ is required for a projected coordinate reference system. "
+                    "Falling back to latlong.")
     except ValueError:
         logger.warning(f"'{crs}' does not define a projected coordinate system. "
                     "Falling back to latlong.")

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -85,6 +85,10 @@ def plot(network, margin=0.05, ax=None, geomap=True, projection=None,
         For Basemap users 'c' (crude), 'l' (low), 'i' (intermediate),
         'h' (high), 'f' (full) are valid resolutions options.
         For Cartopy users '10m', '50m', '110m' are valid resolutions options.
+    projection: cartopy.crs.Projection, defaults to None
+        Define the projection of your geomap, only valid if cartopy is
+        installed. If None (default) is passed the projection for cartropy
+        is set to cartopy.crs.PlateCarree
     bus_colors : dict/pandas.Series
         Colors for the buses, defaults to "b"
     bus_sizes : dict/pandas.Series


### PR DESCRIPTION
Here is the first step in order to update the plot.py a bit. Cartopy enables straightforward plotting with different projections and is much better maintained in future than Basemap. 

Summary of changes (updated on Feb 14, 9:53 am):
- set new argument cartopy_present 
- rename 'basemap' argument to 'geomap' in plot()
- add projection argument in plot() to define the cartopy projection 
- create new function draw_map() outside of plot(), transfer all map drawing code into it
- rename 'bmap' to 'gmap' in draw_map()
- create new function get_projection_from_crs() which takes in account the srid of the network
- Disable transformation of coordinates and segment with basemap object (see [#48](https://github.com/PyPSA/PyPSA/pull/48)), this is probably just a temporary workaround
- create new function projected_area_factor(), which is necessary for scaling circle plots
- update docstring for 'geomap', 'projection' 