### PR TITLE
Split weightings

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -18,6 +18,14 @@ Upcoming Release
 
 * ``network.snapshots`` are now a property, hence assigning values with ``network.snapshots = values `` is the same as ``network.set_snapshots(values)`` 
 
+* ``network.snapshot_weightings`` are now subdivided into weightings for the objective function, generators and storages/storage units.   
+
+  * Objective weightings determine the multiplier of the marginal costs in the objective function of the LOPF. 
+  * Generator weightings specify the impact of generators in `GlobalConstraint`s. 
+  * Store weightings define the elapsed hours for the charge, discharge, standing loss and spillage of storage units and stores in order to determine the current state of charge.
+ 
+  PyPSA still supports setting ``snapshot_weightings`` in the old style, i.e. by a assigning with a pandas.Series. These are then applied to all columns of the new ``snapshot_weightings`` pandas.Dataframe.
+
 
 PyPSA 0.17.1 (15th July 2020)
 =============================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -18,13 +18,13 @@ Upcoming Release
 
 * ``network.snapshots`` are now a property, hence assigning values with ``network.snapshots = values `` is the same as ``network.set_snapshots(values)`` 
 
-* ``network.snapshot_weightings`` are now subdivided into weightings for the objective function, generators and storages/storage units.   
+* ``network.snapshot_weightings`` are now subdivided into weightings for the objective function, generators and stores/storage units.
 
   * Objective weightings determine the multiplier of the marginal costs in the objective function of the LOPF. 
-  * Generator weightings specify the impact of generators in `GlobalConstraint`s. 
+  * Generator weightings specify the impact of generators in a ``GlobalConstraint``. 
   * Store weightings define the elapsed hours for the charge, discharge, standing loss and spillage of storage units and stores in order to determine the current state of charge.
  
-  PyPSA still supports setting ``snapshot_weightings`` in the old style, i.e. by a assigning with a pandas.Series. These are then applied to all columns of the new ``snapshot_weightings`` pandas.Dataframe.
+  PyPSA still supports setting ``snapshot_weightings`` with a ``pandas.Series``. In this case, the weightings are uniformly applied to all columns of the new ``snapshot_weightings`` ``pandas.DataFrame``.
 
 
 PyPSA 0.17.1 (15th July 2020)

--- a/examples/generation-investment-screening-curve.py
+++ b/examples/generation-investment-screening-curve.py
@@ -66,12 +66,12 @@ n.generators_t.p.plot(ylim=[0,600],title="Generation Dispatch")
 
 #Demonstrate zero-profit condition
 print("Total costs:")
-print(n.generators.p_nom_opt*n.generators.capital_cost + n.generators_t.p.multiply(n.snapshot_weightings,axis=0).sum()*n.generators.marginal_cost)
+print(n.generators.p_nom_opt*n.generators.capital_cost + n.generators_t.p.multiply(n.snapshot_weightings.generators,axis=0).sum()*n.generators.marginal_cost)
 
 
 
 print("\nTotal revenue:")
-print(n.generators_t.p.multiply(n.snapshot_weightings,axis=0).multiply(n.buses_t.marginal_price["bus"],axis=0).sum())
+print(n.generators_t.p.multiply(n.snapshot_weightings.generators,axis=0).multiply(n.buses_t.marginal_price["bus"],axis=0).sum())
 
 ## Without expansion optimisation
 #
@@ -95,10 +95,10 @@ n.buses_t.marginal_price.sum(axis=1).value_counts()
 #Differences are due to singular times, see above, not a problem
 
 print("Total costs:")
-print(n.generators.p_nom*n.generators.capital_cost + n.generators_t.p.multiply(n.snapshot_weightings,axis=0).sum()*n.generators.marginal_cost)
+print(n.generators.p_nom*n.generators.capital_cost + n.generators_t.p.multiply(n.snapshot_weightings.generators,axis=0).sum()*n.generators.marginal_cost)
 
 
 
 print("Total revenue:")
-print(n.generators_t.p.multiply(n.snapshot_weightings,axis=0).multiply(n.buses_t.marginal_price["bus"],axis=0).sum())
+print(n.generators_t.p.multiply(n.snapshot_weightings.generators,axis=0).multiply(n.buses_t.marginal_price["bus"],axis=0).sum())
 

