### PR TITLE
Isn't "e_nom_opt" in units of MWh?

### DIFF
--- a/pypsa/component_attrs/stores.csv
+++ b/pypsa/component_attrs/stores.csv
@@ -19,7 +19,7 @@ standing_loss,float,per unit,0.,Losses per hour to energy.,Input (optional)
 p,series,MW,0.,active power at bus (positive if net generation),Output
 q,series,MVar,0.,reactive power (positive if net generation),Output
 e,series,MWh,0.,Energy as calculated by the OPF.,Output
-e_nom_opt,float,MW,0.,Optimised nominal energy capacity outputed by OPF.,Output
+e_nom_opt,float,MWh,0.,Optimised nominal energy capacity outputed by OPF.,Output
 mu_upper,series,currency/MWh,0.,Shadow price of upper e_nom limit,Output
 mu_lower,series,currency/MWh,0.,Shadow price of lower e_nom limit,Output
 mu_e_set,series,currency/MWh,0.,Shadow price of fixed energy level e_set,Output


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.