### PR TITLE
specify when to run CI

### DIFF
--- a/.github/workflows/CI-conda.yml
+++ b/.github/workflows/CI-conda.yml
@@ -1,6 +1,14 @@
 name: CI with conda
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  schedule:
+    - cron: "0 5 * * TUE"
 
 jobs:
   build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,15 @@
 
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  schedule:
+    - cron: "0 5 * * TUE"
 
 jobs:
   build:


### PR DESCRIPTION
Run CI only for:
- direct pushes on master branch
- pull requests to merge into master branch
- every Tuesday at 5AM UTC