--- a/pypsa/component_attrs/networks.csv
+++ b/pypsa/component_attrs/networks.csv
@@ -1,7 +1,7 @@
 attribute,type,unit,default,description,status
 name,string,n/a,n/a,Unique name,Input (required)
 snapshots,list or pandas.Index,n/a,"[""now""]","List of snapshots or time steps. All time-dependent series quantities are indexed by ``network.snapshots``. To reset the snapshots, call ``network.set_snapshots(new)``.",Input (optional)
-snapshot_weightings, pandas.DataFrame, hours , 1. ,"The weightings applied to each snapshot, so that snapshots can represent more than one hour or fractions of one hour. The objective weighting is used to weight snapshots in the LOPF objective function. The store weightings determine the state of charge change for storage units. The generator weightings are used when calculating global constraints.",Input (optional)
+snapshot_weightings, pandas.DataFrame, hours , 1. ,"The weightings applied to each snapshot, so that snapshots can represent more than one hour or fractions of one hour. The objective weightings are used to weight snapshots in the LOPF objective function. The store weightings determine the state of charge change for stores and storage units. The generator weightings are used when calculating global constraints.",Input (optional)
 now,any,n/a,"""now""","The current snapshot/time/scenario, relevant e.g. when ``network.pf()`` is called without a snapshot argument.",Input (optional)
 srid,integer,n/a,4326,"Spatial Reference System Indentifier for x,y coordinates of buses. It defaults to standard longitude and latitude.",Input (optional)
 buses,pandas.DataFrame,n/a,n/a,"All static bus information compiled by PyPSA from inputs. Index is bus names, columns are bus attributes.",Output

--- a/pypsa/component_attrs/networks.csv
+++ b/pypsa/component_attrs/networks.csv
@@ -1,7 +1,7 @@
 attribute,type,unit,default,description,status
 name,string,n/a,n/a,Unique name,Input (required)
 snapshots,list or pandas.Index,n/a,"[""now""]","List of snapshots or time steps. All time-dependent series quantities are indexed by ``network.snapshots``. To reset the snapshots, call ``network.set_snapshots(new)``.",Input (optional)
-snapshot_weightings,pandas.Series, hours , 1. ,"The weighting applied to each snapshot, so that snapshots can represent more than one hour or fractions of one hour. This weighting is used to weight snapshots in the LOPF objective function, to determine the state of charge change for storage units and for calculating global constraints.",Input (optional)
+snapshot_weightings, pandas.DataFrame, hours , 1. ,"The weightings applied to each snapshot, so that snapshots can represent more than one hour or fractions of one hour. The objective weighting is used to weight snapshots in the LOPF objective function. The store weightings determine the state of charge change for storage units. The generator weightings are used when calculating global constraints.",Input (optional)
 now,any,n/a,"""now""","The current snapshot/time/scenario, relevant e.g. when ``network.pf()`` is called without a snapshot argument.",Input (optional)
 srid,integer,n/a,4326,"Spatial Reference System Indentifier for x,y coordinates of buses. It defaults to standard longitude and latitude.",Input (optional)
 buses,pandas.DataFrame,n/a,n/a,"All static bus information compiled by PyPSA from inputs. Index is bus names, columns are bus attributes.",Output

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -414,12 +414,12 @@ class Network(Basic):
         * Objective weightings multiply the operational cost in the
           objective function.
 
-        * Generator weightings multiply the power output of all generators
-          at a specific time.
+        * Generator weightings multiply the impact of all generators
+          in global constraints, e.g. multiplier of GHG emmissions.
 
         * Store weightings define the elapsed hours for the charge, discharge
