### PR TITLE
Set sort to True for component concatenation

### DIFF
--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -784,16 +784,16 @@ class Network(Basic):
     #presence of links without s_nom_extendable
     def branches(self):
         return pd.concat((self.df(c) for c in self.branch_components),
-                         keys=self.branch_components, sort=False,
+                         keys=self.branch_components, sort=True,
                          names=['component', 'name'])
 
     def passive_branches(self):
         return pd.concat((self.df(c) for c in self.passive_branch_components),
-                         keys=self.passive_branch_components, sort=False)
+                         keys=self.passive_branch_components, sort=True)
 
     def controllable_branches(self):
         return pd.concat((self.df(c) for c in self.controllable_branch_components),
-                         keys=self.controllable_branch_components, sort=False)
+                         keys=self.controllable_branch_components, sort=True)
 
     def determine_network_topology(self):
         """


### PR DESCRIPTION
The current version does not guarantee that the components are sorted alphabetically, this leads to non-unique results of `n.incidence()` or other quantities which are based on those functions. This PR fixes it