### PR TITLE
linopf: assign p0/p1 only for attr s

### DIFF
--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -694,7 +694,7 @@ def assign_solution(n, sns, variables_sol, constraints_dual,
             if c in n.passive_branch_components and attr == "s":
                 set_from_frame(pnl, 'p0', values)
                 set_from_frame(pnl, 'p1', - values)
-            elif c == 'Link':
+            elif c == 'Link' and attr == "p":
                 set_from_frame(pnl, 'p0', values)
                 for i in ['1'] + additional_linkports(n):
                     i_eff = '' if i == '1' else i

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -691,7 +691,7 @@ def assign_solution(n, sns, variables_sol, constraints_dual,
             n.solutions.at[(c, attr), 'pnl'] = True
             pnl = n.pnl(c) if predefined else n.sols[c].pnl
             values = variables.stack().map(variables_sol).unstack()
-            if c in n.passive_branch_components:
+            if c in n.passive_branch_components and attr == "s":
                 set_from_frame(pnl, 'p0', values)
                 set_from_frame(pnl, 'p1', - values)
             elif c == 'Link':


### PR DESCRIPTION
I had defined a new time-dependent variable on the lines:
```py
pypsa.linopt.define_variables(network, 0, 1000, "Line", attr='loss')
```
The function `pypsa.linopt.assign_solution` then wrongly assigned the variable values of "loss" to "p0" and "p1" as it only checks whether the component belongs to passive branch components and not the attribute itself.
With this PR I'd still be able to retrieve the variable values after optimisation with 
```py
network.sols["Line"].pnl["loss"]
```
and makes the function a bit more flexible.

[Sorry, that this comes right after the release]