### PR TITLE
Harmonise nomopyomo, pyomo LOPF status and termination_condition

### DIFF
--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -439,7 +439,6 @@ class Network(Basic):
 
         Other Parameters
         ----------------
-
         ptdf_tolerance : float
             Only taking effect when pyomo is True.
             Value below which PTDF entries are ignored
@@ -489,6 +488,16 @@ class Network(Basic):
             Only taking effect when pyomo is False.
             Path to directory where necessary files are written, default None leads
             to the default temporary directory used by tempfile.mkstemp().
+
+        Returns
+        -------
+        status : str
+            Status of optimization.
+            Either "ok" if solution is optimal, or "warning" if not.
+        termination_condition : str
+            More information on how the solver terminated.
+            One of "optimal", "suboptimal" (in which case a solution is still
+            provided), "infeasible", "infeasible or unbounded", or "other".
 
         """
         args = {'snapshots': snapshots, 'keep_files': keep_files,

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -623,8 +623,9 @@ def run_and_read_glpk(n, problem_fn, solution_fn, solver_logfile,
     termination_condition = info.Status.lower().strip()
     objective = float(re.sub('[^0-9\.\+\-]+', '', info.Objective))
 
-    if termination_condition == "optimal":
+    if termination_condition in ["optimal","integer optimal"]:
         status = "ok"
+        termination_condition = "optimal"
     elif termination_condition == "undefined":
         status = "warning"
         termination_condition = "infeasible"


### PR DESCRIPTION
Make nomopyomo LOPF return values `status` and `termination_condition` consistent with pyomo LOPF.

`status`, `termination_condition` are either `ok, optimal` for optimal solutions or `warning, infeasible` for infeasible ones. (NB: Unlike gurobi and cbc, glpk returns `ok, infeasible` for infeasible solutions. For nomopyomo I've made this `warning, infeasible` for all solvers, for consistency.)

For gurobi there are two additional options:

If gurobi is using the barrier method and has a sub-optimal solution, nomopyomo will still read the solution and return `warning, suboptimal`. In this case pyomo would return `warning, other`. This was caught by the pyomo LOPF, see here

https://github.com/PyPSA/PyPSA/blob/54d16deb18a2a07f68efb6f83c2c632933df966e/pypsa/opf.py#L1589

so that PyPSA-Eur could still use the solutions, see here

https://github.com/PyPSA/pypsa-eur/blob/8bd72b47f0bb9bfcde6931b33bc1b1274eb26566/scripts/solve_network.py#L294

since the sub-optimal solutions were often very close to optimal (e.g. gap between primal and dual objective of 1e-3). Some model.energy solutions were also returning sub-optimal, and need to be caught.

If gurobi is using the barrier method, sometimes it cannot distinguish between an infeasible and an unbounded problem, so returns `warning, infeasible or unbounded`. I *think* pyomo just return `warning, infeasible` in this case.


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.