### PR TITLE
networkclustering: handle optional dependencies

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -29,6 +29,8 @@ Upcoming Release
 
 * When solving ``n.lopf(pyomo=False)``, PyPSA now constrains the dispatch variables for non extendable components with actual constraints, not with standard variable bounds. This allows retrieving shadow prices for all dispatch variables when running ``n.lopf(pyomo=False, keep_shadowprices=True).   
 
+* Improved handling of optional dependencies for network clustering functionalities (``sklearn`` and ``community``).
+
 PyPSA 0.17.0 (23rd March 2020)
 ================================
 


### PR DESCRIPTION
Closes #177.

## Changes proposed in this Pull Request

Improve handling of optional dependencies for network clustering functionalities. These are `community` for louvain clustering and `sklearn` for KMeans clustering.

Sorry, the diff got a bit butchered due to the changed indentation, but principle is the same as for the different solvers to import only within the function.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
~- [ ] Unit tests for new features were added (if applicable).~
~- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).~
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.