### PR TITLE
make snapshots a property

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -16,6 +16,9 @@ Upcoming Release
 
 * Adjust log file creation for CPLEX version 12.10 and higher.
 
+* ``network.snapshots`` are now a property, hence assigning values with ``network.snapshots = values `` is the same as ``network.set_snapshots(values)`` 
+
+
 PyPSA 0.17.1 (15th July 2020)
 =============================
 


### PR DESCRIPTION
Closes #224 

## Changes proposed in this Pull Request
Form release notes:
`network.snapshots` are now a property, hence assigning values with ``network.snapshots = values `` is the same as `network.set_snapshots(values)`

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.