### PR TITLE
linopf: fix kirchhoff constraint with radial network

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -14,6 +14,7 @@ PyPSA 0.17.0
 
     * It is now possible to alter the objective function. Terms can be added to the objective via ``extra_functionality`` using the function :func:`pypsa.linopt.write_objective`. When a pure custom objective function needs to be declared, one can set ``skip_objective=True``. In this case, only terms defined through ``extra_functionality`` will be considered in the objective function. 
     * Shadow prices of capacity bounds for non-extendable passive branches are parsed (similar to the ``pyomo=True`` setting)
+    * Fixed :func:`pypsa.linopf.define_kirchhoff_constraints` to handle exclusively radial network topologies.
 
 * When plotting, ``bus_sizes`` are now consistent when they have a ``pandas.MultiIndex`` or a ``pandas.Index``. The default is changed to ``bus_sizes=0.01``. The bus sizes now relate to the axis values.
 * Fixed import from ``pandapower`` for transformers not based on standard types.

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -350,6 +350,7 @@ def define_kirchhoff_constraints(n, sns):
         cycle_sum.index = sns
         con = write_constraint(n, cycle_sum, '=', 0)
         constraints.append(con)
+    if len(constraints) == 0: return 
     constraints = pd.concat(constraints, axis=1, ignore_index=True)
     set_conref(n, constraints, 'SubNetwork', 'mu_kirchhoff_voltage_law')
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

`linopf.define_kirchhoff_constraints()` fails if the network is radial, but has lines (no cycles in any of the subnetworks). In this case `constraints = []` and `pd.concat([])` throws the error. Fix: exit early if list is empy.

```
Traceback (most recent call last):
  File "/home/ws/sp2668/software/anaconda3/envs/decomposition/lib/python3.7/multiprocessing/pool.py", line 121, in worker
    result = (True, func(*args, **kwds))
  File "/home/ws/sp2668/bwSyncAndShare/playgrounds/decomposition/decomposition.py", line 138, in solve_network
    network.lopf(solver_name="cbc", pyomo=False)
  File "/home/ws/sp2668/software/anaconda3/envs/decomposition/lib/python3.7/site-packages/pypsa/components.py", line 516, in lopf
    return network_lopf_lowmem(self, **args)
  File "/home/ws/sp2668/software/anaconda3/envs/decomposition/lib/python3.7/site-packages/pypsa/linopf.py", line 900, in network_lopf
    extra_functionality, solver_dir)
  File "/home/ws/sp2668/software/anaconda3/envs/decomposition/lib/python3.7/site-packages/pypsa/linopf.py", line 628, in prepare_lopf
    define_kirchhoff_constraints(n, snapshots)
  File "/home/ws/sp2668/software/anaconda3/envs/decomposition/lib/python3.7/site-packages/pypsa/linopf.py", line 349, in define_kirchhoff_constraints
    constraints = pd.concat(constraints, axis=1, ignore_index=True)
  File "/home/ws/sp2668/software/anaconda3/envs/decomposition/lib/python3.7/site-packages/pandas/core/reshape/concat.py", line 281, in concat
    sort=sort,
  File "/home/ws/sp2668/software/anaconda3/envs/decomposition/lib/python3.7/site-packages/pandas/core/reshape/concat.py", line 329, in __init__
    raise ValueError("No objects to concatenate")
ValueError: No objects to concatenate
```
## Checklist

- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.