### PR TITLE
linopf: Fix bug whereby snapshot_weightings name is missing

### DIFF
--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -455,7 +455,7 @@ def define_global_constraints(n, sns):
         gens = n.generators.query('carrier in @emissions.index')
         if not gens.empty:
             em_pu = gens.carrier.map(emissions)/gens.efficiency
-            em_pu = n.snapshot_weightings.to_frame() @ em_pu.to_frame('weightings').T
+            em_pu = n.snapshot_weightings.to_frame('weightings') @ em_pu.to_frame('weightings').T
             vals = linexpr((em_pu, get_var(n, 'Generator', 'p')[gens.index]),
                            as_pandas=False)
             lhs += join_exprs(vals)


### PR DESCRIPTION
The old code relied on snapshot_weightings.name being "weightings". However, this is only the case when it has been exported to a netcdf file, when it's given this name:
https://github.com/PyPSA/PyPSA/blob/346de27e5d8769a75f40fdd7d8293438af045d18/pypsa/io.py#L314
and reimported.

Networks created without exporting and importing break at this point with emissions constraints. Minimum breaking model:
```
n = pypsa.Network()
n.add("Bus",
      "bus")
n.add("Load",
      "load",
      bus="bus",
      p_set=10)
n.add("Generator",
      "wind",
      bus="bus",
      p_nom=10)
n.add("Generator",
      "OCGT",
      bus="bus",
      carrier="gas",
      marginal_cost=50,
      p_nom=10)
n.add("Carrier",
      "gas",
      co2_emissions=500)
n.add("GlobalConstraint",
      "co2_limit",
       sense="<=",
       constant=50)
n.lopf(pyomo=False)
```
See also this (fixed) bug issue for https://model.energy/:
https://github.com/PyPSA/whobs-server/issues/14
Thanks to @JanFrederickUnnewehr for finding this bug!