### PR TITLE
Add cartopy>=0.16 to setup and requirements [Closes #59]

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -13,3 +13,4 @@ dependencies:
   - pyomo
   - coincbc
   - glpk
+  - cartopy>=0.16

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     license='GPLv3',
     packages=find_packages(exclude=['doc', 'test']),
     include_package_data=True,
-    install_requires=['numpy','pyomo>=5.3','scipy','pandas>=0.19.0','networkx>=1.10'],
+    install_requires=['numpy','pyomo>=5.3','scipy','pandas>=0.19.0','networkx>=1.10', 'cartopy>=0.16'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
This PR adds `cartopy>=0.16` to `setup.py` and `requirements.yaml` following discussion in #59.