### PR TITLE
Multi indexed snapshots

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -28,7 +28,7 @@ Upcoming Release
 
 * The function ``geo.area_from_lon_lat_poly`` was deprecated and will be removed in v0.19.
 
-* All `pypsa` functionalities except for optimization with `pyomo` work now with multi-indexed snapshots.
+* All ``pypsa`` functionalities except for optimization with ``pyomo`` work now with multi-indexed snapshots.
 
 PyPSA 0.17.1 (15th July 2020)
 =============================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -28,6 +28,8 @@ Upcoming Release
 
 * The function ``geo.area_from_lon_lat_poly`` was deprecated and will be removed in v0.19.
 
+* All `pypsa` functionalities except for optimization with `pyomo` work now with multi-indexed snapshots.
+
 PyPSA 0.17.1 (15th July 2020)
 =============================
 

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -389,7 +389,11 @@ class Network(Basic):
         -------
         None
         """
-        self._snapshots = pd.Index(value)
+        if isinstance(value, pd.MultiIndex):
+            assert value.nlevels == 2, "Maximally two levels of MultiIndex supported"
+            self._snapshots = value.rename(['period', 'snapshot'])
+        else:
+            self._snapshots = pd.Index(value, name='snapshot')
 
         self.snapshot_weightings = (
             self.snapshot_weightings.reindex(self._snapshots, fill_value=1.))

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -334,7 +334,7 @@ def _export_to_exporter(network, exporter, basename, export_standard_types=False
     if isinstance(network.snapshot_weightings.index, pd.MultiIndex):
         network.snapshot_weightings.index.rename(["period", "snapshot"], inplace=True)
     else:
-        network.snapshot_weightings.index.rename("snapshot")
+        network.snapshot_weightings.index.rename("snapshot", inplace=True)
     snapshots = network.snapshot_weightings.reset_index()
     exporter.save_snapshots(snapshots)
 

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -79,7 +79,10 @@ class ImporterCSV(Importer):
     def get_snapshots(self):
         fn = os.path.join(self.csv_folder_name, "snapshots.csv")
         if not os.path.isfile(fn): return None
-        return pd.read_csv(fn, index_col=0, encoding=self.encoding, parse_dates=True)
+        df = pd.read_csv(fn, index_col=0, encoding=self.encoding, parse_dates=True)
+        if "snapshot" in df:
+            df["snapshot"] = pd.to_datetime(df.snapshot)
+        return df
 
     def get_investment_periods(self):
         fn = os.path.join(self.csv_folder_name, "investment_periods.csv")
@@ -619,7 +622,7 @@ def _import_from_importer(network, importer, basename, skip_time=False):
         # check if imported snapshots have MultiIndex
         snapshot_levels = set(["period", "snapshot"]).intersection(df.columns)
         if snapshot_levels:
-            df.set_index(list(snapshot_levels), inplace=True)
+            df.set_index(sorted(snapshot_levels), inplace=True)
         network.set_snapshots(df.index)
 
         cols = ['objective', 'generators', 'stores']

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -245,8 +245,8 @@ def get_clustering_from_busmap(network, busmap, with_time=True, line_length_fact
     io.import_components_from_dataframe(network_c, lines, "Line")
 
     if with_time:
-        network_c.snapshot_weightings = network.snapshot_weightings.copy()
         network_c.set_snapshots(network.snapshots)
+        network_c.snapshot_weightings = network.snapshot_weightings.copy()
 
     one_port_components = network.one_port_components.copy()
 
@@ -345,7 +345,7 @@ def busmap_by_spectral_clustering(network, n_clusters, **kwds):
             "or 'pip install scikit-learn'")
 
     from sklearn.cluster import spectral_clustering as sk_spectral_clustering
-    
+
     lines = network.lines.loc[:,['bus0', 'bus1']].assign(weight=network.lines.num_parallel).set_index(['bus0','bus1'])
     lines.weight+=0.1
     G = nx.Graph()

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -1437,6 +1437,9 @@ def network_lopf_build_model(network, snapshots=None, skip_pre=False,
     -------
     network.model
     """
+    if isinstance(network.snapshots, pd.MultiIndex):
+        raise NotImplementedError("Optimization with multiindexed snapshots "
+                                  "using pyomo is not supported.")
 
     if not skip_pre:
         network.determine_network_topology()

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -49,6 +49,8 @@ def imag(X): return np.imag(X.to_numpy())
 def _as_snapshots(network, snapshots):
     if snapshots is None:
         snapshots = network.snapshots
+    if isinstance(snapshots, pd.MultiIndex):
+        return snapshots
     if not is_list_like(snapshots):
         return pd.Index([snapshots])
     else:

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -1,6 +1,8 @@
 import pypsa
 import pytest
 import os
+import pandas as pd
+import numpy as np
 
 @pytest.fixture
 def network():
@@ -12,6 +14,21 @@ def network():
         "scigrid-with-load-gen-trafos",
     )
     return pypsa.Network(csv_folder_name)
+
+
+@pytest.fixture
+def network_mi():
+    csv_folder_name = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "examples",
+        "ac-dc-meshed",
+        "ac-dc-data",
+    )
+    n = pypsa.Network(csv_folder_name)
+    n.snapshots = pd.MultiIndex.from_product([['first'], n.snapshots])
+    n.generators_t.p.loc[:,:] = np.random.rand(*n.generators_t.p.shape)
+    return n
 
 
 def test_netcdf_io(network, tmpdir):
@@ -30,4 +47,24 @@ def test_hdf5_io(network, tmpdir):
     fn = os.path.join(tmpdir, "hdf5_export.h5")
     network.export_to_hdf5(fn)
     pypsa.Network(fn)
-    
+
+
+def test_netcdf_io_multiindexed(network_mi, tmpdir):
+    fn = os.path.join(tmpdir, "netcdf_export.nc")
+    network_mi.export_to_netcdf(fn)
+    m = pypsa.Network(fn)
+    pd.testing.assert_frame_equal(m.generators_t.p, network_mi.generators_t.p)
+
+
+def test_csv_io(network_mi, tmpdir):
+    fn = os.path.join(tmpdir, "csv_export")
+    network_mi.export_to_csv_folder(fn)
+    m = pypsa.Network(fn)
+    pd.testing.assert_frame_equal(m.generators_t.p, network_mi.generators_t.p)
+
+
+def test_hdf5_io(network_mi, tmpdir):
+    fn = os.path.join(tmpdir, "hdf5_export.h5")
+    network_mi.export_to_hdf5(fn)
+    m = pypsa.Network(fn)
+    pd.testing.assert_frame_equal(m.generators_t.p, network_mi.generators_t.p)


### PR DESCRIPTION
## Changes proposed in this Pull Request

Second step of preparing #211 :

Support multiindexed snapshots. All functionalities except for optimization with `pyomo` now work with multi-indexed snapshots (including io, clustering, pf). 

Note in the `io.py` the functions `get_investment_periods`/`set_investment_periods` are already pulled from #211 but not used anywhere (yet). 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.