### PR TITLE
env: make minimal python version 3.6 explicit

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -2,12 +2,11 @@ name: pypsa
 channels:
   - conda-forge
 dependencies:
-  - python
-  - six >= 1.13.0
+  - python>=3.6
   - numpy
   - pyomo
   - scipy
-  - pandas>=1.1.0
+  - pandas>=0.24.0
   - pytables
   - matplotlib
   - networkx>=1.10

--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -2,7 +2,7 @@ name: pypsa
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python>=3.6
   - pip
   - pytest
   - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,8 @@ setup(
     license='GPLv3',
     packages=find_packages(exclude=['doc', 'test']),
     include_package_data=True,
-    python_requires='>=3',
+    python_requires='>=3.6',
     install_requires=[
-        'six>=1.13.0',
         'numpy',
         'scipy',
         'pandas>=0.24.0',


### PR DESCRIPTION
The minimal Python version supported is 3.6.

The `six` module is not necessary since https://github.com/PyPSA/PyPSA/pull/205 is merged.

The bump to `pandas=1.1.0` was reverted with https://github.com/PyPSA/PyPSA/pull/205.