### PR TITLE
No longer copy snapshot weightings for `n.copy(with_time=False)`

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,6 +35,8 @@ Upcoming Release
 
 * Bugfix in ``network.ilopf()`` where previously all links were fixed in the final iteration when it should only be the DC links.
 
+* ``n.snapshot_weightings`` is no longer copied for ``n.copy(with_time=False)``.
+
 
 PyPSA 0.17.1 (15th July 2020)
 =============================

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -868,8 +868,6 @@ class Network(Basic):
                 for k in component.pnl.keys():
                     pnl[k] = component.pnl[k].loc[snapshots].copy()
             network.snapshot_weightings = self.snapshot_weightings.loc[snapshots].copy()
-        else:
-            network.snapshot_weightings = self.snapshot_weightings.copy()
 
         #catch all remaining attributes of network
         for attr in ["name", "srid"]:


### PR DESCRIPTION
Closes #245 (if applicable).

## Changes proposed in this Pull Request

Do not copy snapshot weightings for  `n.copy(with_time=False)` because this is time-dependent data and with the new snapshot property implementation this also causes problems (#245)

## Checklist

- ~[ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`~
- ~[ ] Unit tests for new features were added (if applicable).~
- ~[ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).~
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.