### PR TITLE
distributed slack implementation

### DIFF
--- a/doc/power_flow.rst
+++ b/doc/power_flow.rst
@@ -69,6 +69,25 @@ These equations :math:`f(x) = 0` are solved using the `Newton-Raphson method <ht
 
 and the initial "flat" guess of :math:`\theta_i = 0` and :math:`|V_i| = 1` for unknown quantities.
 
+Non-linear power flow for AC networks with distributed slack
+------------------------------------------------------------
+
+If the slack is to be distributed to all generators in proportion
+to their dispatch (``distribute_slack=True``), instead of being
+allocated fully to the slack bus, the active power balance is altered to
+
+.. math::
+   \textrm{Re}\left[ V_i \left(\sum_j Y_{ij} V_j\right)^* \right] - P_i - P_{slack}\gamma_i & = 0 \hspace{.7cm}\forall\hspace{.1cm} i \in PV \cup PQ \cup slack
+
+where :math:`P_{slack}` is the total slack power and :math:`\gamma_{i}`
+is the share of bus :math:`i` of the total generation that is used to
+distribute the slack power. Note that also an additional active power
+balance is included for the slack bus since it is now part of the
+distribution scheme.
+
+This adds an additional **row** to the Jacobian for the derivatives
+of the slack bus active power balance and an additional **column**
+for the partial derivatives with respect to :math:`\gamma_i`.
 
 
 .. _line-model:

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python
-  - six
+  - six >= 1.13.0
   - numpy
   - pyomo
   - scipy

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -20,6 +20,8 @@
 from __future__ import division, absolute_import
 from six.moves import range
 from six import iterkeys
+from six.moves.collections_abc import Sequence
+
 
 __author__ = "Tom Brown (FIAS), Jonas Hoersch (FIAS)"
 __copyright__ = "Copyright 2015-2017 Tom Brown (FIAS), Jonas Hoersch (FIAS), GNU GPL 3"
@@ -37,7 +39,7 @@ import numpy as np
 import pandas as pd
 import networkx as nx
 
-import collections, six
+import six
 from operator import itemgetter
 import time
 
@@ -55,7 +57,7 @@ def _as_snapshots(network, snapshots):
     if snapshots is None:
         snapshots = network.snapshots
     if (isinstance(snapshots, six.string_types) or
-        not isinstance(snapshots, (collections.Sequence, pd.Index))):
+        not isinstance(snapshots, (Sequence, pd.Index))):
         return pd.Index([snapshots])
     else:
         return pd.Index(snapshots)

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -372,7 +372,7 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
         if distribute_slack: 
             guess = np.append(guess, [0]) # for total slack power
 
-        if distribute_slack and slack_weights is None
+        if distribute_slack and slack_weights is None:
             slack_args["slack_weights"] = slack_weights_t.loc[now]
 
         #Now try and solve

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -29,18 +29,16 @@ logger = logging.getLogger(__name__)
 
 from scipy.sparse import issparse, csr_matrix, csc_matrix, hstack as shstack, vstack as svstack, dok_matrix
 
-from numpy import r_, ones, zeros, newaxis
+from numpy import r_, ones
 from scipy.sparse.linalg import spsolve
 from numpy.linalg import norm
 
 import numpy as np
 import pandas as pd
-import scipy as sp, scipy.sparse
 import networkx as nx
 
 import collections, six
 from operator import itemgetter
-from itertools import chain
 import time
 
 from .descriptors import get_switchable_as_dense, allocate_series_dataframes, Dict, zsum, degree
@@ -107,7 +105,6 @@ def _network_prepare_and_run_pf(network, snapshots, skip_pre, linear=False, **kw
         network.links_t.p0.loc[snapshots] = p_set.loc[snapshots]
         for i in [int(col[3:]) for col in network.links.columns if col[:3] == "bus" and col != "bus0"]:
             eff_name = "efficiency" if i == 1 else "efficiency{}".format(i)
-            p_name = "p{}".format(i)
             efficiency = get_switchable_as_dense(network, 'Link', eff_name, snapshots)
             links = network.links.index[network.links["bus{}".format(i)] != ""]
             network.links_t['p{}'.format(i)].loc[snapshots, links] = -network.links_t.p0.loc[snapshots, links]*efficiency.loc[snapshots, links]
@@ -283,7 +280,7 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
         else:
             mismatch = V*np.conj(sub_network.Y*V) - s
 
-        if distribute_slack:   
+        if distribute_slack:
             F = r_[real(mismatch)[:],imag(mismatch)[1+len(sub_network.pvs):]]
         else:
             F = r_[real(mismatch)[1:],imag(mismatch)[1+len(sub_network.pvs):]]
@@ -368,7 +365,7 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
         #Make a guess for what we don't know: V_ang for PV and PQs and v_mag_pu for PQ buses
         guess = r_[network.buses_t.v_ang.loc[now,sub_network.pvpqs],network.buses_t.v_mag_pu.loc[now,sub_network.pqs]]
 
-        if distribute_slack: 
+        if distribute_slack:
             guess = np.append(guess, [0]) # for total slack power
 
         if distribute_slack and slack_weights is None:
@@ -385,7 +382,7 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
 
     #now set everything
     if distribute_slack:
-        last_pq = -1 
+        last_pq = -1
         slack_power = roots[:,-1]
     else:
         last_pq = None

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -55,7 +55,7 @@ def _as_snapshots(network, snapshots):
     if snapshots is None:
         snapshots = network.snapshots
     if (isinstance(snapshots, six.string_types) or
-        not isinstance(snapshots, (collections.Sequence, pd.Index))):
+        not isinstance(snapshots, (collections.abc.Sequence, pd.Index))):
         return pd.Index([snapshots])
     else:
         return pd.Index(snapshots)

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -47,6 +47,10 @@ from .descriptors import get_switchable_as_dense, allocate_series_dataframes, Di
 
 pd.Series.zsum = zsum
 
+def real(X): return np.real(X.to_numpy())
+
+def imag(X): return np.imag(X.to_numpy())
+
 def _as_snapshots(network, snapshots):
     if snapshots is None:
         snapshots = network.snapshots
@@ -126,7 +130,8 @@ def _network_prepare_and_run_pf(network, snapshots, skip_pre, linear=False, **kw
     if not linear:
         return Dict({ 'n_iter': itdf, 'error': difdf, 'converged': cnvdf })
 
-def network_pf(network, snapshots=None, skip_pre=False, x_tol=1e-6, use_seed=False):
+def network_pf(network, snapshots=None, skip_pre=False, x_tol=1e-6, use_seed=False,
+               distribute_slack=False):
     """
     Full non-linear power flow for generic network.
 
@@ -141,6 +146,8 @@ def network_pf(network, snapshots=None, skip_pre=False, x_tol=1e-6, use_seed=Fal
         Tolerance for Newton-Raphson power flow.
     use_seed : bool, default False
         Use a seed for the initial guess for the Newton-Raphson algorithm.
+    distribute_slack : bool, default False
+        Distribute the slack power proportional to generator dispatch.
 
     Returns
     -------
@@ -150,19 +157,22 @@ def network_pf(network, snapshots=None, skip_pre=False, x_tol=1e-6, use_seed=Fal
         iteration error for each snapshot (rows) and sub_network (columns)
     """
 
-    return _network_prepare_and_run_pf(network, snapshots, skip_pre, linear=False, x_tol=x_tol, use_seed=use_seed)
+    return _network_prepare_and_run_pf(network, snapshots, skip_pre, linear=False, x_tol=x_tol,
+                                       use_seed=use_seed, distribute_slack=False)
 
 
-def newton_raphson_sparse(f, guess, dfdx, x_tol=1e-10, lim_iter=100):
+def newton_raphson_sparse(f, guess, dfdx, x_tol=1e-10, lim_iter=100, distribute_slack=False, slack_weights=None):
     """Solve f(x) = 0 with initial guess for x and dfdx(x). dfdx(x) should
     return a sparse Jacobian.  Terminate if error on norm of f(x) is <
     x_tol or there were more than lim_iter iterations.
 
     """
 
+    slack_args = {"distribute_slack": distribute_slack,
+                  "slack_weights": slack_weights}
     converged = False
     n_iter = 0
-    F = f(guess)
+    F = f(guess, **slack_args)
     diff = norm(F,np.Inf)
 
     logger.debug("Error at iteration %d: %f", n_iter, diff)
@@ -171,9 +181,9 @@ def newton_raphson_sparse(f, guess, dfdx, x_tol=1e-10, lim_iter=100):
 
         n_iter +=1
 
-        guess = guess - spsolve(dfdx(guess),F)
+        guess = guess - spsolve(dfdx(guess, **slack_args),F)
 
-        F = f(guess)
+        F = f(guess, **slack_args)
         diff = norm(F,np.Inf)
 
         logger.debug("Error at iteration %d: %f", n_iter, diff)
@@ -187,7 +197,8 @@ def newton_raphson_sparse(f, guess, dfdx, x_tol=1e-10, lim_iter=100):
 
 
 
-def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_seed=False):
+def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_seed=False,
+                   distribute_slack=False, slack_weights=None):
     """
     Non-linear power flow for connected sub-network.
 
@@ -202,6 +213,13 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
         Tolerance for Newton-Raphson power flow.
     use_seed : bool, default False
         Use a seed for the initial guess for the Newton-Raphson algorithm.
+    distribute_slack : bool, default False
+        Distribute the slack power across generators proportional to generator dispatch by default
+        or according to the distribution scheme provided in ``slack_weights``.
+    slack_weights : pandas.Series, default None
+        Distribution scheme describing the fraction of the total slack power a bus of the subnetwork
+        takes up. Must sum up to 1.
+
 
     Returns
     -------
@@ -224,6 +242,7 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
     # get indices for the components on this subnetwork
     branches_i = sub_network.branches_i()
     buses_o = sub_network.buses_o
+    sn_buses = sub_network.buses().index
 
     if not skip_pre and len(branches_i) > 0:
         calculate_Y(sub_network, skip_pre=True)
@@ -248,27 +267,36 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
                  for c in network.iterate_components(network.controllable_branch_components)
                  for i in [int(col[3:]) for col in c.df.columns if col[:3] == "bus"]])
 
-    def f(guess):
+    def f(guess, distribute_slack=False, slack_weights=None):
+
         network.buses_t.v_ang.loc[now,sub_network.pvpqs] = guess[:len(sub_network.pvpqs)]
 
-        network.buses_t.v_mag_pu.loc[now,sub_network.pqs] = guess[len(sub_network.pvpqs):]
+        last_pq = -1 if distribute_slack else None
+        network.buses_t.v_mag_pu.loc[now,sub_network.pqs] = guess[len(sub_network.pvpqs):last_pq]
 
         v_mag_pu = network.buses_t.v_mag_pu.loc[now,buses_o]
         v_ang = network.buses_t.v_ang.loc[now,buses_o]
         V = v_mag_pu*np.exp(1j*v_ang)
 
-        mismatch = V*np.conj(sub_network.Y*V) - s
+        if distribute_slack:
+            slack_power = slack_weights*guess[-1]
+            mismatch = V*np.conj(sub_network.Y*V) - s + slack_power
+        else:
+            mismatch = V*np.conj(sub_network.Y*V) - s
 
-        F = r_[mismatch.real[1:],mismatch.imag[1+len(sub_network.pvs):]]
+        if distribute_slack:   
+            F = r_[real(mismatch)[:],imag(mismatch)[1+len(sub_network.pvs):]]
+        else:
+            F = r_[real(mismatch)[1:],imag(mismatch)[1+len(sub_network.pvs):]]
 
         return F
 
 
-    def dfdx(guess):
+    def dfdx(guess, distribute_slack=False, slack_weights=None):
 
+        last_pq = -1 if distribute_slack else None
         network.buses_t.v_ang.loc[now,sub_network.pvpqs] = guess[:len(sub_network.pvpqs)]
-
-        network.buses_t.v_mag_pu.loc[now,sub_network.pqs] = guess[len(sub_network.pvpqs):]
+        network.buses_t.v_mag_pu.loc[now,sub_network.pqs] = guess[len(sub_network.pvpqs):last_pq]
 
         v_mag_pu = network.buses_t.v_mag_pu.loc[now,buses_o]
         v_ang = network.buses_t.v_ang.loc[now,buses_o]
@@ -286,14 +314,25 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
 
         dS_dVm = V_norm_diag*np.conj(I_diag) + V_diag * np.conj(sub_network.Y*V_norm_diag)
 
-        J00 = dS_dVa[1:,1:].real
-        J01 = dS_dVm[1:,1+len(sub_network.pvs):].real
         J10 = dS_dVa[1+len(sub_network.pvs):,1:].imag
         J11 = dS_dVm[1+len(sub_network.pvs):,1+len(sub_network.pvs):].imag
 
+        if distribute_slack:
+            J00 = dS_dVa[:,1:].real
+            J01 = dS_dVm[:,1+len(sub_network.pvs):].real
+            J02 = csr_matrix(slack_weights,(1,1+len(sub_network.pvpqs))).T
+            J12 = csr_matrix(0,(1,len(sub_network.pqs))).T
+            J_P_blocks = [J00, J01, J02]
+            J_Q_blocks = [J10, J11, J12]
+        else:
+            J00 = dS_dVa[1:,1:].real
+            J01 = dS_dVm[1:,1+len(sub_network.pvs):].real
+            J_P_blocks = [J00, J01]
+            J_Q_blocks = [J10, J11]
+
         J = svstack([
-            shstack([J00, J01]),
-            shstack([J10, J11])
+            shstack(J_P_blocks),
+            shstack(J_Q_blocks)
         ], format="csr")
 
         return J
@@ -309,8 +348,16 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
         network.buses_t.v_mag_pu.loc[snapshots,sub_network.pqs] = 1.
         network.buses_t.v_ang.loc[snapshots,sub_network.pvpqs] = 0.
 
+    slack_args = {'distribute_slack': distribute_slack,
+                  'slack_weights': slack_weights}
+    slack_variable_b = 1 if distribute_slack else 0
+
+    if distribute_slack and slack_weights is None:
+        bus_generation = network.generators_t.p_set.rename(columns=network.generators.bus)
+        slack_weights_t = pd.DataFrame(bus_generation.groupby(bus_generation.columns, axis=1).sum(), columns=buses_o).apply(normed, axis=1).fillna(0)
+
     ss = np.empty((len(snapshots), len(buses_o)), dtype=np.complex)
-    roots = np.empty((len(snapshots), len(sub_network.pvpqs) + len(sub_network.pqs)))
+    roots = np.empty((len(snapshots), len(sub_network.pvpqs) + len(sub_network.pqs) + slack_variable_b))
     iters = pd.Series(0, index=snapshots)
     diffs = pd.Series(index=snapshots)
     convs = pd.Series(False, index=snapshots)
@@ -322,9 +369,15 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
         #Make a guess for what we don't know: V_ang for PV and PQs and v_mag_pu for PQ buses
         guess = r_[network.buses_t.v_ang.loc[now,sub_network.pvpqs],network.buses_t.v_mag_pu.loc[now,sub_network.pqs]]
 
+        if distribute_slack: 
+            guess = np.append(guess, [0]) # for total slack power
+
+        if distribute_slack and slack_weights is None
+            slack_args["slack_weights"] = slack_weights_t.loc[now]
+
         #Now try and solve
         start = time.time()
-        roots[i], n_iter, diff, converged = newton_raphson_sparse(f,guess,dfdx,x_tol=x_tol)
+        roots[i], n_iter, diff, converged = newton_raphson_sparse(f, guess, dfdx, x_tol=x_tol, **slack_args)
         logger.info("Newton-Raphson solved in %d iterations with error of %f in %f seconds", n_iter,diff,time.time()-start)
         iters[now] = n_iter
         diffs[now] = diff
@@ -332,8 +385,11 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
 
 
     #now set everything
+    last_pq = -1 if distribute_slack else None
     network.buses_t.v_ang.loc[snapshots,sub_network.pvpqs] = roots[:,:len(sub_network.pvpqs)]
-    network.buses_t.v_mag_pu.loc[snapshots,sub_network.pqs] = roots[:,len(sub_network.pvpqs):]
+    network.buses_t.v_mag_pu.loc[snapshots,sub_network.pqs] = roots[:,len(sub_network.pvpqs):last_pq]
+
+    if distribute_slack: slack_power = roots[:,-1]
 
     v_mag_pu = network.buses_t.v_mag_pu.loc[snapshots,buses_o].values
     v_ang = network.buses_t.v_ang.loc[snapshots,buses_o].values
@@ -369,7 +425,10 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
     for i in np.arange(len(snapshots)):
         s_calc[i] = V[i]*np.conj(sub_network.Y*V[i])
     slack_index = buses_o.get_loc(sub_network.slack_bus)
-    network.buses_t.p.loc[snapshots,sub_network.slack_bus] = s_calc[:,slack_index].real
+    if distribute_slack:
+        network.buses_t.p.loc[snapshots,sn_buses] = s_calc.real[:,buses_indexer(sn_buses)]
+    else:
+        network.buses_t.p.loc[snapshots,sub_network.slack_bus] = s_calc[:,slack_index].real
     network.buses_t.q.loc[snapshots,sub_network.slack_bus] = s_calc[:,slack_index].imag
     network.buses_t.q.loc[snapshots,sub_network.pvs] = s_calc[:,buses_indexer(sub_network.pvs)].imag
 
@@ -382,10 +441,16 @@ def sub_network_pf(sub_network, snapshots=None, skip_pre=False, x_tol=1e-6, use_
         network.shunt_impedances_t.q.loc[snapshots,shunt_impedances_i] = (shunt_impedances_v_mag_pu**2)*network.shunt_impedances.loc[shunt_impedances_i, 'b_pu'].values
 
     #let slack generator take up the slack
-    network.generators_t.p.loc[snapshots,sub_network.slack_generator] += network.buses_t.p.loc[snapshots,sub_network.slack_bus] - ss[:,slack_index].real
-    network.generators_t.q.loc[snapshots,sub_network.slack_generator] += network.buses_t.q.loc[snapshots,sub_network.slack_bus] - ss[:,slack_index].imag
+    if distribute_slack:
+        distributed_slack_power = (network.buses_t.p.loc[snapshots,sn_buses] - ss[:,buses_indexer(sn_buses)].real)
+        for bus, group in network.generators.groupby('bus'):
+            bus_generator_shares = network.generators_t.p.loc[snapshots,group.index].apply(normed, axis=1).fillna(0)
+            network.generators_t.p.loc[snapshots,group.index] += bus_generator_shares.multiply(distributed_slack_power.loc[snapshots,bus], axis=0)
+    else:
+        network.generators_t.p.loc[snapshots,sub_network.slack_generator] += network.buses_t.p.loc[snapshots,sub_network.slack_bus] - ss[:,slack_index].real
 
-    #set the Q of the PV generators
+    #set the Q of the slack and PV generators
+    network.generators_t.q.loc[snapshots,sub_network.slack_generator] += network.buses_t.q.loc[snapshots,sub_network.slack_bus] - ss[:,slack_index].imag
     network.generators_t.q.loc[snapshots,network.buses.loc[sub_network.pvs, "generator"]] += np.asarray(network.buses_t.q.loc[snapshots,sub_network.pvs] - ss[:,buses_indexer(sub_network.pvs)].imag)
 
     return iters, diffs, convs

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ setup(
     packages=find_packages(exclude=['doc', 'test']),
     include_package_data=True,
     install_requires=[
-        'six',
+        'six >= 1.13.0',
         'numpy',
         'scipy',
-        'pandas>=0.19.0',
+        'pandas>=0.24.0',
         'tables',
         'pyomo>=5.3',
         'matplotlib',

--- a/test/test_pf_distributed_slack.py
+++ b/test/test_pf_distributed_slack.py
@@ -5,7 +5,8 @@ import pypsa
 def normed(s): return s/s.sum()
 
 def test_pf_distributed_slack():
-    csv_folder_name = os.path.join(os.path.dirname(__file__), "../examples/scigrid-de/scigrid-with-load-gen-trafos/")
+    csv_folder_name = os.path.join(os.path.dirname(__file__), "..",
+                      "examples", "scigrid-de", "scigrid-with-load-gen-trafos")
 
     network = pypsa.Network(csv_folder_name)
 

--- a/test/test_pf_distributed_slack.py
+++ b/test/test_pf_distributed_slack.py
@@ -17,10 +17,7 @@ def test_pf_distributed_slack():
     network.lopf(network.snapshots, solver_name='cbc', formulation='kirchhoff')
 
     #For the PF, set the P to the optimised P
-    network.generators_t.p_set = network.generators_t.p_set.reindex(columns=network.generators.index)
     network.generators_t.p_set = network.generators_t.p
-
-    network.storage_units_t.p_set = network.storage_units_t.p_set.reindex(columns=network.storage_units.index)
     network.storage_units_t.p_set = network.storage_units_t.p
 
     #set all buses to PV, since we don't know what Q set points are

--- a/test/test_pf_distributed_slack.py
+++ b/test/test_pf_distributed_slack.py
@@ -9,6 +9,7 @@ def test_pf_distributed_slack():
                       "examples", "scigrid-de", "scigrid-with-load-gen-trafos")
 
     network = pypsa.Network(csv_folder_name)
+    network.set_snapshots(network.snapshots[:2])
 
     #There are some infeasibilities without line extensions
     network.lines.s_max_pu = 0.7
@@ -37,4 +38,4 @@ def test_pf_distributed_slack():
 
 
 if __name__ == "__main__":
-    pf_distributed_slack()
+    test_pf_distributed_slack()


### PR DESCRIPTION
fixes #10 

Adds an option `distribute_slack` to 
```python
def network_pf(network, snapshots=None, skip_pre=False, 
x_tol=1e-6, use_seed=False, distribute_slack=False):`
```
to distribute the total slack power to all generators proportional to their dispatch at the respective snapshot.

Docstrings already extended.

@anileinchen, could you please also test this?

Remaining TODOs:
- [x] add a test
- [x] update documentation