### PR TITLE
deprecate geo.area_from_lon_lat_poly

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -18,6 +18,7 @@ Upcoming Release
 
 * ``network.snapshots`` are now a property, hence assigning values with ``network.snapshots = values `` is the same as ``network.set_snapshots(values)`` 
 
+* The function ``geo.area_from_lon_lat_poly`` was deprecated and will be removed in v0.19.
 
 PyPSA 0.17.1 (15th July 2020)
 =============================

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,5 +13,6 @@ dependencies:
   - pyomo>=5.7.0
   - cartopy>=0.16
   - glpk
+  - deprecation
 #  - coincbc
 #  - gurobi::gurobi

--- a/environment_docs.yml
+++ b/environment_docs.yml
@@ -16,6 +16,7 @@ dependencies:
   - pyomo
   - cartopy>=0.16
   - coincbc
+  - deprecation
 
   - pip:
     - .

--- a/pypsa/geo.py
+++ b/pypsa/geo.py
@@ -23,6 +23,7 @@ __author__ = "Tom Brown (FIAS)"
 __copyright__ = "Copyright 2016-2017 Tom Brown (FIAS), GNU GPL 3"
 
 import numpy as np
+from deprecation import deprecated
 
 import logging
 logger = logging.getLogger(__name__)
@@ -100,12 +101,13 @@ def haversine(a, b):
     return haversine_pts(a[np.newaxis,:], b[:,np.newaxis])
 
 
-#This function follows http://toblerity.org/shapely/manual.html
-
+@deprecated(deprecated_in="0.18", removed_in="0.19")
 def area_from_lon_lat_poly(geometry):
     """
     Compute the area in km^2 of a shapely geometry, whose points are in
     longitude and latitude.
+    
+    This function follows http://toblerity.org/shapely/manual.html
 
     Parameters
     ----------

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'tables',
         'pyomo>=5.7',
         'matplotlib',
-        'networkx>=1.10'
+        'networkx>=1.10',
+        'deprecation'
     ],
     extras_require = {
         "cartopy": ['cartopy>=0.16'],


### PR DESCRIPTION
widely unused and dependencies that are not tracked.

@FabianHofmann is this a good way to also handle deprecations in the future?