### PR TITLE
FutureWarning

### DIFF
--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -766,9 +766,9 @@ def import_series_from_dataframe(network, dataframe, cls_name, attr):
         dataframe = dataframe.reindex(network.snapshots, fill_value=default)
 
     if not attr_series.static:
-        pnl[attr] = pnl[attr].reindex(columns=df.index | columns, fill_value=default)
+        pnl[attr] = pnl[attr].reindex(columns=df.index.union(columns), fill_value=default)
     else:
-        pnl[attr] = pnl[attr].reindex(columns=(pnl[attr].columns | columns))
+        pnl[attr] = pnl[attr].reindex(columns=(pnl[attr].columns.union(columns)))
 
     pnl[attr].loc[network.snapshots, columns] = dataframe.loc[network.snapshots, columns]
 

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -82,7 +82,7 @@ def define_dispatch_for_extendable_and_committable_variables(n, sns, c, attr):
     """
     ext_i = get_extendable_i(n, c)
     if c == 'Generator':
-        ext_i = ext_i | n.generators.query('committable').index
+        ext_i = ext_i.union(n.generators.query('committable').index)
     if ext_i.empty: return
     define_variables(n, -inf, inf, c, attr, axes=[sns, ext_i], spec='ext')
 
@@ -182,7 +182,7 @@ def define_fixed_variable_constraints(n, sns, c, attr, pnl=True):
 def define_generator_status_variables(n, snapshots):
     com_i = n.generators.query('committable').index
     ext_i = get_extendable_i(n, 'Generator')
-    if not (ext_i & com_i).empty:
+    if not (ext_i.intersection(com_i)).empty:
         logger.warning("The following generators have both investment optimisation"
         f" and unit commitment:\n\n\t{', '.join((ext_i & com_i))}\n\nCurrently PyPSA cannot "
         "do both these functions, so PyPSA is choosing investment optimisation "
@@ -1011,7 +1011,7 @@ def ilopf(n, snapshots=None, msq_threshold=0.05, min_iterations=1,
     ext_i = get_extendable_i(n, 'Line')
     typed_i = n.lines.query('type != ""').index
     ext_untyped_i = ext_i.difference(typed_i)
-    ext_typed_i = ext_i & typed_i
+    ext_typed_i = ext_i.intersection(typed_i)
     base_s_nom = (np.sqrt(3) * n.lines['type'].map(n.line_types.i_nom) *
                   n.lines.bus0.map(n.buses.v_nom))
     n.lines.loc[ext_typed_i, 'num_parallel'] = (n.lines.s_nom/base_s_nom)[ext_typed_i]

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -83,7 +83,7 @@ def define_generator_variables_constraints(network,snapshots):
     ## Define generator dispatch variables ##
 
     gen_p_bounds = {(gen,sn) : (None,None)
-                    for gen in extendable_gens_i | fixed_committable_gens_i
+                    for gen in extendable_gens_i.union(fixed_committable_gens_i)
                     for sn in snapshots}
 
     if len(fixed_gens_i):


### PR DESCRIPTION
The following FutureWarning affects `io.py` and `linopf.py`:
`Index.__or__ operating as a set operation is deprecated, in the future this will be a logical operation matching Series.__or__.  Use index.union(other) instead` & `Index.__and__ operating as a set operation is deprecated, in the future this will be a logical operation matching Series.__and__.  Use index.intersection(other) instead`

As suggested, `.union()` instead of a logical `or`/ `|` and `.intersection()` instead od a logical `and`/`&` should avert the problem

If you find other scripts that print the same Warning, comment or include them into this PR? Thanks