### PR TITLE
add compatibility with pyomo 5.7.0

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,6 +24,8 @@ Upcoming Release
 
 * When solving ``n.lopf(pyomo=False, store_basis=True, solver_name="cplex")`` an error raised by trying to store a non-existing basis is caught.
 
+* Add compatibility for Pyomo 5.7.
+
 
 PyPSA 0.17.0 (23rd March 2020)
 ================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,7 +24,7 @@ Upcoming Release
 
 * When solving ``n.lopf(pyomo=False, store_basis=True, solver_name="cplex")`` an error raised by trying to store a non-existing basis is caught.
 
-* Add compatibility for Pyomo 5.7.
+* Add compatibility for Pyomo 5.7. This is also the new minimum requirement.
 
 
 PyPSA 0.17.0 (23rd March 2020)

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - pytables
   - matplotlib
   - networkx>=1.10
-  - pyomo
+  - pyomo>=5.7.0
   - cartopy>=0.16
 #  - coincbc
   - glpk

--- a/environment_docs.yml
+++ b/environment_docs.yml
@@ -6,7 +6,7 @@ dependencies:
   - python
   - six
   - numpy
-  - pyomo
+  - pyomo>=5.7.0
   - scipy
   - pandas>=0.24.0
   - pytables

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -34,12 +34,6 @@ from collections import namedtuple
 import os
 
 
-from distutils.version import StrictVersion, LooseVersion
-try:
-    _pd_version = StrictVersion(pd.__version__)
-except ValueError:
-    _pd_version = LooseVersion(pd.__version__)
-
 from .descriptors import Dict, get_switchable_as_dense
 
 from .io import (export_to_csv_folder, import_from_csv_folder,
@@ -389,8 +383,6 @@ class Network(Basic):
         self.snapshots = pd.Index(snapshots)
 
         self.snapshot_weightings = self.snapshot_weightings.reindex(self.snapshots,fill_value=1.)
-        if isinstance(snapshots, pd.DatetimeIndex) and _pd_version < '0.18.0':
-            snapshots = pd.Index(snapshots.values)
 
         for component in self.all_components:
             pnl = self.pnl(component)

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -42,12 +42,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-from distutils.version import StrictVersion, LooseVersion
-try:
-    _pd_version = StrictVersion(pd.__version__)
-except ValueError:
-    _pd_version = LooseVersion(pd.__version__)
-
 from .pf import (calculate_dependent_values, find_slack_bus,
                  find_bus_controls, calculate_B_H, calculate_PTDF, find_tree,
                  find_cycles, _as_snapshots)
@@ -1230,10 +1224,6 @@ def define_linear_objective(network,snapshots):
 
 def extract_optimisation_results(network, snapshots, formulation="angles", free_pyomo=True,
                                  extra_postprocessing=None):
-
-    if isinstance(snapshots, pd.DatetimeIndex) and _pd_version < '0.18.0':
-        # Work around pandas bug #12050 (https://github.com/pydata/pandas/issues/12050)
-        snapshots = pd.Index(snapshots.values)
 
     allocate_series_dataframes(network, {'Generator': ['p'],
                                          'Load': ['p'],

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -1583,8 +1583,8 @@ def network_lopf_solve(network, snapshots=None, formulation="angles", solver_opt
     if logger.isEnabledFor(logging.INFO):
         network.results.write()
 
-    status = network.results["Solver"][0]["Status"].key
-    termination_condition = network.results["Solver"][0]["Termination condition"].key
+    status = network.results["Solver"][0]["Status"]
+    termination_condition = network.results["Solver"][0]["Termination condition"]
 
     if status == "ok" and termination_condition == "optimal":
         logger.info("Optimization successful")

--- a/pypsa/opt.py
+++ b/pypsa/opt.py
@@ -145,6 +145,13 @@ class LConstraint(object):
     def __repr__(self):
         return "{} {} {}".format(self.lhs, self.sense, self.rhs)
 
+def _build_sum_expression(variables, constant=0.):
+    expr = LinearExpression()
+    expr.linear_vars = [item[1] for item in variables]
+    expr.linear_coefs = [item[0] for item in variables]
+    expr.constant = constant
+    return expr
+
 def l_constraint(model,name,constraints,*args):
     """A replacement for pyomo's Constraint that quickly builds linear
     constraints.

--- a/pypsa/opt.py
+++ b/pypsa/opt.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 from pyomo.environ import Constraint, Objective, Var, ComponentUID, minimize
+from pyomo.core.expr.numeric_expr import LinearExpression
 
 import pyomo
 from contextlib import contextmanager
@@ -143,34 +144,6 @@ class LConstraint(object):
 
     def __repr__(self):
         return "{} {} {}".format(self.lhs, self.sense, self.rhs)
-
-try:
-    try:
-        # With pyomo version 5.6.2, expr_pyomo5.py has been split into three files
-        # https://github.com/Pyomo/pyomo/pull/888
-        from pyomo.core.expr.numeric_expr import LinearExpression
-    except ImportError:
-        # [5.6, 5.6.2)
-        from pyomo.core.expr.expr_pyomo5 import LinearExpression
-
-    def _build_sum_expression(variables, constant=0.):
-        expr = LinearExpression()
-        expr.linear_vars = [item[1] for item in variables]
-        expr.linear_coefs = [item[0] for item in variables]
-        expr.constant = constant
-        return expr
-
-except ImportError:
-    # - 5.6)
-    from pyomo.core.base import expr_coopr3
-
-    def _build_sum_expression(variables, constant=0.):
-        expr = expr_coopr3._SumExpression()
-        expr._args = [item[1] for item in variables]
-        expr._coef = [item[0] for item in variables]
-        expr._const = constant
-        return expr
-
 
 def l_constraint(model,name,constraints,*args):
     """A replacement for pyomo's Constraint that quickly builds linear

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'scipy',
         'pandas>=0.24.0',
         'tables',
-        'pyomo>=5.3',
+        'pyomo>=5.7',
         'matplotlib',
         'networkx>=1.10'
     ],


### PR DESCRIPTION
Closes #186.

## Changes proposed in this Pull Request

Add compatibility for pyomo v5.7.0.

There were some (for our use breaking) changes in the newest version due to
https://github.com/Pyomo/pyomo/pull/1506 as described in the issue above. It replaces use of PyUtilib's Enum with the built-in Python enum package. The new SolverStatus class does not have a `key` attribute any longer.

The relevant lines in pyomo are here:
https://github.com/Pyomo/pyomo/blob/master/pyomo/opt/results/solver.py#L20-L82

## Checklist

~- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.~
~- [ ] Unit tests for new features were added (if applicable).~
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.