### PR TITLE
linopf: Stop over-writing of n.stores["carrier"] if already there

### DIFF
--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -515,9 +515,10 @@ def define_global_constraints(n, sns):
             lhs = lhs + '\n' + join_exprs(vals)
             rhs -= sus.carrier.map(emissions) @ sus.state_of_charge_initial
 
-        # stores
-        n.stores['carrier'] = n.stores.bus.map(n.buses.carrier)
-        stores = n.stores.query('carrier in @emissions.index and not e_cyclic')
+        # stores (copy to avoid over-writing existing carrier attribute)
+        stores = n.stores.copy()
+        stores['carrier'] = stores.bus.map(n.buses.carrier)
+        stores = stores.query('carrier in @emissions.index and not e_cyclic')
         if not stores.empty:
             coeff_val = (-stores.carrier.map(emissions), get_var(n, 'Store', 'e')
                          .loc[sns[-1], stores.index])


### PR DESCRIPTION
When parsing the global constraints for ``n.lopf(pyomo=False)``, ``n.stores["carrier"]`` is over-written with the carrier of ``n.stores["bus"]``.

Stop this behaviour.

For global constraints, the relevant carrier is always taken from the bus, since it is a bus property.

``n.stores["carrier"]`` is for grouping different components together.

This behaviour is consistent with ``n.lopf(pyomo=True)``.

(The old behaviour was causing confusion in PyPSA-Eur-Sec where Stores are grouped by ``carrier`` attribute, but this was being over-written by ``n.lopf(pyomo=False)``.)