### PR TITLE
travis: omit python 3.8 due to missing gurobi version for conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ os:
 env:
   - PYTHON_VERSION="3.6"
   - PYTHON_VERSION="3.7"
-  - PYTHON_VERSION="3.8"
+  # - PYTHON_VERSION="3.8" # until gurobi in conda https://anaconda.org/Gurobi/gurobi/files?version=9.0.0
 
 before_install:
   - wget https://raw.githubusercontent.com/trichter/conda4travis/latest/conda4travis.sh -O conda4travis.sh

--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python
   - pip
   - pytest
-  - pytest-cov
+  # - pytest-cov
   - twine
   - pip:
     - pypower

--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  #- python
+  - python
   - pip
   - pytest
   - pytest-cov

--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -4,10 +4,10 @@ channels:
   - conda-forge
 
 dependencies:
-  - python
+  #- python
   - pip
   - pytest
-  # - pytest-cov
+  - pytest-cov
   - twine
   - pip:
     - pypower


### PR DESCRIPTION
The culprit for failing tests is gurobi which doesn't provide a `conda` package for python 3.8 yet.
- https://anaconda.org/Gurobi/gurobi/files?version=9.0.0
- https://www.gurobi.com/gurobi-and-anaconda-for-linux/

**Squash if merging**