### PR TITLE
networkclustering: Fix aggregategenerators to handle unweighted generators

### DIFF
--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -78,8 +78,7 @@ def aggregategenerators(network, busmap, with_time=True, carriers=None, custom_s
     columns = (set(attrs.index[attrs.static & attrs.status.str.startswith('Input')]) | {'weight'}) & set(generators.columns)
     grouper = [generators.bus, generators.carrier]
 
-    generators.weight.fillna(1., inplace=True)
-    weighting = generators.weight.groupby(grouper, axis=0).transform(lambda x: x/x.sum() )
+    weighting = generators.weight.groupby(grouper, axis=0).transform(lambda x: (x/x.sum()).fillna(1./len(x)))
     generators['capital_cost'] *= weighting
     strategies = {'p_nom_max': np.min, 'weight': np.sum, 'p_nom': np.sum, 'capital_cost': np.sum}
     strategies.update(custom_strategies)


### PR DESCRIPTION
If generators are aggregated by weight in `aggregategenerators` and happen to have a `nan` weight, the weighting does not add up to `1.`