### PR TITLE
linopf.py: Fix bug: multi-link outputs set when not multi-link

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,7 +7,14 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
-* Upcoming feature.
+* There was a bug in the LOPF with `pyomo=False` whereby if some Links
+  were defined with multiple outputs (i.e. bus2, bus3, etc. were
+  defined), but there remained some Links without multiple outputs
+  (bus2, bus3, etc. set to `""`), then the Links without multiple
+  outputs were assigned erroneous non-zero values for p2, p3, etc. in
+  the LOPF with `pyomo=False`. Now p2, p3, etc. revert to the default
+  value for Links where bus2, bus3, etc. are not defined, just like
+  for the LOPF with `pyomo=True`.
 
 
 PyPSA 0.17.0 (23rd March 2020)

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -700,6 +700,7 @@ def assign_solution(n, sns, variables_sol, constraints_dual,
                     i_eff = '' if i == '1' else i
                     eff = get_as_dense(n, 'Link', f'efficiency{i_eff}', sns)
                     set_from_frame(pnl, f'p{i}', - values * eff)
+                    pnl[f'p{i}'].loc[sns, n.links.index[n.links[f'bus{i}'] == ""]] = n.component_attrs['Link'].loc[f'p{i}','default']
             else:
                 set_from_frame(pnl, attr, values)
         else:

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -700,7 +700,8 @@ def assign_solution(n, sns, variables_sol, constraints_dual,
                     i_eff = '' if i == '1' else i
                     eff = get_as_dense(n, 'Link', f'efficiency{i_eff}', sns)
                     set_from_frame(pnl, f'p{i}', - values * eff)
-                    pnl[f'p{i}'].loc[sns, n.links.index[n.links[f'bus{i}'] == ""]] = n.component_attrs['Link'].loc[f'p{i}','default']
+                    pnl[f'p{i}'].loc[sns, n.links.index[n.links[f'bus{i}'] == ""]] = \
+                                              n.component_attrs['Link'].loc[f'p{i}','default']
             else:
                 set_from_frame(pnl, attr, values)
         else:


### PR DESCRIPTION
There can be mixed situations where some links have multiple outputs to bus2, bus3, etc, but we still have some links with single outputs to bus1 and no other outputs bus2 = "" and bus3 = "".

However, the LOPF with pyomo=False was setting non-zero outputs for p2 and p3 also for the links with single outputs.

Now, if bus2 and bus3 etc are empty, the p2 and p3 is set to the default, just like pyomo=True (see https://github.com/PyPSA/PyPSA/blob/7ece53e087df984f84c5a34917fe9a09cc5d8246/pypsa/opf.py#L1347).


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.