### PR TITLE
plot.py: Using Basemap or `geomap=False` works again

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - pyomo
   - scipy
-  - pandas>=0.19.0
+  - pandas>=0.24.0
   - matplotlib
   - networkx>=1.10
   - pyomo


### PR DESCRIPTION
- Basemap was broken: buses and lines were not drawn on the axis.

- `geomap=False` was broken: `transform` was never defined. Using this option now gives:

<img src="https://i.imgur.com/ujggBBO.png" width=200>

I will add custom projection options this week!