### PR TITLE
plot: consistency between MultiIndex and Index bus sizes (closes #132)

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,7 @@ PyPSA 0.17.0
 * The argument ``bus_colors`` can a now also be a pandas.Series. 
 * The ``carrier`` component has two new columns 'color' and 'nice_name'. The color column is used by the plotting function if ``bus_sizes`` is a pandas.Series with a MultiIndex and ``bus_colors`` is not explicitly defined. 
 * When using the ``pyomo=False`` formulation of the LOPF, it is now possible to alter the objective function. Terms can be added to the objective via ``extra_functionality`` using the function :func:`pypsa.linopt.write_objective`. When a pure custom objective function needs to be declared, one can set ``skip_objective=True``. In this case, only terms defined through ``extra_functionality`` will be considered in the objective function.  
+* When plotting, ``bus_sizes`` are now consistent when they have a ``pandas.MultiIndex`` or a ``pandas.Index``. The default is changed to ``bus_sizes=0.01``. The bus sizes now relate to the axis values.
 
 
 PyPSA 0.16.1 (10th January 2020)


### PR DESCRIPTION
Closes #132 .

Achieve consistency of `bus_sizes` regardless of whether it has a `pd.MultiIndex` or `pd.Index`.
Substitutes `ax.scatter(...)` with `matplotlib.patches.Circle` (which is very similar to `matplotlib.patches.Wedge`). The unit of the radius is now, hence changed default `bus_size=0.01`. Also using `ax.set_aspect('equal')` to avoid squeezed circles.

Test with:

```python
import pypsa
import matplotlib.pyplot as plt
import cartopy.crs as ccrs
import pandas as pd

n = pypsa.Network("examples/scigrid-de/scigrid-with-load-gen-trafos/")

c = n.generators.groupby('bus').sum().p_nom

fig, ax = plt.subplots(figsize=(7,7), subplot_kw={"projection":ccrs.PlateCarree()})
n.plot(ax=ax, geomap=True, line_widths=0, bus_sizes=c/3e4);

c.index = pd.MultiIndex.from_product([c.index,["dummy"]])

fig, ax = plt.subplots(figsize=(7,7), subplot_kw={"projection":ccrs.PlateCarree()})
n.plot(ax=ax, geomap=True, line_widths=0, bus_sizes=c/3e4, bus_colors={'dummy': 'b'});
```

Also change projection, geomap, bus_colors, colormap for testing.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.