### PR TITLE
SCLOPF for pyomo=False and ease of import

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,7 +7,7 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
-* Upcoming feature.
+* Security-constrained linear optimal power flow is now also supported without pyomo, by running ``network.sclopf(pyomo=False)``.
 
 
 PyPSA 0.17.0 (23rd March 2020)

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -252,7 +252,7 @@ def add_contingency_constraints_lowmem(network, snapshots):
                 if branch.name == outage:
                     return pd.Series('', branch.index)
                 flow = linexpr((1, branch))
-                added_flow = linexpr((BODF.loc[branch.name, outage], p.loc[:, outage]))
+                added_flow = linexpr((BODF.at[branch.name, outage], p.loc[:, outage]))
                 return flow + added_flow
 
             lhs_flow = p.apply(contingency_flow, axis=0)

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -249,7 +249,8 @@ def add_contingency_constraints_lowmem(network, snapshots):
         for outage in outages:
 
             def contingency_flow(branch):
-                if branch.name == outage: return ""
+                if branch.name == outage:
+                    return pd.Series('', branch.index)
                 flow = linexpr((1, branch))
                 added_flow = linexpr((BODF.loc[branch.name, outage], p.loc[:, outage]))
                 return flow + added_flow

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -208,11 +208,12 @@ def add_contingency_constraints_lowmem(network, snapshots):
 
     n = network
 
