### PR TITLE
fix boundaries and margins for geomap=False

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,7 +9,7 @@ Upcoming Release
 
 * Bump minimum ``pandas`` requirement to version 1.1.0.
 
-* Fix setting `margin` and `boundaries` when plotting a network with `geomap=False`. 
+* Fix setting ``margin`` and ``boundaries`` when plotting a network with ``geomap=False``. 
 
 PyPSA 0.17.1 (15th July 2020)
 =============================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,8 @@ Upcoming Release
 
 * Bump minimum ``pandas`` requirement to version 1.1.0.
 
+* Fix setting `margin` and `boundaries` when plotting a network with `geomap=False`. 
+
 PyPSA 0.17.1 (15th July 2020)
 =============================
 

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -56,7 +56,7 @@ except ImportError:
     pltly_present = False
 
 
-def plot(n, margin=0.05, ax=None, geomap=True, projection=None,
+def plot(n, margin=None, ax=None, geomap=True, projection=None,
          bus_colors='cadetblue', bus_alpha=1, bus_sizes=2e-2, bus_cmap=None,
          line_colors='rosybrown', link_colors='darkseagreen',
          transformer_colors='orange',
@@ -146,8 +146,7 @@ def plot(n, margin=0.05, ax=None, geomap=True, projection=None,
         Collections for buses and branches.
     """
     x, y = _get_coordinates(n, layouter=layouter)
-    if boundaries is None:
-        # in long-term replace margin setting with ax.autoscale()
+    if boundaries is None and margin:
         boundaries = sum(zip(*compute_bbox_with_margins(margin, x, y)), ())
 
     if geomap:
@@ -169,11 +168,11 @@ def plot(n, margin=0.05, ax=None, geomap=True, projection=None,
         transform = draw_map_cartopy(n, x, y, ax, geomap, color_geomap)
         x, y, z = ax.projection.transform_points(transform, x.values, y.values).T
         x, y = pd.Series(x, n.buses.index), pd.Series(y, n.buses.index)
-        ax.set_extent(boundaries, crs=transform)
+        if boundaries:
+            ax.set_extent(boundaries, crs=transform)
     elif ax is None:
         ax = plt.gca()
-        ax.axis(boundaries)
-    else:
+    if not geomap and boundaries:
         ax.axis(boundaries)
 
     ax.set_aspect('equal')
@@ -325,6 +324,9 @@ def plot(n, margin=0.05, ax=None, geomap=True, projection=None,
         ax.add_collection(b_collection)
         b_collection.set_zorder(3)
         branch_collections.append(b_collection)
+
+    if boundaries is None:
+        ax.autoscale()
 
     return (bus_collection,) + tuple(branch_collections) + tuple(arrow_collections)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

The settings of boundaries with geopmap = False are currently ignored in the plot function. This PR generalizes a bit 

Test it with 

```

n = pypsa.Network()
n.madd('Bus', [1,2], x=[0,1], y=[0,0.5])
n.add('Line', 1, bus0='1', bus1='2')
for geomap in [True, False]:
    for margin in [None, 0.3]:
        for projection in [None, ccrs.EqualEarth()]:
            proj = None if projection is None else 'Eq. Earth'
            n.plot(margin=margin, geomap=geomap, projection=projection, 
                   title = f'Margin: {margin}, Geomap: {geomap}, Projection: {proj}')
            plt.show()

for geomap in [True, False]:
    for boundaries in [None, [0,1,0,1]]:
        for projection in [None, ccrs.EqualEarth()]:
            proj = None if projection is None else 'Eq. Earth'
            n.plot(boundaries=boundaries, geomap=geomap, projection=projection, 
                   title = f'Boundaries: {boundaries}, Geomap: {geomap}, Projection: {proj}')
            plt.show()
```

## Checklist

- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.