### PR TITLE
updated cplex log file creation

### DIFF
--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -690,7 +690,8 @@ def run_and_read_cplex(n, problem_fn, solution_fn, solver_logfile,
            "or 'pip install cplex'")
     import cplex
     m = cplex.Cplex()
-    out = m.set_log_stream(solver_logfile)
+    with open(solver_logfile, "w") as f:
+        out = m.set_log_stream(f)
     if solver_options is not None:
         for key, value in solver_options.items():
             param = m.parameters


### PR DESCRIPTION
## Changes proposed in this Pull Request

Updates the creation of the cplex logfile in line 693 of `linopt.py`

The current state

`out = m.set_log_stream(solver_logfile)`

raises `TypeError: outputfile must have a write method`.

A quick fix to this relies on the example provided in the documentation of `set_log_stream` in the `__init__.py` of cplex and replaces the line above with 

`with open(solver_logfile, "w") as f:`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`out = m.set_log_stream(f)`

## EDIT 1

According to [these](https://www.ibm.com/support/knowledgecenter/SSSA5P_12.10.0/ilog.odms.studio.help/CPLEX/ReleaseNotes/topics/releasenotes12100/removed.html) release notes, this is a problem in CPLEX versions 12.10 and later.

## EDIT 2

Subsequent checks revealed that, even though the error is suppressed, the resulting log file is created, but empty.

## Checklist

- [ ] ~~Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.~~
- [ ] Unit tests for new features were added (if applicable).
- [ ] ~~Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).~~
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.