### PR TITLE
Allow layered parameter for CPLEX in `pyomo=False`

### DIFF
--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -688,7 +688,10 @@ def run_and_read_cplex(n, problem_fn, solution_fn, solver_logfile,
     out = m.set_log_stream(solver_logfile)
     if solver_options is not None:
         for key, value in solver_options.items():
-            getattr(m.parameters, key).set(value)
+            param = m.parameters
+            for key_layer in key.split("."):
+                param = getattr(param, key_layer)
+            param.set(value)
     m.read(problem_fn)
     if warmstart:
         m.start.read_basis(warmstart)


### PR DESCRIPTION
This is an amendment to the recent addition of CPLEX support in `n.lopf(pyomo=False)`.

So far the implementation did not support layered parameters such as `solver_options={"barrier.convergetol": 1e-4}` but only single layer parameters such as `solver_options={"lpmethod": 2}`.

See for instance https://www.ibm.com/support/knowledgecenter/SSSA5P_12.7.0/ilog.odms.cplex.help/CPLEX/Parameters/topics/BarEpComp.html for an example of layered parameters.

This fix extends the functionality accordingly. I decided to stick to the CPLEX Python API syntax that separates layered parameters by dots (`"."`) and not go for a layered dictionary for the `solver_options` argument.