### PR TITLE
Network deepcopy with timeslice

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,7 @@ PyPSA 0.17.0
 
 * In favour of ``cartopy``, plotting geographical features with ``basemap`` is not supported anymore.  
 * Importing time series from custom non-standard output fields in ``network.component`` is now supported.
+* Deep copies of networks can now be created with a subset of snapshots, e.g. ``network.copy(snapshots=network.snapshots[:2])``.
 * The argument ``bus_colors`` can a now also be a pandas.Series. 
 * The ``carrier`` component has two new columns 'color' and 'nice_name'. The color column is used by the plotting function if ``bus_sizes`` is a pandas.Series with a MultiIndex and ``bus_colors`` is not explicitly defined. 
 * When using the ``pyomo=False`` formulation of the LOPF: 

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -247,9 +247,10 @@ class Network(Basic):
         else:
             self.component_attrs = override_component_attrs
 
-        for c_type in set(self.components.type.unique()) - {np.nan}:
-            setattr(self, c_type + "_components",
-                    set(self.components.index[self.components.type == c_type]))
+        for c_type in set(self.components.type.unique()):
+            if not isinstance(c_type, float):
+                setattr(self, c_type + "_components",
+                        set(self.components.index[self.components.type == c_type]))
 
         self.one_port_components = self.passive_one_port_components|self.controllable_one_port_components
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Deep copies of networks can now be created with a subset of snapshots, e.g. `network.copy(snapshots=network.snapshots[:2])`.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.