### PR TITLE
Add nominal bounds for bus & carrier

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,7 +7,7 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
-* First new feature
+* When solving ``n.lopf(pyomo=False)``, PyPSA now supports setting lower and upper capacity bounds per bus and carrier. These are specified in the columns ``n.buses['nom_min_{carrier}']`` and ``n.buses['nom_max_{carrier}']`` respectively. For example, if multiple generators of carrier "wind" are at bus "bus1", the combined capacity is limited to 1000 MW by setting ``n.buses.loc['bus1', 'nom_max_wind'] = 1000`` (a minimal capacity is forced by setting ``n.buses.loc['bus1', 'nom_min_wind']``). In the same manner the combined ``p_nom`` of components ``StorageUnit`` and ``e_nom`` of components ``Store`` can be limited.  
 
 PyPSA 0.17.1 (15th July 2020)
 =============================

--- a/examples/notebooks/capacity-constraint-per-bus.ipynb
+++ b/examples/notebooks/capacity-constraint-per-bus.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Constraining the total capacity per bus and carrier\n",
+    "\n",
+    "In this small example, we limit the nominal capacity of generators of the same production carrier at the same bus. \n",
+    "\n",
+    "Therefore, we introduce a column `nom_min_{carrier}` and `nom_max_{carrier}` in the `buses` dataframe. These are then used as lower and upper bounds of generators of the same carrier at the same bus. \n",
+    "\n",
+    "\n",
+    "We start with importing a small example network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:pypsa.io:\n",
+      "Importing PyPSA from older version of PyPSA than current version 0.17.1.\n",
+      "Please read the release notes at https://pypsa.org/doc/release_notes.html\n",
+      "carefully to prepare your network for import.\n",
+      "\n",
+      "INFO:pypsa.io:Imported network ac-dc-data has buses, carriers, generators, global_constraints, lines, links, loads\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pypsa\n",
+    "from pathlib import Path\n",
+    "\n",
+    "n = pypsa.Network(str(Path(pypsa.__file__).parent.parent / 'examples'/\n",
+    "                      'ac-dc-meshed'/ 'ac-dc-data'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now add a second wind generator at bus 'Frankfurt' and limit the combined capacity. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n.add('Generator', 'Frankfurt Wind 2', bus='Frankfurt', capital_cost = 120,\n",
+    "      carrier='wind', p_nom_extendable=True)\n",
+    "\n",
+    "n.buses.loc[['Frankfurt', 'Manchester'], 'nom_min_wind'] = 2000\n",
+    "n.buses.loc[['Frankfurt'],'nom_max_wind'] = 2200"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are running the lopf and check whether the constraint is fulfilled. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pypsa.linopf:Prepare linear problem\n",
+      "INFO:pypsa.linopf:Total preparation time: 0.25s\n",
+      "INFO:pypsa.linopf:Solve linear problem using Glpk solver\n",
+      "INFO:pypsa.linopf:Optimization successful. Objective value: -1.38e+07\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Manchester Wind     2000.0000\n",
+      "Manchester Gas         0.0000\n",
+      "Norway Wind          895.3730\n",
+      "Norway Gas            91.0017\n",
+      "Frankfurt Wind       100.0000\n",
+      "Frankfurt Gas        884.0930\n",
+      "Frankfurt Wind 2    2100.0000\n",
+      "Name: p_nom_opt, dtype: float64\n"
+     ]
+    }
+   ],
+   "source": [
+    "n.lopf(pyomo=False)\n",
+    "\n",
+    "print(n.generators.p_nom_opt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looks good! The generators of carrier 'wind' at bus 'Frankfurt' are just the limit of 2200 MW.  "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -282,6 +282,46 @@ def define_ramp_limit_constraints(n, sns):
                       (limit_shut, status_prev))
         define_constraints(n, lhs, '>=', 0, c, 'mu_ramp_limit_down', spec='com.')
 
+
+def define_nominal_constraints_per_bus_carrier(n, sns):
+    for carrier in n.carriers.index:
+        col = f'nom_max_{carrier}'
+        if col not in n.buses.columns: continue
+        rhs = n.buses[col].dropna()
+        lhs = pd.Series('', rhs.index)
+
+        for c, attr in nominal_attrs.items():
+            if c not in n.one_port_components: continue
+            attr = nominal_attrs[c]
+            if (c, attr) not in n.variables.index: continue
+            nominals = get_var(n, c, attr)[n.df(c).carrier == carrier]
+            if nominals.empty: continue
+            per_bus = linexpr((1, nominals)).groupby(n.df(c).bus).sum()
+            lhs += per_bus.reindex(lhs.index, fill_value='')
+        lhs = lhs[lhs != '']
+        rhs = rhs.reindex(lhs.index)
+        define_constraints(n, lhs, '<=', rhs, 'Bus', 'mu_' + col)
+
+    for carrier in n.carriers.index:
+        col = f'nom_min_{carrier}'
+        if col not in n.buses.columns: continue
+        rhs = n.buses[col].dropna()
+        lhs = pd.Series('', rhs.index)
+
+        for c, attr in nominal_attrs.items():
+            if c not in n.one_port_components: continue
+            attr = nominal_attrs[c]
+            if (c, attr) not in n.variables.index: continue
+            nominals = get_var(n, c, attr)[n.df(c).carrier == carrier]
+            if nominals.empty: continue
+            per_bus = linexpr((1, nominals)).groupby(n.df(c).bus).sum()
+            lhs += per_bus.reindex(lhs.index, fill_value='')
+        assert (lhs != '').all(), (
+            f'No extendable components of carrier {carrier} on bus '
+            f'{list(lhs[lhs == ""].index)}')
+        define_constraints(n, lhs, '>=', rhs, 'Bus', 'mu_' + col)
+
+
 def define_nodal_balance_constraints(n, sns):
     """
     Defines nodal balance constraint.
@@ -620,6 +660,7 @@ def prepare_lopf(n, snapshots=None, keep_files=False, skip_objective=False,
         define_dispatch_for_extendable_constraints(n, snapshots, c, attr)
         # define_fixed_variable_constraints(n, snapshots, c, attr)
     define_generator_status_variables(n, snapshots)
+    define_nominal_constraints_per_bus_carrier(n, snapshots)
 
     # consider only state_of_charge_set for the moment
     define_fixed_variable_constraints(n, snapshots, 'StorageUnit', 'state_of_charge')


### PR DESCRIPTION
## Changes proposed in this Pull Request

Support lower and upper capacity constraints per bus and carrier. With this feature the combined capacity of components of the same carrier at the same bus can be constrained by setting values in `n.buses['nom_max_{carrier}']` / `n.buses['nom_min_{carrier}']` (where carrier is a dummy for wind, solar etc. )

Test it with 

```
import pypsa
from pathlib import Path

n = pypsa.Network(str(Path(pypsa.__file__).parent.parent / 'examples'/
                      'ac-dc-meshed'/ 'ac-dc-data'))

n.add('Generator', 'Frankfurt Wind 2', bus='Frankfurt', capital_cost = 120,
      carrier='wind', p_nom_extendable=True)

n.buses.loc[['Frankfurt', 'Manchester'], 'nom_min_wind'] = 2000
n.buses.loc[['Frankfurt'],'nom_max_wind'] = 2200

n.lopf(pyomo=False)

print(n.generators.p_nom_opt)

```

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] ~Unit tests for new features were added (if applicable).~
- [x] ~Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).~
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.