### PR TITLE
Parse shadow price of non-extenable passive branch capacities

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,9 +9,14 @@ PyPSA 0.17.0
 * Importing time series from custom non-standard output fields in ``network.component`` is now supported.
 * The argument ``bus_colors`` can a now also be a pandas.Series. 
 * The ``carrier`` component has two new columns 'color' and 'nice_name'. The color column is used by the plotting function if ``bus_sizes`` is a pandas.Series with a MultiIndex and ``bus_colors`` is not explicitly defined. 
-* When using the ``pyomo=False`` formulation of the LOPF, it is now possible to alter the objective function. Terms can be added to the objective via ``extra_functionality`` using the function :func:`pypsa.linopt.write_objective`. When a pure custom objective function needs to be declared, one can set ``skip_objective=True``. In this case, only terms defined through ``extra_functionality`` will be considered in the objective function.  
+* When using the ``pyomo=False`` formulation of the LOPF: 
+
+    * It is now possible to alter the objective function. Terms can be added to the objective via ``extra_functionality`` using the function :func:`pypsa.linopt.write_objective`. When a pure custom objective function needs to be declared, one can set ``skip_objective=True``. In this case, only terms defined through ``extra_functionality`` will be considered in the objective function. 
+    * Shadow prices of capacity bounds for non-extendable passive branches are parsed (similar to the pyomo=True setting)
+
 * When plotting, ``bus_sizes`` are now consistent when they have a ``pandas.MultiIndex`` or a ``pandas.Index``. The default is changed to ``bus_sizes=0.01``. The bus sizes now relate to the axis values.
 * Fixed import from ``pandapower`` for transformers not based on standard types.
+
 
 PyPSA 0.16.1 (10th January 2020)
 ================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,7 +12,7 @@ PyPSA 0.17.0
 * When using the ``pyomo=False`` formulation of the LOPF: 
 
     * It is now possible to alter the objective function. Terms can be added to the objective via ``extra_functionality`` using the function :func:`pypsa.linopt.write_objective`. When a pure custom objective function needs to be declared, one can set ``skip_objective=True``. In this case, only terms defined through ``extra_functionality`` will be considered in the objective function. 
-    * Shadow prices of capacity bounds for non-extendable passive branches are parsed (similar to the pyomo=True setting)
+    * Shadow prices of capacity bounds for non-extendable passive branches are parsed (similar to the ``pyomo=True`` setting)
 
 * When plotting, ``bus_sizes`` are now consistent when they have a ``pandas.MultiIndex`` or a ``pandas.Index``. The default is changed to ``bus_sizes=0.01``. The bus sizes now relate to the axis values.
 * Fixed import from ``pandapower`` for transformers not based on standard types.

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -76,6 +76,7 @@ def define_variables(n, lower, upper, name, attr='', axes=None, spec=''):
     """
     var = write_bound(n, lower, upper, axes)
     set_varref(n, var, name, attr, spec=spec)
+    return var
 
 
 def define_binaries(n, axes, name, attr='',  spec=''):
@@ -107,6 +108,7 @@ def define_binaries(n, axes, name, attr='',  spec=''):
     """
     var = write_binary(n, axes)
     set_varref(n, var, name, attr, spec=spec)
+    return var
 
 
 def define_constraints(n, lhs, sense, rhs, name, attr='', axes=None, spec=''):
@@ -172,6 +174,7 @@ def define_constraints(n, lhs, sense, rhs, name, attr='', axes=None, spec=''):
     """
     con = write_constraint(n, lhs, sense, rhs, axes)
     set_conref(n, con, name, attr, spec=spec)
+    return con
 
 # =============================================================================
 # writing functions


### PR DESCRIPTION
Closes #119 

Minor: The functions `define_variables`, `define_binaries` and `define_constraints` now have a return value


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.