### PR TITLE
fix assignment of dual variables in lv_limit for final lopf

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,6 +22,9 @@ Upcoming Release
 
 * When solving ``n.lopf(pyomo=False, store_basis=True, solver_name="cplex")`` an error raised by trying to store a non-existing basis is caught.
 
+* Fixed bug when saving dual variables in the lv_limit dual. Now using dual from the second last iteration in pypsa.linopf,
+  as last iteration returns NaN (no optimisation of line volumes in last iteration).
+
 
 PyPSA 0.17.0 (23rd March 2020)
 ================================

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -1007,6 +1007,7 @@ def ilopf(n, snapshots=None, msq_threshold=0.05, min_iterations=1,
         setattr(n, f"status_{iteration}", status)
         setattr(n, f"objective_{iteration}", n.objective)
         n.iteration = iteration
+        n.global_constraints = n.global_constraints.rename(columns={'mu': f'mu_{iteration}'})
 
 
     if track_iterations:
@@ -1028,8 +1029,6 @@ def ilopf(n, snapshots=None, msq_threshold=0.05, min_iterations=1,
                                 f'and termination {termination_condition}')
         if track_iterations:
             save_optimal_capacities(n, iteration, status)
-            n.global_constraints = n.global_constraints.rename(columns={'mu': f'mu_{iteration}'})
-        final_duals = n.global_constraints.mu.copy() #save second last iteration of duals (needed for lv_limit duals)
         update_line_params(n, s_nom_prev)
         diff = msq_diff(n, s_nom_prev)
         iteration += 1
@@ -1041,11 +1040,6 @@ def ilopf(n, snapshots=None, msq_threshold=0.05, min_iterations=1,
     kwargs['warmstart'] = False
     network_lopf(n, snapshots, **kwargs)
     if track_iterations:
-        n.global_constraints = n.global_constraints.rename(columns={'mu':f'mu_{iteration}'})
-    if 'lv_limit' in n.global_constraints.index:
-        logger.info(f'Resulting dual value for line volume limit (lv_limit) set to the one of iteration {iteration-1} '
-                    'due to its optimisation process.') # otherwise, final dual for lv_limit is NaN.
-        if track_iterations: n.global_constraints.at['lv_limit', f'mu_{iteration}'] = final_duals['lv_limit']
-        else: n.global_constraints.at['lv_limit', f'mu'] = final_duals['lv_limit']
+        save_optimal_capacities(n, iteration, status)
     n.lines.loc[ext_i, 's_nom_extendable'] = True
     n.links.loc[ext_links_i, 'p_nom_extendable'] = True

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -1028,6 +1028,8 @@ def ilopf(n, snapshots=None, msq_threshold=0.05, min_iterations=1,
                                 f'and termination {termination_condition}')
         if track_iterations:
             save_optimal_capacities(n, iteration, status)
+            n.global_constraints = n.global_constraints.rename(columns={'mu': f'mu_{iteration}'})
+        final_duals = n.global_constraints.mu.copy() #save second last iteration of duals (needed for lv_limit duals)
         update_line_params(n, s_nom_prev)
         diff = msq_diff(n, s_nom_prev)
         iteration += 1
@@ -1038,5 +1040,12 @@ def ilopf(n, snapshots=None, msq_threshold=0.05, min_iterations=1,
     n.links[['p_nom', 'p_nom_extendable']] = n.links['p_nom_opt'], False
     kwargs['warmstart'] = False
     network_lopf(n, snapshots, **kwargs)
+    if track_iterations:
+        n.global_constraints = n.global_constraints.rename(columns={'mu':f'mu_{iteration}'})
+    if 'lv_limit' in n.global_constraints.index:
+        logger.info(f'Resulting dual value for line volume limit (lv_limit) set to the one of iteration {iteration-1} '
+                    'due to its optimisation process.') # otherwise, final dual for lv_limit is NaN.
+        if track_iterations: n.global_constraints.at['lv_limit', f'mu_{iteration}'] = final_duals['lv_limit']
+        else: n.global_constraints.at['lv_limit', f'mu'] = final_duals['lv_limit']
     n.lines.loc[ext_i, 's_nom_extendable'] = True
     n.links.loc[ext_links_i, 'p_nom_extendable'] = True

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -1039,7 +1039,5 @@ def ilopf(n, snapshots=None, msq_threshold=0.05, min_iterations=1,
     n.links[['p_nom', 'p_nom_extendable']] = n.links['p_nom_opt'], False
     kwargs['warmstart'] = False
     network_lopf(n, snapshots, **kwargs)
-    if track_iterations:
-        save_optimal_capacities(n, iteration, status)
     n.lines.loc[ext_i, 's_nom_extendable'] = True
     n.links.loc[ext_links_i, 'p_nom_extendable'] = True


### PR DESCRIPTION
If a line volume is given (such as lv1.25), its dual variable after the optimisation process \mu in the global constraints is NaN, because the last iteration of the lopf fixes lines and links. Hence, we use the second last dual.

Additionally, if track_iterations is true, the global constraint shadow variables \mu are being tracked as well.