-          standing loss and spillage of storage units and stores to determine
-          the state of charge
+          standing loss and spillage of storage units and stores in order to
+          determine the state of charge.
 
         """
         return self._snapshot_weightings

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -434,7 +434,7 @@ class Network(Basic):
             self._snapshot_weightings = df
         else:
             self._snapshot_weightings = df
-giot
+
 
     def lopf(self, snapshots=None, pyomo=True, solver_name="glpk",
              solver_options={}, solver_logfile=None, formulation="kirchhoff",

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -583,6 +583,9 @@ def _import_from_importer(network, importer, basename, skip_time=False):
         network.set_snapshots(df.index)
         if "weightings" in df.columns:
             network.snapshot_weightings = df["weightings"].reindex(network.snapshots)
+        elif df.columns.intersection(['objective', 'generators', 'stores']):
+            network.snapshot_weightings = df.reindex(
+                index=network.snapshots, columns=['objective', 'generators', 'stores'])
 
     imported_components = []
 

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -539,7 +539,7 @@ def define_storage_variables_constraints(network,snapshots):
 
             soc[su,sn] =  [[],"==",0.]
 
-            elapsed_hours = network.snapshot_weightings.loc[sn, "store_weightings"]
+            elapsed_hours = network.snapshot_weightings.stores[sn]
 
             if i == 0 and not sus.at[su,"cyclic_state_of_charge"]:
                 previous_state_of_charge = sus.at[su,"state_of_charge_initial"]
@@ -567,7 +567,7 @@ def define_storage_variables_constraints(network,snapshots):
             soc[su,sn][2] -= inflow.at[sn,su] * elapsed_hours
 
     for su,sn in spill_index:
-        elapsed_hours = network.snapshot_weightings.loc[sn, "store_weightings"]
+        elapsed_hours = network.snapshot_weightings.stores[sn]
         storage_p_spill = model.storage_p_spill[su,sn]
         soc[su,sn][0].append((-1.*elapsed_hours,storage_p_spill))
 
@@ -648,7 +648,7 @@ def define_store_variables_constraints(network,snapshots):
 
             e[store,sn].lhs.variables.append((-1,model.store_e[store,sn]))
 
-            elapsed_hours = network.snapshot_weightings.loc[sn, "store_weightings"]
+            elapsed_hours = network.snapshot_weightings.stores[sn]
 
             if i == 0 and not stores.at[store,"e_cyclic"]:
                 previous_e = stores.at[store,"e_initial"]
@@ -1104,7 +1104,7 @@ def define_global_constraints(network,snapshots):
                 gens = network.generators.index[network.generators.carrier == carrier]
                 c.lhs.variables.extend([(attribute
                                          * (1/network.generators.at[gen,"efficiency"])
-                                         * network.snapshot_weightings.loc[sn, "generator_weightings"],
+                                         * network.snapshot_weightings.generators[sn],
                                          network.model.generator_p[gen,sn])
                                         for gen in gens
                                         for sn in snapshots])
@@ -1167,7 +1167,7 @@ def define_linear_objective(network,snapshots):
     for sn, marginal_cost in zip(snapshots, marginal_cost_it):
         gen_mc, su_mc, st_mc, link_mc = marginal_cost
 
-        weight = network.snapshot_weightings.loc[sn, "objective_weightings"]
+        weight = network.snapshot_weightings.objective[sn]
         for gen in network.generators.index:
             coefficient = gen_mc.at[gen] * weight
             objective.variables.extend([(coefficient, model.generator_p[gen, sn])])
@@ -1348,7 +1348,9 @@ def extract_optimisation_results(network, snapshots, formulation="angles", free_
                             .map(duals))
 
             #correct for snapshot weightings
-            network.buses_t.marginal_price.loc[snapshots] = network.buses_t.marginal_price.loc[snapshots].divide(network.snapshot_weightings.loc[snapshots, "objective_weightings"],axis=0)
+            network.buses_t.marginal_price.loc[snapshots] = (
+                network.buses_t.marginal_price.loc[snapshots].divide(
+                    network.snapshot_weightings.objective.loc[snapshots],axis=0))
 
         if formulation == "angles":
             set_from_series(network.buses_t.v_ang,

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -539,7 +539,7 @@ def define_storage_variables_constraints(network,snapshots):
 
             soc[su,sn] =  [[],"==",0.]
 
-            elapsed_hours = network.snapshot_weightings[sn]
+            elapsed_hours = network.snapshot_weightings.loc[sn, "store_weightings"]
 
             if i == 0 and not sus.at[su,"cyclic_state_of_charge"]:
                 previous_state_of_charge = sus.at[su,"state_of_charge_initial"]
@@ -567,7 +567,7 @@ def define_storage_variables_constraints(network,snapshots):
             soc[su,sn][2] -= inflow.at[sn,su] * elapsed_hours
 
     for su,sn in spill_index:
-        elapsed_hours = network.snapshot_weightings.at[sn]
+        elapsed_hours = network.snapshot_weightings.loc[sn, "store_weightings"]
         storage_p_spill = model.storage_p_spill[su,sn]
         soc[su,sn][0].append((-1.*elapsed_hours,storage_p_spill))
 
@@ -648,7 +648,7 @@ def define_store_variables_constraints(network,snapshots):
 
             e[store,sn].lhs.variables.append((-1,model.store_e[store,sn]))
 
-            elapsed_hours = network.snapshot_weightings[sn]
+            elapsed_hours = network.snapshot_weightings.loc[sn, "store_weightings"]
 
             if i == 0 and not stores.at[store,"e_cyclic"]:
                 previous_e = stores.at[store,"e_initial"]
@@ -1104,7 +1104,7 @@ def define_global_constraints(network,snapshots):
                 gens = network.generators.index[network.generators.carrier == carrier]
                 c.lhs.variables.extend([(attribute
                                          * (1/network.generators.at[gen,"efficiency"])
-                                         * network.snapshot_weightings[sn],
+                                         * network.snapshot_weightings.loc[sn, "generator_weightings"],
                                          network.model.generator_p[gen,sn])
                                         for gen in gens
                                         for sn in snapshots])
@@ -1167,7 +1167,7 @@ def define_linear_objective(network,snapshots):
     for sn, marginal_cost in zip(snapshots, marginal_cost_it):
         gen_mc, su_mc, st_mc, link_mc = marginal_cost
 
-        weight = network.snapshot_weightings[sn]
+        weight = network.snapshot_weightings.loc[sn, "objective_weightings"]
         for gen in network.generators.index:
             coefficient = gen_mc.at[gen] * weight
             objective.variables.extend([(coefficient, model.generator_p[gen, sn])])
@@ -1348,7 +1348,7 @@ def extract_optimisation_results(network, snapshots, formulation="angles", free_
                             .map(duals))
 
             #correct for snapshot weightings
-            network.buses_t.marginal_price.loc[snapshots] = network.buses_t.marginal_price.loc[snapshots].divide(network.snapshot_weightings.loc[snapshots],axis=0)
+            network.buses_t.marginal_price.loc[snapshots] = network.buses_t.marginal_price.loc[snapshots].divide(network.snapshot_weightings.loc[snapshots, "objective_weightings"],axis=0)
 
         if formulation == "angles":
             set_from_series(network.buses_t.v_ang,

--- a/pypsa/stats.py
+++ b/pypsa/stats.py
@@ -64,7 +64,7 @@ def describe_storage_unit_contraints(n):
 
     description = {}
 
-    eh = expand_series(n.snapshot_weightings, sus_i)
+    eh = expand_series(n.snapshot_weightings.stores, sus_i)
     stand_eff = expand_series(1-n.df(c).standing_loss, sns).T.pow(eh)
     dispatch_eff = expand_series(n.df(c).efficiency_dispatch, sns).T
     store_eff = expand_series(n.df(c).efficiency_store, sns).T
@@ -152,7 +152,7 @@ def describe_store_contraints(n):
     c = 'Store'
     pnl = n.pnl(c)
 
-    eh = expand_series(n.snapshot_weightings, stores_i)
+    eh = expand_series(n.snapshot_weightings.stores, stores_i)
     stand_eff = expand_series(1-n.df(c).standing_loss, sns).T.pow(eh)
 
     start = pnl.e.iloc[-1].where(stores.e_cyclic, stores.e_initial)


### PR DESCRIPTION
## Changes proposed in this Pull Request

derived from #211 

Split the snapshot weightings into objective weightings, generator weightings and store weightings. 

@lisazeyen I renamed the columns in the snapshot_weightings to "objective", "generators" and "stores", fine with that? The repeated "weightings" seemed a bit unnecessary.


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.