### PR TITLE
Add flow plotting functionality

### DIFF
--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -783,7 +783,8 @@ class Network(Basic):
     #presence of links without s_nom_extendable
     def branches(self):
         return pd.concat((self.df(c) for c in self.branch_components),
-                         keys=self.branch_components, sort=False)
+                         keys=self.branch_components, sort=False,
+                         names=['component', 'name'])
 
     def passive_branches(self):
         return pd.concat((self.df(c) for c in self.passive_branch_components),

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -265,11 +265,11 @@ def plot(network, margin=0.05, ax=None, geomap=True, projection=None,
                          zip(network.iterate_components(ser.keys()), ser.values())},
                     names=['component', 'name'])
         elif isinstance(ser, pd.Series) and isinstance(ser.index, pd.MultiIndex):
-                return ser.rename_axis(index=['component', 'name'])
+            return ser.rename_axis(index=['component', 'name'])
         else:
             ser =  pd.Series(ser, network.lines.index)
-        return pd.concat([ser], axis=0, keys=['Line'],
-                         names=['component', 'name']).fillna(0)
+            return pd.concat([ser], axis=0, keys=['Line'],
+                             names=['component', 'name']).fillna(0)
 
     line_colors = as_branch_series(line_colors)
     line_widths = as_branch_series(line_widths)
