### PR TITLE
don't allow pyomo 6.1 yet

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - pytables
   - matplotlib
   - networkx>=1.10
-  - pyomo>=5.7.0
+  - pyomo>=5.7.0,<6.1
   - cartopy>=0.16
   - glpk
   - deprecation

--- a/environment_docs.yml
+++ b/environment_docs.yml
@@ -7,7 +7,7 @@ dependencies:
   - python
   - six
   - numpy
-  - pyomo>=5.7.0
+  - pyomo>=5.7.0,<6.1
   - scipy
   - pandas>=1.1.0
   - xarray

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'xarray',
         'netcdf4',
         'tables',
-        'pyomo>=5.7',
+        'pyomo>=5.7,<6.1',
         'matplotlib',
         'networkx>=1.10',
         'deprecation'


### PR DESCRIPTION
Some changes required to support pyomo 6.1, so exclude from allowed versions for now.

Support for pyomo 6.1 will be addressed in #283 