### PR TITLE
plot.py: Custom Basemap projection; better switching between basemap and cartopy

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - pyomo
   - scipy
-  - pandas>=0.19.0
+  - pandas>=0.24.0
   - matplotlib
   - networkx>=1.10
   - pyomo


### PR DESCRIPTION
Cartopy is now used by default, unless the new parameter `basemap_parameters` is a dict. In that case, a Basemap is created, with the dict as additional constructor parameters. These can be used to specify a Basemap projection.
