### PR TITLE
Add rudimentary test for import and export functionality

### DIFF
--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -7,6 +7,7 @@ dependencies:
   - pytest
   - pytest-cov
   - twine
+  - xarray # for netcdf export test
   - pip:
     - pypower
     - pandapower>=2.0

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -1,0 +1,33 @@
+import pypsa
+import pytest
+import os
+
+@pytest.fixture
+def network():
+    csv_folder_name = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "examples",
+        "scigrid-de",
+        "scigrid-with-load-gen-trafos",
+    )
+    return pypsa.Network(csv_folder_name)
+
+
+def test_netcdf_io(network, tmpdir):
+    fn = os.path.join(tmpdir, "netcdf_export.nc")
+    network.export_to_netcdf(fn)
+    pypsa.Network(fn)
+
+
+def test_csv_io(network, tmpdir):
+    fn = os.path.join(tmpdir, "csv_export")
+    network.export_to_csv_folder(fn)
+    pypsa.Network(fn)
+
+
+def test_hdf5_io(network, tmpdir):
+    fn = os.path.join(tmpdir, "hdf5_export.h5")
+    network.export_to_hdf5(fn)
+    pypsa.Network(fn)
+    


### PR DESCRIPTION
Adds three tests that check whether exports and imports as CSV, netCDF, and HDF5 run through. No content check.