### PR TITLE
Handle cbc asterisk

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -16,6 +16,8 @@ Upcoming Release
   value for Links where bus2, bus3, etc. are not defined, just like
   for the LOPF with `pyomo=True`.
 
+* Handle double-asterisk prefix in solution_fn when solving lopf with pyomo=False using CBC.
+
 
 PyPSA 0.17.0 (23rd March 2020)
 ================================

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -594,7 +594,11 @@ def run_and_read_cbc(n, problem_fn, solution_fn, solver_logfile,
     if termination_condition != "optimal":
         return status, termination_condition, None, None, None
 
-    sol = pd.read_csv(solution_fn, header=None, skiprows=[0],
+    f = open(solution_fn,"rb")
+    trimed_sol_fn = re.sub(b'\*\*\s+', b'', f.read())
+    f.close()
+
+    sol = pd.read_csv(io.BytesIO(trimed_sol_fn), header=None, skiprows=[0],
                       sep=r'\s+', usecols=[1,2,3], index_col=0)
     variables_b = sol.index.str[0] == 'x'
     variables_sol = sol[variables_b][2].pipe(set_int_index)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Fix rare double-asterisk prefix cases when running lopf with pyomo=False using cbc. 
The solver founds the optimal solution but raises the following error while reading back the solution_fn.
`TypeError: bad operand type for unary -: 'str'`

For reference, this is how pyomo handles this kind of issue
[` elif (n_tokens == 5) and tokens[0] == "**": tokens = tokens[1:]`](https://github.com/Pyomo/pyomo/blob/eb325a145bafc125fd34c58a23cd2a4992cd9300/pyomo/solvers/plugins/solvers/CBCplugin.py#L807)

[Google forum: topic on this issue](https://groups.google.com/forum/#!topic/pypsa/XXaF4tI1AHI)

## Checklist

- [v] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [v] Unit tests for new features were added (if applicable).
- [v] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [v] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.