### PR TITLE
networkclustering: add s_max_pu to aggregation

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -29,6 +29,8 @@ Upcoming Release
 
 * When solving ``n.lopf(pyomo=False)``, PyPSA now constrains the dispatch variables for non extendable components with actual constraints, not with standard variable bounds. This allows retrieving shadow prices for all dispatch variables when running ``n.lopf(pyomo=False, keep_shadowprices=True).   
 
+* Can now cluster lines with different ``s_max_pu`` values.
+
 PyPSA 0.17.0 (23rd March 2020)
 ================================
 

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -185,6 +185,7 @@ def aggregatelines(network, buses, interlines, line_length_factor=1.0):
             g=(voltage_factor * length_factor * l['g']).sum(),
             b=(voltage_factor * length_factor * l['b']).sum(),
             terrain_factor=l['terrain_factor'].mean(),
+            s_max_pu=(l['s_max_pu'] * _normed(l['s_nom'])).sum(),
             s_nom=l['s_nom'].sum(),
             s_nom_min=l['s_nom_min'].sum(),
             s_nom_max=l['s_nom_max'].sum(),


### PR DESCRIPTION
Closes #187 .

## Changes proposed in this Pull Request

Can now merge `s_max_pu` in network clustering as proposed by @ClaraBuettner

## Checklist

~- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.~
~- [ ] Unit tests for new features were added (if applicable).~
~- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).~
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.