### PR TITLE
io: fix incomplete transition to pandapower 2.x

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,7 +9,7 @@ PyPSA 0.17.0
 * The argument ``bus_colors`` can a now also be a pandas.Series. 
 * The ``carrier`` component has two new columns 'color' and 'nice_name'. The color column is used by the plotting function if ``bus_sizes`` is a pandas.Series with a MultiIndex and ``bus_colors`` is not explicitly defined. 
 * When using the ``pyomo=False`` formulation of the LOPF, it is now possible to alter the objective function. Terms can be added to the objective via ``extra_functionality`` using the function :func:`pypsa.linopt.write_objective`. When a pure custom objective function needs to be declared, one can set ``skip_objective=True``. In this case, only terms defined through ``extra_functionality`` will be considered in the objective function.  
-
+* Fixed import from ``pandapower`` for transformers not based on standard types.
 
 PyPSA 0.16.1 (10th January 2020)
 ================================

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -1046,10 +1046,10 @@ def import_from_pandapower_net(network, net, extra_line_data=False):
 
     # if it's not based on a standard-type - get the included values:
     else:
-        s_nom = net.trafo.sn_kva.values/1000.
+        s_nom = net.trafo.sn_mva.values/1000.
 
-        r = net.trafo.vscr_percent.values/100.
-        x = np.sqrt((net.trafo.vsc_percent.values/100.)**2 - r**2)
+        r = net.trafo.vkr_percent.values/100.
+        x = np.sqrt((net.trafo.vk_percent.values/100.)**2 - r**2)
         # NB: b and g are per unit of s_nom
         g = net.trafo.pfe_kw.values/(1000. * s_nom)
 


### PR DESCRIPTION
Closes #123 

The transition to `pandapower>=2` was incomplete for transformers which are not based on a standard transformer type.

## Checklist

- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.