### PR TITLE
add automated code coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+source = pypsa
+omit =
+    test/*
+    pypsa/plot.py
+    setup.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,5 +3,4 @@ branch = True
 source = pypsa
 omit =
     test/*
-    pypsa/plot.py
     setup.py

--- a/.github/workflows/CI-conda.yml
+++ b/.github/workflows/CI-conda.yml
@@ -52,5 +52,3 @@ jobs:
     - name: Upload code coverage report
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
       uses: codecov/codecov-action@v1
-      with:
-        verbose: true

--- a/.github/workflows/CI-conda.yml
+++ b/.github/workflows/CI-conda.yml
@@ -47,4 +47,8 @@ jobs:
         
     - name: Test with pytest
       run: |
-        pytest
+        pytest --cov=./
+
+    - name: Upload code coverage report
+      if: matrix.os == 'ubuntu-latest' and matrix.python-version == '3.9'
+      uses: codecov/codecov-action@v1

--- a/.github/workflows/CI-conda.yml
+++ b/.github/workflows/CI-conda.yml
@@ -47,8 +47,10 @@ jobs:
         
     - name: Test with pytest
       run: |
-        pytest --cov=./
+        pytest --cov=./ --cov-report=xml
 
     - name: Upload code coverage report
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
       uses: codecov/codecov-action@v1
+      with:
+        verbose: true

--- a/.github/workflows/CI-conda.yml
+++ b/.github/workflows/CI-conda.yml
@@ -1,6 +1,6 @@
 name: CI with conda
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:
@@ -50,5 +50,5 @@ jobs:
         pytest --cov=./
 
     - name: Upload code coverage report
-      if: matrix.os == 'ubuntu-latest' and matrix.python-version == '3.9'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
       uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@
 
 name: CI
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ website/examples/*.py
 *.html
 
 .vscode
+
+.coverage

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|badge_pypi| |badge_conda| |badge_travis| |badge_docs| |badge_license| |link-latest-doi| |gitter| |binder|
+|badge_pypi| |badge_conda| |ci_badge| |ci_badge_conda| |codecov| |badge_docs| |badge_license| |link-latest-doi| |gitter| |binder|
 
 -----
 
@@ -267,9 +267,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 .. |badge_license| image:: https://img.shields.io/pypi/l/pypsa.svg
     :target: License
 
-.. |badge_travis| image:: https://img.shields.io/travis/PyPSA/PyPSA/master.svg
-    :target: https://travis-ci.org/PyPSA/PyPSA
-    :alt: Build status on Linux
+.. |ci_badge_conda| image:: https://github.com/pypsa/pypsa/actions/workflows/CI-conda.yml/badge.svg
+    :target: https://github.com/pypsa/pypsa/actions/workflows/CI-conda.yml
+
+.. |ci_badge| image:: https://github.com/pypsa/pypsa/actions/workflows/CI.yml/badge.svg
+    :target: https://github.com/pypsa/pypsa/actions/workflows/CI.yml
 
 .. |badge_docs| image:: https://readthedocs.org/projects/pypsa/badge/?version=latest
     :target: https://pypsa.readthedocs.io/en/latest/?badge=latest
@@ -286,3 +288,6 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 .. |binder| image:: https://mybinder.org/badge_logo.svg
     :target: https://mybinder.org/v2/gh/PyPSA/PyPSA/master?filepath=examples%2Fnotebooks
     :alt: Examples of use
+
+.. |codecov| image:: https://codecov.io/gh/PyPSA/PyPSA/branch/master/graph/badge.svg?token=kCpwJiV6Jr
+    :target: https://codecov.io/gh/PyPSA/PyPSA

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,9 +14,14 @@ PyPSA: Python for Power System Analysis
     :target: https://anaconda.org/conda-forge/pypsa
     :alt: Conda version
 
-.. image:: https://img.shields.io/travis/PyPSA/PyPSA/master.svg
-    :target: https://travis-ci.org/PyPSA/PyPSA
-    :alt: Build status on Linux
+.. image:: https://github.com/pypsa/pypsa/actions/workflows/CI.yml/badge.svg
+    :target: https://github.com/pypsa/pypsa/actions/workflows/circumstances.yml
+
+.. image:: https://github.com/pypsa/pypsa/actions/workflows/CI-conda.yml/badge.svg
+    :target: https://github.com/pypsa/pypsa/actions/workflows/CI-conda.yml
+
+.. image:: https://codecov.io/gh/PyPSA/PyPSA/branch/master/graph/badge.svg?token=kCpwJiV6Jr
+    :target: https://codecov.io/gh/PyPSA/PyPSA
 
 .. image:: https://readthedocs.org/projects/pypsa/badge/?version=latest
     :target: https://pypsa.readthedocs.io/en/latest/?badge=latest

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -41,6 +41,8 @@ Upcoming Release
 
 * The deprecated column names 'source', 'dispatch', 'p_max_pu_fixed', 'p_min_pu_fixed' for the class ``Generator``, 'current_type' for the class ``Bus`` and 's_nom' for the class ``Link`` were removed. 
 
+* Automated upload of code coverage reports.
+
 
 PyPSA 0.17.1 (15th July 2020)
 =============================


### PR DESCRIPTION
## Changes proposed in this Pull Request

Automated code coverage reporting with Codecov. Example see comment below, but expressive only if there is a code coverage report already in the master.

## Checklist

- ~[] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.~
- ~[ ] Unit tests for new features were added (if applicable).~
- ~[ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).~
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.