### PR TITLE
PyPSA version 0.14.1

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -2,6 +2,18 @@
 Release Notes
 #######################
 
+PyPSA 0.14.1 (27th May 2019)
+================================
+
+This minor release contains three small bug fixes:
+
+* Documentation parses now correctly on PyPI
+* Python 2.7 and 3.6 are automatically tested using Travis
+* PyPSA on Python 2.7 was fixed
+
+This will also be the first release to be available directly from
+`conda-forge`<https://conda-forge.org/>.
+
 PyPSA 0.14.0 (15th May 2019)
 ============================
 


### PR DESCRIPTION
The cartopy changes unfortunately still included a Python 3.4 only feature that broke PyPSA on Python 2.7, while `conda` seems to have changed in the mean-time to ignore the python 2.7 version restriction.

This is why it would be good to have a small bug fix release. We can also pre-announce that we'll have a conda package soon (#70).

Release notes are included and are awaiting review.