@@ -484,7 +484,6 @@ def directed_flow(n, flow, x=None, y=None, ax=None, geomap=True,
     """
     Helper function to generate arrows from flow data.
     """
-    #Probably plt.quiver is much faster here!
     # this funtion is used for diplaying arrows representing the network flow
     from matplotlib.patches import FancyArrow
     if ax is None:

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -281,10 +281,10 @@ def plot(network, margin=0.05, ax=None, geomap=True, projection=None,
 
     if flow is not None:
         flow = (_flow_ds_from_arg(flow, network, branch_components)
-                     .pipe(as_branch_series)
-                     .div(sum(len(t.df) for t in
-                              network.iterate_components(branch_components)) + 100)
-                     .mul(line_widths, fill_value=1))
+                .pipe(as_branch_series)
+                .div(sum(len(t.df) for t in
+                         network.iterate_components(branch_components)) + 100)
+                .mul(line_widths, fill_value=1))
         # update the line width, allows to set line widths separately from flows
         line_widths.update((5 * flow.abs()).pipe(np.sqrt))
         arrows = directed_flow(network, flow, x=x, y=y, ax=ax, geomap=geomap,

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -69,7 +69,7 @@ except ImportError:
 
 def plot(network, margin=0.05, ax=None, geomap=True, projection=None,
          bus_colors='b', line_colors='g', bus_sizes=10, line_widths=2,
-         title="", line_cmap=None, bus_cmap=None, boundaries=None,
+         flow=None, title="", line_cmap=None, bus_cmap=None, boundaries=None,
          geometry=False, branch_components=['Line', 'Link'], jitter=None,
          basemap=None, basemap_parameters=None, color_geomap=None):
     """
@@ -103,6 +103,15 @@ def plot(network, margin=0.05, ax=None, geomap=True, projection=None,
         Widths of lines, defaults to 2. Widths for branches other
         than Lines can be specified using a pandas Series with a
         MultiIndex.
+    flow : snapshot/pandas.Series/function/string
+        Flow to be displayed in the plot, defaults to None. If an element of
+        network.snapshots is given, the flow at this timestamp will be
+        displayed. If an aggregation function is given, is will be applied
+        to the total network flow via pandas.DataFrame.agg (accepts also
+        function names). Otherwise flows can be specified by passing a pandas
+        Series with MultiIndex including all necessary branch components.
+        Use the line_widths argument to additionally adjust the size of the
+        flow arrows.
     title : string
         Graph title
     line_cmap : plt.cm.ColorMap/str|dict
@@ -132,11 +141,11 @@ def plot(network, margin=0.05, ax=None, geomap=True, projection=None,
     bus_collection, branch_collection1, ... : tuple of Collections
         Collections for buses and branches.
     """
-    defaults_for_branches = {
+    defaults_for_branches = pd.Series({
         'Link': dict(color="cyan", width=2),
         'Line': dict(color="b", width=2),
         'Transformer': dict(color='green', width=2)
-    }
+    }).rename_axis('component')
 
     if not plt_present:
         logger.error("Matplotlib is not present, so plotting won't work.")
@@ -247,26 +256,39 @@ def plot(network, margin=0.05, ax=None, geomap=True, projection=None,
         bus_collection = ax.scatter(x, y, c=c, s=s, cmap=bus_cmap, edgecolor='face')
 
     def as_branch_series(ser):
+        # ensure that this function always return a multiindexed series
         if isinstance(ser, dict) and set(ser).issubset(branch_components):
-            return pd.Series(ser)
-        elif isinstance(ser, pd.Series):
-            if isinstance(ser.index, pd.MultiIndex):
-                return ser
-            index = ser.index
-            ser = ser.values
+            return network.branches().loc[branch_components] \
+                          .join(pd.Series(ser, name='value') \
+                          .rename_axis('component')).value
+        elif isinstance(ser, pd.Series) and isinstance(ser.index, pd.MultiIndex):
+                return ser.rename_axis(['component', 'name'])
         else:
-            index = network.lines.index
-        return pd.Series(ser,
-                         index=pd.MultiIndex(levels=(["Line"], index),
-                                             codes=(np.zeros(len(index)),
-                                                    np.arange(len(index)))))
+            ser =  pd.Series(ser, network.lines.index)
+        return pd.concat([ser], axis=0, keys=['Line'],
+                         names=['component', 'name']).fillna(0)
 
     line_colors = as_branch_series(line_colors)
     line_widths = as_branch_series(line_widths)
+
     if not isinstance(line_cmap, dict):
         line_cmap = {'Line': line_cmap}
 
     branch_collections = []
+
+    if flow is not None:
+        flow = _flow_ds_from_arg(flow, network, branch_components)\
+                        .pipe(as_branch_series)\
+                        .div(len(network.branches()) + 100)\
+                        .mul(line_widths, fill_value=1)
+        # update the line width, allows to set line widths separately from flows
+        line_widths.update((5 * flow.abs()).pipe(np.sqrt))
+        arrows = directed_flow(network, flow, x=x, y=y, ax=ax,
+                               branch_colors=line_colors,
+                               branch_comps=branch_components,
+                               cmap=line_cmap['Line'])
+        branch_collections.append(arrows)
+
 
     for c in network.iterate_components(branch_components):
         l_defaults = defaults_for_branches[c.name]
@@ -334,7 +356,8 @@ def get_projection_from_crs(crs):
     try:
         return ccrs.epsg(crs)
     except requests.RequestException:
-        logger.warning("A connection to http://epsg.io/ is required for a projected coordinate reference system. "
+        logger.warning("A connection to http://epsg.io/ is "
+                       "required for a projected coordinate reference system. "
                        "Falling back to latlong.")
     except ValueError:
         logger.warning("'{crs}' does not define a projected coordinate system. "
@@ -399,7 +422,6 @@ def draw_map_basemap(network, x, y, ax, boundaries=None, margin=0.05,
                     grid=1.25, ax=ax, zorder=1)
 
     # no transformation -> use the default
-    axis_transformation = ax.transData
     basemap_projection = gmap
 
     # disable gmap transformation due to arbitrary conversion
@@ -418,7 +440,6 @@ def draw_map_cartopy(network, x, y, ax, boundaries=None, margin=0.05,
     resolution = '50m' if isinstance(geomap, bool) else geomap
     assert resolution in ['10m', '50m', '110m'], (
             "Resolution has to be one of '10m', '50m', '110m'")
-    gmap = ax.projection
     axis_transformation = get_projection_from_crs(network.srid)
     ax.set_extent([x1, x2, y1, y2], crs=axis_transformation)
 
@@ -437,6 +458,84 @@ def draw_map_cartopy(network, x, y, ax, boundaries=None, margin=0.05,
     ax.add_feature(border, linewidth=0.3)
 
     return axis_transformation
+
+
+def _flow_ds_from_arg(flow, n, branch_components):
+    if isinstance(flow, pd.Series):
+        return flow
+    if flow in n.snapshots:
+        return (pd.concat([n.pnl(c).p0.loc[flow]
+                for c in branch_components],
+                keys=branch_components, sort=True))
+    elif isinstance(flow, str) or callable(flow):
+        return (pd.concat([n.pnl(c).p0 for c in branch_components],
+                axis=1, keys=branch_components, sort=True)
+                .agg(flow, axis=0))
+
+
+def directed_flow(n, flow, x=None, y=None, ax=None,
+                  branch_colors='darkgreen', branch_comps=['Line', 'Link'],
+                  cmap=None):
+    """
+    Helper function to generate arrows from flow data.
+    """
+    # this funtion is used for diplaying arrows representing the network flow
+    from matplotlib.patches import FancyArrow
+    if ax is None:
+        ax = plt.gca()
+    x = n.buses.x if x is None else x
+    y = n.buses.y if y is None else y
+    #set the scale of the arrowsizes
+    fdata = pd.concat([pd.DataFrame(
+                      {'x1': n.df(l).bus0.map(x),
+                       'y1': n.df(l).bus0.map(y),
+                       'x2': n.df(l).bus1.map(x),
+                       'y2': n.df(l).bus1.map(y)})
+                      for l in branch_comps], keys=branch_comps,
+                    names=['component', 'name'])
+    fdata['arrowsize'] = (flow.abs().pipe(np.sqrt)
+                          .clip(lower=1e-8).mul(projected_area_factor(ax, 4326)))
+    fdata['direction'] = np.sign(flow)
+    fdata['linelength'] = (np.sqrt((fdata.x1 - fdata.x2)**2. +
+                           (fdata.y1 - fdata.y2)**2))
+    fdata['arrowtolarge'] = (1.5 * fdata.arrowsize >
+                             fdata.loc[:, 'linelength'])
+    # swap coords for negativ directions
+    fdata.loc[fdata.direction == -1., ['x1', 'x2', 'y1', 'y2']] = \
+        fdata.loc[fdata.direction == -1., ['x2', 'x1', 'y2', 'y1']].values
+    if ((fdata.linelength > 0.) & (~fdata.arrowtolarge)).any():
+        fdata['arrows'] = (
+                fdata[(fdata.linelength > 0.) & (~fdata.arrowtolarge)]
+                .apply(lambda ds:
+                       FancyArrow(ds.x1, ds.y1,
+                                  0.6*(ds.x2 - ds.x1) - ds.arrowsize
+                                  * 0.75 * (ds.x2 - ds.x1) / ds.linelength,
+                                  0.6 * (ds.y2 - ds.y1) - ds.arrowsize
+                                  * 0.75 * (ds.y2 - ds.y1)/ds.linelength,
+                                  head_width=ds.arrowsize), axis=1))
+    fdata.loc[(fdata.linelength > 0.) & (fdata.arrowtolarge), 'arrows'] = \
+        (fdata[(fdata.linelength > 0.) & (fdata.arrowtolarge)]
+         .apply(lambda ds:
+                FancyArrow(ds.x1, ds.y1,
+                           0.001*(ds.x2 - ds.x1),
+                           0.001*(ds.y2 - ds.y1),
+                           head_width=ds.arrowsize), axis=1))
+    if isinstance(branch_colors.index, (pd.MultiIndex, str)):
+        # Catch the case that only multiindex with lines as passed
+        fdata = fdata.assign(color=branch_colors.reindex_like(fdata)
+                                                .fillna('darkgreen'))
+    else:
+        fdata = fdata.join(branch_colors.rename('color'))
+    fdata = fdata.dropna(subset=['arrows'])
+    arrowcol = PatchCollection(fdata.arrows,
+                               color=fdata.color,
+                               edgecolors='k',
+                               linewidths=0.,
+                               zorder=3, alpha=1)
+    ax.add_collection(arrowcol)
+    return arrowcol
+
+
 
 #This function was borne out of a breakout group at the October 2017
 #Munich Open Energy Modelling Initiative Workshop to hack together a

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -68,7 +68,8 @@ except ImportError:
 
 
 def plot(network, margin=0.05, ax=None, geomap=True, projection=None,
-         bus_colors='b', line_colors='g', bus_sizes=10, line_widths=2,
+         bus_colors='b', line_colors={'Line':'g', 'Link':'cyan'}, bus_sizes=10,
+         line_widths={'Line':2, 'Link':2},
          flow=None, title="", line_cmap=None, bus_cmap=None, boundaries=None,
          geometry=False, branch_components=['Line', 'Link'], jitter=None,
          basemap=None, basemap_parameters=None, color_geomap=None):

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -375,10 +375,11 @@ def compute_bbox_with_margins(margin, x, y):
     return tuple(xy1), tuple(xy2)
 
 
-def projected_area_factor(ax, original_crs):
+def projected_area_factor(ax, original_crs=4326):
     """
     Helper function to get the area scale of the current projection in
-    reference to the default projection.
+    reference to the default projection. The default 'original crs' is assumed
+    to be 4326, which translates to the cartopy default cartopy.crs.PlateCarree()
     """
     if not hasattr(ax, 'projection'):
         return 1


### PR DESCRIPTION
Some changes in plot.py to plot flows. 

Status was tested using the following cases

```python


import pypsa, os
import cartopy.crs as ccrs
import matplotlib.pyplot as plt
import pandas as pd

n = pypsa.Network(os.path.dirname(pypsa.__file__) + '/../examples/ac-dc-meshed/ac-dc-data/')
n.lopf()

#standard projetion
gen = n.generators.assign(g = n.generators_t.p.mean()).groupby(['bus', 'carrier']).g.sum()

n.plot(bus_sizes=gen/1e4,
       bus_colors={'gas':'indianred', 'wind':'midnightblue'},
       margin=.5,
       flow='mean',
       line_widths=0.1,
       line_colors={'Line':'coral', 'Link':'skyblue'})
plt.show()


#different projection
n.plot(margin=.5,
       flow=pd.Series(10, n.branches().index),
       line_widths=1,
       line_colors={'Line':'coral', 'Link':'skyblue'},
       projection=ccrs.EqualEarth(),
       color_geomap=True)
plt.show()

#cmap for flow not implemented but works for static plot

n.plot(margin=.5,
       line_widths=10,
       line_colors=pd.Series(range(1, 1+len(n.branches())), n.branches().index)/10,
       projection=ccrs.EqualEarth(),
       color_geomap=True)
plt.show()

#  plot flow of snapshot

n.plot(margin=.5,
       flow=n.snapshots[0],
       line_widths={'Line':0.1, 'Link':0.1},
       projection=ccrs.EqualEarth(),
       color_geomap=True)
plt.show()
```