-    assert hasattr(n, "_branch_outages"), "Branch outages must be passed in `n._branch_outages`."
+    if not hasattr(n, "_branch_outages")
+        n._branch_outages = n.passive_branches().index
 
     branch_outages = [b
         if isinstance(b, tuple) else ("Line", b)
-        for b in network._branch_outages
+        for b in n._branch_outages
     ]
 
     comps = n.passive_branch_components & set(n.variables.index.levels[0])

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -17,8 +17,8 @@
 """
 
 
-__author__ = "Tom Brown (FIAS)"
-__copyright__ = "Copyright 2016-2017 Tom Brown (FIAS), GNU GPL 3"
+__author__ = "Tom Brown (FIAS), Fabian Neumann (KIT)"
+__copyright__ = "Copyright 2016-2017 Tom Brown (FIAS), 2020 Fabian Neumann (KIT), GNU GPL 3"
 
 
 from scipy.sparse import issparse, csr_matrix, csc_matrix, hstack as shstack

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -250,7 +250,7 @@ def add_contingency_constraints_lowmem(network, snapshots):
 
             def contingency_flow(branch):
                 if branch.name == outage:
-                    return pd.Series('', branch.index)
+                    return linexpr((0, branch))
                 flow = linexpr((1, branch))
                 added_flow = linexpr((BODF.at[branch.name, outage], p[outage]))
                 return flow + added_flow

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -33,9 +33,10 @@ import pandas as pd
 
 import collections
 
+from .descriptors import get_extendable_i, get_non_extendable_i
 from .pf import calculate_PTDF, _as_snapshots
-
 from .opt import l_constraint
+from .linopt import set_conref, write_constraint, get_var, linexpr
 
 
 def calculate_BODF(sub_network, skip_pre=False):
@@ -154,11 +155,151 @@ def network_lpf_contingency(network, snapshots=None, branch_outages=None):
     return p0
 
 
+def add_contingency_constraints(network,snapshots):
+
+    passive_branches = network.passive_branches()
+
+    branch_outages = network._branch_outages
+
+    #prepare the sub networks by calculating BODF and preparing helper DataFrames
+
+    for sn in network.sub_networks.obj:
+
+        sn.calculate_BODF()
+
+        sn._branches = sn.branches()
+        sn._branches["_i"] = range(sn._branches.shape[0])
+
+        sn._extendable_branches = sn._branches[sn._branches.s_nom_extendable]
+        sn._fixed_branches = sn._branches[~ sn._branches.s_nom_extendable]
+
+    #a list of tuples with branch_outage and passive branches in same sub_network
+    branch_outage_keys = []
+    flow_upper = {}
+    flow_lower = {}
+
+    for branch in branch_outages:
+        if type(branch) is not tuple:
+            logger.warning("No type given for {}, assuming it is a line".format(branch))
+            branch = ("Line",branch)
+
+        sub = network.sub_networks.at[passive_branches.at[branch,"sub_network"],"obj"]
+
+        branch_i = sub._branches.at[branch,"_i"]
+
+        branch_outage_keys.extend([(branch[0],branch[1],b[0],b[1]) for b in sub._branches.index])
+
+        flow_upper.update({(branch[0],branch[1],b[0],b[1],sn) : [[(1,network.model.passive_branch_p[b[0],b[1],sn]),(sub.BODF[sub._branches.at[b,"_i"],branch_i],network.model.passive_branch_p[branch[0],branch[1],sn])],"<=",sub._fixed_branches.at[b,"s_nom"]] for b in sub._fixed_branches.index for sn in snapshots})
+
+        flow_upper.update({(branch[0],branch[1],b[0],b[1],sn) : [[(1,network.model.passive_branch_p[b[0],b[1],sn]),(sub.BODF[sub._branches.at[b,"_i"],branch_i],network.model.passive_branch_p[branch[0],branch[1],sn]),(-1,network.model.passive_branch_s_nom[b[0],b[1]])],"<=",0] for b in sub._extendable_branches.index for sn in snapshots})
+
+
+        flow_lower.update({(branch[0],branch[1],b[0],b[1],sn) : [[(1,network.model.passive_branch_p[b[0],b[1],sn]),(sub.BODF[sub._branches.at[b,"_i"],branch_i],network.model.passive_branch_p[branch[0],branch[1],sn])],">=",-sub._fixed_branches.at[b,"s_nom"]] for b in sub._fixed_branches.index for sn in snapshots})
+
+        flow_lower.update({(branch[0],branch[1],b[0],b[1],sn) : [[(1,network.model.passive_branch_p[b[0],b[1],sn]),(sub.BODF[sub._branches.at[b,"_i"],branch_i],network.model.passive_branch_p[branch[0],branch[1],sn]),(1,network.model.passive_branch_s_nom[b[0],b[1]])],">=",0] for b in sub._extendable_branches.index for sn in snapshots})
+
+
+    l_constraint(network.model,"contingency_flow_upper",flow_upper,branch_outage_keys,snapshots)
+
+    l_constraint(network.model,"contingency_flow_lower",flow_lower,branch_outage_keys,snapshots)
+
+
+def add_contingency_constraints_lowmem(network, snapshots):
+
+    n = network
+
+    assert hasattr(n, "_branch_outages"), "Branch outages must be passed in `n._branch_outages`."
+
+    branch_outages = [b
+        if isinstance(b, tuple) else ("Line", b)
+        for b in network._branch_outages
+    ]
+
+    comps = n.passive_branch_components & set(n.variables.index.levels[0])
+    if len(comps) == 0: return
+    dispatch_vars = pd.concat({c: get_var(n, c, "s") for c in comps}, axis=1)
+
+    invest_vars = pd.concat({
+        c: get_var(n, c, "s_nom")
+        if not get_extendable_i(n, c).empty
+        else pd.Series(dtype=np.float64)
+        for c in comps
+    })
+
+    constraints = {}
+    for sn in n.sub_networks.obj:
+
+        sn.calculate_BODF()
+
+        branches_i = sn.branches_i()
+        branches = sn.branches()
+        outages = branches_i.intersection(branch_outages)
+        
+        ext_i = branches.loc[branches.s_nom_extendable].index
+        fix_i = branches.loc[~branches.s_nom_extendable].index
+
+        p = dispatch_vars.loc[:, branches_i]
+        
+        BODF = pd.DataFrame(sn.BODF, index=branches_i, columns=branches_i)
+
+        lhs = {}
+        rhs = {}
+
+        for outage in outages:
+
+            def contingency_flow(branch):
+                if branch.name == outage: return ""
+                flow = linexpr((1, branch))
+                added_flow = linexpr((BODF.loc[branch.name, outage], p.loc[:, outage]))
+                return flow + added_flow
+
+            lhs_flow = p.apply(contingency_flow, axis=0)
+
+            if len(fix_i):
+                lhs_flow_fix = lhs_flow.reindex(columns=fix_i).dropna(axis=1)
+                s_nom_fix = branches.loc[fix_i, "s_nom"]
+
+                key = ("upper", "non_ext", outage)
+                lhs[key] = lhs_flow_fix
+                rhs[key] = s_nom_fix
+
+                key = ("lower", "non_ext", outage)
+                lhs[key] = lhs_flow_fix
+                rhs[key] = - s_nom_fix
+            
+            if len(ext_i):
+                lhs_flow_ext = lhs_flow.reindex(columns=ext_i).dropna(axis=1)
+                s_nom_ext = invest_vars.reindex(branches_i).dropna().astype(int)
+
+                key = ("upper", "ext", outage)
+                lhs[key] = lhs_flow_ext + linexpr((-1, s_nom_ext))
+                rhs[key] = 0
+
+                key = ("lower", "ext", outage)
+                lhs[key] = lhs_flow_ext + linexpr((1, s_nom_ext))
+                rhs[key] = 0
+
+        for k in lhs.keys():
+            sense = "<=" if k[0] == "upper" else ">="
+            axes = (lhs[k].index, lhs[k].columns)
+            con = write_constraint(n, lhs[k], sense, rhs[k], axes)
+            if k not in constraints.keys():
+                constraints[k] = []
+            constraints[k].append(con)
+
+    for (bound, spec, outage), constr in constraints.items():
+        constr = pd.concat(constr, axis=1)
+        for c in comps:
+            if c in constr.columns.levels[0]:
+                constr_name = "_".join([bound, *outage])
+                set_conref(n, constr.loc[:, c], c,
+                           f"mu_contingency_{constr_name}",
+                           spec=spec)
 
 
 def network_sclopf(network, snapshots=None, branch_outages=None, solver_name="glpk",
-                   skip_pre=False, extra_functionality=None, solver_options={},
-                   keep_files=False, formulation="angles", ptdf_tolerance=0.):
+                   pyomo=True, skip_pre=False, extra_functionality=None, solver_options={},
+                   keep_files=False, formulation="kirchhoff", ptdf_tolerance=0.):
     """
     Computes Security-Constrained Linear Optimal Power Flow (SCLOPF).
 
