### PR TITLE
linopf: Correct marginal prices by snapshot weightings

### DIFF
--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -794,7 +794,7 @@ def network_lopf(n, snapshots=None, solver_name="cbc",
          solver_logfile=None, extra_functionality=None,
          extra_postprocessing=None, formulation="kirchhoff",
          keep_references=False, keep_files=False,
-         keep_shadowprices=['Bus', 'Line', 'GlobalConstraint'],
+         keep_shadowprices=['Bus', 'Line', 'Transformer', 'Link', 'GlobalConstraint'],
          solver_options=None, warmstart=False, store_basis=False,
          solver_dir=None):
     """

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -746,6 +746,9 @@ def assign_solution(n, sns, variables_sol, constraints_dual,
     for c, attr in sp:
         map_dual(c, attr)
 
+    #correct prices for snapshot weightings
+    n.buses_t.marginal_price.loc[sns] = n.buses_t.marginal_price.loc[sns].divide(n.snapshot_weightings.loc[sns],axis=0)
+
     # discard remaining if wanted
     if not keep_references:
         for c, attr in n.constraints.index.difference(sp):


### PR DESCRIPTION
Marginal prices should be corrected by the snapshot weightings.
This is then consistent with the marginal prices in the Pyomo LOPF:
https://github.com/PyPSA/PyPSA/blob/b76798d2347101dd8e8239251ae7ebe6a1643d23/pypsa/opf.py#L1359
and the original nomopyomo:
https://github.com/PyPSA/nomopyomo/blob/1e9ef2ad58ae864d2baf826c58af7f5931229543/nomopyomo.py#L567
It means the prices have a clear EUR/MWh definition regardless of the snapshot weighting. It also makes them stay roughly the same when snapshots are aggregated.
Dual variables are anyway only defined up to a constant (since you can multiply the whole constraint by a constant).
It raises the question of whether to correct the other dual values saved by PyPSA (e.g. line mu's) by the snapshot weightings. I'm not sure about this. First we should make the behaviour consistent between pyomo and nomopyomo versions of PyPSA, which is what this PR does.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.