### PR TITLE
fix for pandas 1.3.0, closes #265

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -41,6 +41,8 @@ Upcoming Release
 
 * The deprecated column names 'source', 'dispatch', 'p_max_pu_fixed', 'p_min_pu_fixed' for the class ``Generator``, 'current_type' for the class ``Bus`` and 's_nom' for the class ``Link`` were removed. 
 
+* Add support for ``pandas`` up to version 1.3.
+
 
 PyPSA 0.17.1 (15th July 2020)
 =============================

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python>=3.6
   - numpy
   - scipy
-  - pandas>=0.24.0,<1.3
+  - pandas>=0.24.0
   - xarray
   - netcdf4
   - pytables

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -35,6 +35,9 @@ import pandas as pd
 import numpy as np
 from numpy import inf
 
+from distutils.version import LooseVersion
+pd_version = LooseVersion(pd.__version__)
+
 import gc, time, os, re, shutil
 from tempfile import mkstemp
 
@@ -339,9 +342,10 @@ def define_nodal_balance_constraints(n, sns):
         eff = get_as_dense(n, 'Link', f'efficiency{i}', sns)
         args.append(['Link', 'p', f'bus{i}', eff])
 
+    kwargs = dict(numeric_only=False) if pd_version < "1.3" else {}
     lhs = (pd.concat([bus_injection(*arg) for arg in args], axis=1)
            .groupby(axis=1, level=0)
-           .sum(numeric_only=False)
+           .sum(**kwargs)
            .reindex(columns=n.buses.index, fill_value=''))
     sense = '='
     rhs = ((- get_as_dense(n, 'Load', 'p_set', sns) * n.loads.sign)

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -341,7 +341,7 @@ def define_nodal_balance_constraints(n, sns):
 
     lhs = (pd.concat([bus_injection(*arg) for arg in args], axis=1)
            .groupby(axis=1, level=0)
-           .sum()
+           .sum(numeric_only=False)
            .reindex(columns=n.buses.index, fill_value=''))
     sense = '='
     rhs = ((- get_as_dense(n, 'Load', 'p_set', sns) * n.loads.sign)

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -342,7 +342,7 @@ def define_nodal_balance_constraints(n, sns):
         eff = get_as_dense(n, 'Link', f'efficiency{i}', sns)
         args.append(['Link', 'p', f'bus{i}', eff])
 
-    kwargs = dict(numeric_only=False) if pd_version < "1.3" else {}
+    kwargs = dict(numeric_only=False) if pd_version >= "1.3" else {}
     lhs = (pd.concat([bus_injection(*arg) for arg in args], axis=1)
            .groupby(axis=1, level=0)
            .sum(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'numpy',
         'scipy',
-        'pandas>=0.24.0,<1.3',
+        'pandas>=0.24.0',
         'xarray',
         'netcdf4',
         'tables',


### PR DESCRIPTION
Closes #265.

## Changes proposed in this Pull Request

In the new pandas version 1.3.0 it seems to be necessary to pass `numeric_only=False` to the sum aggregation function of a GroupbyDataFrame when strings are added.

## Checklist

- ~[ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.~
- ~[ ] Unit tests for new features were added (if applicable).~
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.