### PR TITLE
Make Import tolerant of non-predefined series 

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,7 @@ Release Notes
 PyPSA 0.17.0
 =============
 
-* Importing timeseries for predefined attributes in network.component is now possible. 
+* Importing time series from custom non-standard output fields in ``network.component`` is now supported.
 * The argument ``bus_colors`` can a now also be a pandas.Series. 
 * The ``carrier`` component has two new columns 'color' and 'nice_name'. The color column is used by the plotting function if ``bus_sizes`` is a pandas.Series with a MultiIndex and ``bus_colors`` is not explicitly defined. 
 * When using the ``pyomo=False`` formulation of the LOPF, it is now possible to alter the objective function. Terms can be added to the objective via ``extra_functionality`` using the function :func:`pypsa.linopt.write_objective`. When a pure custom objective function needs to be declared, one can set ``skip_objective=True``. In this case, only terms defined through ``extra_functionality`` will be considered in the objective function.  

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
 PyPSA 0.17.0
 =============
 
+* Importing timeseries for predefined attributes in network.component is now possible. 
 * The argument ``bus_colors`` can a now also be a pandas.Series. 
 * The ``carrier`` component has two new columns 'color' and 'nice_name'. The color column is used by the plotting function if ``bus_sizes`` is a pandas.Series with a MultiIndex and ``bus_colors`` is not explicitly defined. 
 * When using the ``pyomo=False`` formulation of the LOPF, it is now possible to alter the objective function. Terms can be added to the objective via ``extra_functionality`` using the function :func:`pypsa.linopt.write_objective`. When a pure custom objective function needs to be declared, one can set ``skip_objective=True``. In this case, only terms defined through ``extra_functionality`` will be considered in the objective function.  


### PR DESCRIPTION
Closes #120 

## Changes proposed in this Pull Request
Modify the `import_series_from_dataframe` function, check whether the attribute is predefined and if not, assign it to the pnl. 

## Checklist

- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.