@@ -175,6 +316,9 @@ def network_sclopf(network, snapshots=None, branch_outages=None, solver_name="gl
     solver_name : string
         Must be a solver name that pyomo recognises and that is
         installed, e.g. "glpk", "gurobi"
+    pyomo : bool, default True
+        Whether to use pyomo for building and solving the model, setting
+        this to False saves a lot of memory and time.
     skip_pre : bool, default False
         Skip the preliminary steps of computing topology, calculating
         dependent values and finding bus controls.
@@ -190,7 +334,7 @@ def network_sclopf(network, snapshots=None, branch_outages=None, solver_name="gl
     keep_files : bool, default False
         Keep the files that pyomo constructs from OPF problem
         construction, e.g. .lp file - useful for debugging
-    formulation : string
+    formulation : string, default "kirchhoff"
         Formulation of the linear power flow equations to use; must be
         one of ["angles","cycles","kirchoff","ptdf"]
     ptdf_tolerance : float
@@ -212,60 +356,22 @@ def network_sclopf(network, snapshots=None, branch_outages=None, solver_name="gl
     passive_branches = network.passive_branches()
 
     if branch_outages is None:
-        branch_outages = passive_branches.index
+        branch_outages = passive_branches.index  
 
-    #prepare the sub networks by calculating BODF and preparing helper DataFrames
+    # save to network for extra_functionality
+    network._branch_outages = branch_outages
 
-    for sn in network.sub_networks.obj:
-
-        sn.calculate_BODF()
-
-        sn._branches = sn.branches()
-        sn._branches["_i"] = range(sn._branches.shape[0])
-
-        sn._extendable_branches = sn._branches[sn._branches.s_nom_extendable]
-        sn._fixed_branches = sn._branches[~ sn._branches.s_nom_extendable]
-
-
-    def add_contingency_constraints(network,snapshots):
-
-        #a list of tuples with branch_outage and passive branches in same sub_network
-        branch_outage_keys = []
-        flow_upper = {}
-        flow_lower = {}
-
-        for branch in branch_outages:
-            if type(branch) is not tuple:
-                logger.warning("No type given for {}, assuming it is a line".format(branch))
-                branch = ("Line",branch)
-
-            sub = network.sub_networks.at[passive_branches.at[branch,"sub_network"],"obj"]
-
-            branch_i = sub._branches.at[branch,"_i"]
-
-            branch_outage_keys.extend([(branch[0],branch[1],b[0],b[1]) for b in sub._branches.index])
-
-            flow_upper.update({(branch[0],branch[1],b[0],b[1],sn) : [[(1,network.model.passive_branch_p[b[0],b[1],sn]),(sub.BODF[sub._branches.at[b,"_i"],branch_i],network.model.passive_branch_p[branch[0],branch[1],sn])],"<=",sub._fixed_branches.at[b,"s_nom"]] for b in sub._fixed_branches.index for sn in snapshots})
-
-            flow_upper.update({(branch[0],branch[1],b[0],b[1],sn) : [[(1,network.model.passive_branch_p[b[0],b[1],sn]),(sub.BODF[sub._branches.at[b,"_i"],branch_i],network.model.passive_branch_p[branch[0],branch[1],sn]),(-1,network.model.passive_branch_s_nom[b[0],b[1]])],"<=",0] for b in sub._extendable_branches.index for sn in snapshots})
-
-
-            flow_lower.update({(branch[0],branch[1],b[0],b[1],sn) : [[(1,network.model.passive_branch_p[b[0],b[1],sn]),(sub.BODF[sub._branches.at[b,"_i"],branch_i],network.model.passive_branch_p[branch[0],branch[1],sn])],">=",-sub._fixed_branches.at[b,"s_nom"]] for b in sub._fixed_branches.index for sn in snapshots})
-
-            flow_lower.update({(branch[0],branch[1],b[0],b[1],sn) : [[(1,network.model.passive_branch_p[b[0],b[1],sn]),(sub.BODF[sub._branches.at[b,"_i"],branch_i],network.model.passive_branch_p[branch[0],branch[1],sn]),(1,network.model.passive_branch_s_nom[b[0],b[1]])],">=",0] for b in sub._extendable_branches.index for sn in snapshots})
-
-
-        l_constraint(network.model,"contingency_flow_upper",flow_upper,branch_outage_keys,snapshots)
-
-
-        l_constraint(network.model,"contingency_flow_lower",flow_lower,branch_outage_keys,snapshots)
-
+    def _extra_functionality(network, snapshots):
+        if pyomo:
+            add_contingency_constraints(network, snapshots)
+        else:
+            add_contingency_constraints_lowmem(network, snapshots)
         if extra_functionality is not None:
             extra_functionality(network, snapshots)
 
     #need to skip preparation otherwise it recalculates the sub-networks
 
-    network.lopf(snapshots=snapshots, solver_name=solver_name, skip_pre=True,
-                 extra_functionality=add_contingency_constraints,
+    network.lopf(snapshots=snapshots, solver_name=solver_name, pyomo=pyomo, 
+                 skip_pre=True, extra_functionality=_extra_functionality,
                  solver_options=solver_options, keep_files=keep_files,
                  formulation=formulation, ptdf_tolerance=ptdf_tolerance)

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -256,7 +256,7 @@ def add_contingency_constraints_lowmem(network, snapshots):
             lhs_flow = p.apply(contingency_flow, axis=0)
 
             if len(fix_i):
-                lhs_flow_fix = lhs_flow.reindex(columns=fix_i).dropna(axis=1)
+                lhs_flow_fix = lhs_flow.loc[:,fix_i]
                 s_nom_fix = branches.loc[fix_i, "s_nom"]
 
                 key = ("upper", "non_ext", outage)
@@ -268,8 +268,8 @@ def add_contingency_constraints_lowmem(network, snapshots):
                 rhs[key] = - s_nom_fix
             
             if len(ext_i):
-                lhs_flow_ext = lhs_flow.reindex(columns=ext_i).dropna(axis=1)
-                s_nom_ext = invest_vars.reindex(branches_i).dropna().astype(int)
+                lhs_flow_ext = lhs_flow.loc[:,ext_i]
+                s_nom_ext = invest_vars.loc[ext_i]
 
                 key = ("upper", "ext", outage)
                 lhs[key] = lhs_flow_ext + linexpr((-1, s_nom_ext))

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -208,7 +208,7 @@ def add_contingency_constraints_lowmem(network, snapshots):
 
     n = network
 
-    if not hasattr(n, "_branch_outages")
+    if not hasattr(n, "_branch_outages"):
         n._branch_outages = n.passive_branches().index
 
     branch_outages = [b

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -239,7 +239,7 @@ def add_contingency_constraints_lowmem(network, snapshots):
         ext_i = branches.loc[branches.s_nom_extendable].index
         fix_i = branches.loc[~branches.s_nom_extendable].index
 
-        p = dispatch_vars.loc[:, branches_i]
+        p = dispatch_vars[branches_i]
         
         BODF = pd.DataFrame(sn.BODF, index=branches_i, columns=branches_i)
 
@@ -252,13 +252,13 @@ def add_contingency_constraints_lowmem(network, snapshots):
                 if branch.name == outage:
                     return pd.Series('', branch.index)
                 flow = linexpr((1, branch))
-                added_flow = linexpr((BODF.at[branch.name, outage], p.loc[:, outage]))
+                added_flow = linexpr((BODF.at[branch.name, outage], p[outage]))
                 return flow + added_flow
 
             lhs_flow = p.apply(contingency_flow, axis=0)
 
             if len(fix_i):
-                lhs_flow_fix = lhs_flow.loc[:,fix_i]
+                lhs_flow_fix = lhs_flow[fix_i]
                 s_nom_fix = branches.loc[fix_i, "s_nom"]
 
                 key = ("upper", "non_ext", outage)
@@ -270,8 +270,8 @@ def add_contingency_constraints_lowmem(network, snapshots):
                 rhs[key] = - s_nom_fix
             
             if len(ext_i):
-                lhs_flow_ext = lhs_flow.loc[:,ext_i]
-                s_nom_ext = invest_vars.loc[ext_i]
+                lhs_flow_ext = lhs_flow[ext_i]
+                s_nom_ext = invest_vars[ext_i]
 
                 key = ("upper", "ext", outage)
                 lhs[key] = lhs_flow_ext + linexpr((-1, s_nom_ext))
@@ -294,7 +294,7 @@ def add_contingency_constraints_lowmem(network, snapshots):
         for c in comps:
             if c in constr.columns.levels[0]:
                 constr_name = "_".join([bound, *outage])
-                set_conref(n, constr.loc[:, c], c,
+                set_conref(n, constr[c], c,
                            f"mu_contingency_{constr_name}",
                            spec=spec)
 

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -815,11 +815,11 @@ def assign_solution(n, sns, variables_sol, constraints_dual,
 
 def network_lopf(n, snapshots=None, solver_name="cbc",
          solver_logfile=None, extra_functionality=None, skip_objective=False,
-         extra_postprocessing=None, formulation="kirchhoff",
+         skip_pre=False, extra_postprocessing=None, formulation="kirchhoff",
          keep_references=False, keep_files=False,
          keep_shadowprices=['Bus', 'Line', 'Transformer', 'Link', 'GlobalConstraint'],
          solver_options=None, warmstart=False, store_basis=False,
-         solver_dir=None):
+         solver_dir=None, ptdf_tolerance=0.):
     """
     Linear optimal power flow for a group of snapshots.
 
@@ -854,6 +854,8 @@ def network_lopf(n, snapshots=None, solver_name="cbc",
         the model building is complete, but before it is sent to the
         solver. It allows the user to
         add/change constraints and add/change the objective function.
+    skip_pre : bool, default False
+        Skip the preliminary steps of computing topology.
     skip_objective : bool, default False
         Skip writing the default objective function. If False, a custom
         objective has to be defined via extra_functionality.
@@ -881,6 +883,8 @@ def network_lopf(n, snapshots=None, solver_name="cbc",
         names. Defaults to ['Bus', 'Line', 'GlobalConstraint'].
         After solving, the shadow prices can be retrieved using
         :func:`pypsa.linopt.get_dual` with corresponding name
+    ptdf_tolerance : float
+        For "ptdf" formulation with pyomo.
 
     """
     supported_solvers = ["cbc", "gurobi", 'glpk', 'cplex']
@@ -899,7 +903,8 @@ def network_lopf(n, snapshots=None, solver_name="cbc",
     #disable logging because multiple slack bus calculations, keep output clean
     snapshots = _as_snapshots(n, snapshots)
     n.calculate_dependent_values()
-    n.determine_network_topology()
+    if not skip_pre:
+        n.determine_network_topology()
 
     logger.info("Prepare linear problem")
     fdp, problem_fn = prepare_lopf(n, snapshots, keep_files, skip_objective,

--- a/test/test_sclopf_scigrid.py
+++ b/test/test_sclopf_scigrid.py
@@ -27,7 +27,7 @@ def test_sclopf():
         n.lines.loc[line_name, "s_nom"] = 1200
 
     # choose the contingencies
-    branch_outages = n.lines.index[:3]
+    branch_outages = n.lines.index[:2]
 
     objectives = []
     for pyomo in [True, False]:
@@ -59,7 +59,7 @@ def test_sclopf():
             .loc["max"]
         )
 
-        arr_equal(max_loading, np.ones((len(max_loading))))
+        arr_equal(max_loading, np.ones((len(max_loading))), decimal=4)
 
         objectives.append(n.objective)
 

--- a/test/test_sclopf_scigrid.py
+++ b/test/test_sclopf_scigrid.py
@@ -3,45 +3,67 @@ import numpy as np
 import pypsa
 import sys
 
-solver_name = 'glpk' if sys.platform == 'win32' else 'cbc'
+from numpy.testing import assert_array_almost_equal as arr_equal
+from numpy.testing import assert_almost_equal as equal
+
+solver_name = "glpk" if sys.platform == "win32" else "cbc"
 
 
 def test_sclopf():
-    csv_folder_name = os.path.join(os.path.dirname(__file__), "..", "examples",
-                                   "scigrid-de", "scigrid-with-load-gen-trafos")
+    csv_folder_name = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "examples",
+        "scigrid-de",
+        "scigrid-with-load-gen-trafos",
+    )
 
-    network = pypsa.Network(csv_folder_name)
+    n = pypsa.Network(csv_folder_name)
 
-    #test results were generated with GLPK and other solvers may differ
+    # test results were generated with GLPK and other solvers may differ
 
-    #There are some infeasibilities without line extensions
-    for line_name in ["316","527","602"]:
-        network.lines.loc[line_name,"s_nom"] = 1200
+    # There are some infeasibilities without line extensions
+    for line_name in ["316", "527", "602"]:
+        n.lines.loc[line_name, "s_nom"] = 1200
 
-    #choose the contingencies
-    branch_outages = network.lines.index[:3]
+    # choose the contingencies
+    branch_outages = n.lines.index[:3]
 
-    print("Performing security-constrained linear OPF:")
+    objectives = []
+    for pyomo in [True, False]:
 
-    network.sclopf(network.snapshots[0],branch_outages=branch_outages,solver_name=solver_name)
+        n.sclopf(
+            n.snapshots[0],
+            branch_outages=branch_outages,
+            pyomo=pyomo,
+            solver_name=solver_name,
+        )
 
-    #For the PF, set the P to the optimised P
-    network.generators_t.p_set = network.generators_t.p.copy()
-    network.generators.loc[:,'p_set_t'] = True
-    network.storage_units_t.p_set = network.storage_units_t.p.copy()
-    network.storage_units.loc[:,'p_set_t'] = True
+        # For the PF, set the P to the optimised P
+        n.generators_t.p_set = n.generators_t.p.copy()
+        n.generators.loc[:, "p_set_t"] = True
+        n.storage_units_t.p_set = n.storage_units_t.p.copy()
+        n.storage_units.loc[:, "p_set_t"] = True
 
-    #Check no lines are overloaded with the linear contingency analysis
+        # Check no lines are overloaded with the linear contingency analysis
 
-    p0_test = network.lpf_contingency(network.snapshots[0],branch_outages=branch_outages)
+        p0_test = n.lpf_contingency(
+            n.snapshots[0], branch_outages=branch_outages
+        )
 
-    #check loading as per unit of s_nom in each contingency
+        # check loading as per unit of s_nom in each contingency
 
-    max_loading = abs(p0_test.divide(network.passive_branches().s_nom,axis=0)).describe().loc["max"]
+        max_loading = (
+            abs(p0_test.divide(n.passive_branches().s_nom, axis=0))
+            .describe()
+            .loc["max"]
+        )
 
+        arr_equal(max_loading, np.ones((len(max_loading))))
 
-    np.testing.assert_array_almost_equal(max_loading,np.ones((len(max_loading))))
+        objectives.append(n.objective)
 
+    equal(*objectives, decimal=1)
 
 if __name__ == "__main__":
     test_sclopf()


### PR DESCRIPTION
Closes #176

## Changes proposed in this Pull Request

Re-implementation of security-constrained LOPF for `pyomo=False`.
- https://pypsa.readthedocs.io/en/latest/contingency_analysis.html#security-constrained-linear-optimal-power-flow-sclopf

Additionally, slight restructuring of `pypsa.contingency` to allow imports like

```python
from pypsa.contingency import add_contingency_constraints
from pypsa.contingency import add_contingency_constraints_lowmem
```
This would for instance simplify adding an SCLOPF option in PyPSA-Eur; just import and add to the collection of extra functionalities.

@FabianHofmann, I hope I did not misuse the `pypsa.linopt` functions. Particularly, I would be interested whether there would be a cleaner way to set the constraint reference.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- ~[ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).~
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.