### PR TITLE
deprecate clustering methods that are not evaluated or maintained

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,9 +8,9 @@ Upcoming Release
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
 * Functions ``busmap_by_linemask()``, ``busmap_by_length()``, ``length_clustering()``,
-  ``busmap_by_louvain()``, ``louvain_clustering()``, ``busmap_by_rectangular_grid()``,
-  ``rectangular_grid_clustering()`` and ``stubs_clustering()`` were deprecated and
-  will be removed in v0.20.
+  ``busmap_by_spectral_clustering()``, ``spectral_clustering()``, ``busmap_by_louvain()``,
+  ``louvain_clustering()``, ``busmap_by_rectangular_grid()``, ``rectangular_grid_clustering()``
+  and ``stubs_clustering()`` were deprecated and will be removed in v0.20.
 * Distance measures for function ``busmap_by_spectral()`` and ``busmap_by_louvain()``
   were adapted to electrical distance (``s_nom/|r+i*x|``) (before: ``num_parallel``).
 * add new features here

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,12 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* Functions ``busmap_by_linemask()``, ``busmap_by_length()``, ``length_clustering()``,
+  ``busmap_by_louvain()``, ``louvain_clustering()``, ``busmap_by_rectangular_grid()``,
+  ``rectangular_grid_clustering()`` and ``stubs_clustering()`` were deprecated and
+  will be removed in v0.20.
+* Distance measures for function ``busmap_by_spectral()`` and ``busmap_by_louvain()``
+  were adapted to electrical distance (``s_nom/|r+i*x|``) (before: ``num_parallel``).
 * add new features here
 
 

--- a/pypsa/component_attrs/lines.csv
+++ b/pypsa/component_attrs/lines.csv
@@ -3,8 +3,8 @@ name,string,n/a,n/a,Unique name,Input (required),
 bus0,string,n/a,n/a,Name of first bus to which branch is attached.,Input (required),
 bus1,string,n/a,n/a,Name of second bus to which branch is attached.,Input (required),
 type,string,n/a,n/a,"Name of line standard type. If this is not an empty string """", then the line standard type impedance parameters are multiplied with the line length and divided/multiplied by num_parallel to compute x, r, etc. This will override any values set in r, x, and b. If the string is empty, PyPSA will simply read r, x, etc.",Input (optional),
-x,float,Ohm,0,Series reactance, must be non-zero for AC branch in linear power flow. If the line has series inductance :math:`L` in Henries then :math:`x = 2\pi f L` where :math:`f` is the frequency in Hertz. Series impedance :math:`z = r + jx` must be non-zero for the non-linear power flow. Ignored if type defined.,Input (required)
-r,float,Ohm,0,Series resistance, must be non-zero for DC branch in linear power flow. Series impedance :math:`z = r + jx` must be non-zero for the non-linear power flow. Ignored if type defined.,Input (required)
+x,float,Ohm,0,"Series reactance, must be non-zero for AC branch in linear power flow. If the line has series inductance :math:`L` in Henries then :math:`x = 2\pi f L` where :math:`f` is the frequency in Hertz. Series impedance :math:`z = r + jx` must be non-zero for the non-linear power flow. Ignored if type defined.",Input (required)
+r,float,Ohm,0,"Series resistance, must be non-zero for DC branch in linear power flow. Series impedance :math:`z = r + jx` must be non-zero for the non-linear power flow. Ignored if type defined.",Input (required)
 g,float,Siemens,0,Shunt conductivity. Shunt admittance is :math:`y = g + jb`.,Input (optional),
 b,float,Siemens,0,Shunt susceptance. If the line has shunt capacitance :math:`C` in Farads then :math:`b = 2\pi f C` where :math:`f` is the frequency in Hertz. Shunt admittance is :math:`y = g + jb`. Ignored if type defined.,Input (optional),
 s_nom,float,MVA,0,Limit of apparent power which can pass through branch.,Input (optional),

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -314,7 +314,7 @@ def get_clustering_from_busmap(network, busmap, with_time=True, line_length_fact
 # Length
 
 @deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
-            details="Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead.")
+            details="Use ``busmap_by_kmeans`` instead.")
 def busmap_by_linemask(network, mask):
     mask = network.lines[['bus0', 'bus1']].assign(mask=mask).set_index(['bus0','bus1'])['mask']
     G = nx.OrderedGraph()
@@ -326,13 +326,13 @@ def busmap_by_linemask(network, mask):
                      name='name')
 
 @deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
-            details="Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead.")
+            details="Use ``busmap_by_kmeans`` instead.")
 def busmap_by_length(network, length):
     return busmap_by_linemask(network, network.lines.length < length)
 
 
 @deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
-            details="Use ``kmeans_clustering`` or ``spectral_clustering`` instead.")
+            details="Use ``kmeans_clustering`` instead.")
 def length_clustering(network, length):
     busmap = busmap_by_length(network, length=length)
     return get_clustering_from_busmap(network, busmap)
@@ -340,6 +340,8 @@ def length_clustering(network, length):
 ################
 # SpectralClustering
 
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``busmap_by_kmeans`` instead.")
 def busmap_by_spectral_clustering(network, n_clusters, **kwds):
 
     if find_spec('sklearn') is None:
@@ -357,6 +359,8 @@ def busmap_by_spectral_clustering(network, n_clusters, **kwds):
     # input arg for spectral clustering must be symmetric, but A is directed. use A+A.T:
     return pd.Series(sk_spectral_clustering(A+A.T, n_clusters=50).astype(str), index=network.buses.index)
 
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``kmeans_clustering`` instead.")
 def spectral_clustering(network, n_clusters=8, **kwds):
     busmap = busmap_by_spectral_clustering(network, n_clusters=n_clusters, **kwds)
     return get_clustering_from_busmap(network, busmap)
@@ -365,7 +369,7 @@ def spectral_clustering(network, n_clusters=8, **kwds):
 # Louvain
 
 @deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
-            details="Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead.")
+            details="Use ``busmap_by_kmeans`` instead.")
 def busmap_by_louvain(network):
 
     if find_spec('community') is None:
@@ -393,7 +397,7 @@ def busmap_by_louvain(network):
 
 
 @deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
-            details="Use ``kmeans_clustering`` or ``spectral_clustering`` instead.")
+            details="Use ``kmeans_clustering`` instead.")
 def louvain_clustering(network, **kwds):
     busmap = busmap_by_louvain(network)
     return get_clustering_from_busmap(network, busmap)
@@ -491,7 +495,7 @@ def kmeans_clustering(network, bus_weightings, n_clusters, line_length_factor=1.
 # Rectangular grid clustering
 
 @deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
-            details="Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead.")
+            details="Use ``busmap_by_kmeans`` instead.")
 def busmap_by_rectangular_grid(buses, divisions=10):
 
     busmap = pd.Series(0, index=buses.index)
@@ -505,7 +509,7 @@ def busmap_by_rectangular_grid(buses, divisions=10):
     return busmap
 
 @deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
-            details="Use ``kmeans_clustering`` or ``spectral_clustering`` instead.")
+            details="Use ``kmeans_clustering`` instead.")
 def rectangular_grid_clustering(network, divisions):
     busmap = busmap_by_rectangular_grid(network.buses, divisions)
     return get_clustering_from_busmap(network, busmap)
@@ -556,7 +560,7 @@ def busmap_by_stubs(network, matching_attrs=None):
     return busmap
 
 @deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
-            details="Use ``kmeans_clustering`` or ``spectral_clustering`` instead.")
+            details="Use ``kmeans_clustering`` instead.")
 def stubs_clustering(network,use_reduced_coordinates=True, line_length_factor=1.0):
     """Cluster network by reducing stubs and stubby trees
     (i.e. sequentially reducing dead-ends).

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -359,7 +359,7 @@ def busmap_by_spectral_clustering(network, n_clusters, **kwds):
     from sklearn.cluster import spectral_clustering as sk_spectral_clustering
 
     weight = {"Line": network.lines.s_max_pu*network.lines.s_nom/abs(network.lines.r+1j*network.lines.x),
-              "Link": network.links.p_nom}
+              "Link": network.links.p_max_pu*network.links.p_nom}
 
     A = network.adjacency_matrix(branch_components=["Line", "Link"], weights=weight)
 
@@ -391,7 +391,7 @@ def busmap_by_louvain(network):
             .assign(weight=network.lines.s_max_pu*network.lines.s_nom/abs(network.lines.r+1j*network.lines.x))
             .set_index(['bus0','bus1']))
     lines = lines.append(network.links.loc[:, ['bus0', 'bus1']]
-                         .assign(weight=network.links.p_nom).set_index(['bus0','bus1']))
+                         .assign(weight=network.links.p_max_pu*network.links.p_nom).set_index(['bus0','bus1']))
 
     G = nx.Graph()
     G.add_nodes_from(network.buses.index)

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -379,10 +379,10 @@ def busmap_by_louvain(network):
     import community
 
     lines = (network.lines[['bus0', 'bus1']]
-            .assign(weight=network.lines.s_max_pu*network.lines.s_nom/abs(network.lines.r+1j*network.lines.x))
+            .assign(weight=network.lines.s_max_pu*network.lines.s_nom.clip(.1)/abs(network.lines.r+1j*network.lines.x))
             .set_index(['bus0','bus1']))
     lines = lines.append(network.links.loc[:, ['bus0', 'bus1']]
-                         .assign(weight=network.links.p_max_pu*network.links.p_nom).set_index(['bus0','bus1']))
+                         .assign(weight=network.links.p_max_pu*network.links.p_nom.clip(.1)).set_index(['bus0','bus1']))
 
     G = nx.Graph()
     G.add_nodes_from(network.buses.index)

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -351,8 +351,8 @@ def busmap_by_spectral_clustering(network, n_clusters, **kwds):
 
     from sklearn.cluster import spectral_clustering as sk_spectral_clustering
 
-    weight = {"Line": network.lines.s_max_pu*network.lines.s_nom/abs(network.lines.r+1j*network.lines.x),
-              "Link": network.links.p_max_pu*network.links.p_nom}
+    weight = {"Line": network.lines.s_max_pu*network.lines.s_nom.clip(.1)/abs(network.lines.r+1j*network.lines.x),
+              "Link": network.links.p_max_pu*network.links.p_nom.clip(.1)}
 
     A = network.adjacency_matrix(branch_components=["Line", "Link"], weights=weight)
 

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -19,6 +19,7 @@ import networkx as nx
 from collections import OrderedDict, namedtuple
 from functools import reduce
 from importlib.util import find_spec
+from deprecation import deprecated
 
 import logging
 logger = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 from .components import Network
 from .geo import haversine_pts
+from .__init__ import __version__ as pypsa_version
 
 from . import io
 
@@ -311,14 +313,10 @@ def get_clustering_from_busmap(network, busmap, with_time=True, line_length_fact
 ################
 # Length
 
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead.")
 def busmap_by_linemask(network, mask):
-
-    logger.warning(
-        "Function ``busmap_by_linemask`` is deprecated and will not work a future release. "
-        "Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead."
-    )
-
-    mask = network.lines.loc[:,['bus0', 'bus1']].assign(mask=mask).set_index(['bus0','bus1'])['mask']
+    mask = network.lines[['bus0', 'bus1']].assign(mask=mask).set_index(['bus0','bus1'])['mask']
     G = nx.OrderedGraph()
     G.add_nodes_from(network.buses.index)
     G.add_edges_from(mask.index[mask])
@@ -327,22 +325,15 @@ def busmap_by_linemask(network, mask):
                                  for n in g),
                      name='name')
 
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead.")
 def busmap_by_length(network, length):
-
-    logger.warning(
-        "Function ``busmap_by_length`` is deprecated and will not work a future release. "
-        "Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead."
-    )
-
     return busmap_by_linemask(network, network.lines.length < length)
 
+
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``kmeans_clustering`` or ``spectral_clustering`` instead.")
 def length_clustering(network, length):
-
-    logger.warning(
-        "Function ``length_clustering`` is deprecated and will not work a future release. "
-        "Use ``kmeans_clustering`` or ``spectral_clustering`` instead."
-    )
-
     busmap = busmap_by_length(network, length=length)
     return get_clustering_from_busmap(network, busmap)
 
@@ -373,12 +364,9 @@ def spectral_clustering(network, n_clusters=8, **kwds):
 ################
 # Louvain
 
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead.")
 def busmap_by_louvain(network):
-
-    logger.warning(
-        "Function ``busmap_by_louvain`` is deprecated and will not work a future release. "
-        "Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead."
-    )
 
     if find_spec('community') is None:
         raise ModuleNotFoundError("Optional dependency 'community' not found."
@@ -387,7 +375,7 @@ def busmap_by_louvain(network):
 
     import community
 
-    lines = (network.lines.loc[:, ['bus0', 'bus1']]
+    lines = (network.lines[['bus0', 'bus1']]
             .assign(weight=network.lines.s_max_pu*network.lines.s_nom/abs(network.lines.r+1j*network.lines.x))
             .set_index(['bus0','bus1']))
     lines = lines.append(network.links.loc[:, ['bus0', 'bus1']]
@@ -403,13 +391,10 @@ def busmap_by_louvain(network):
         list_cluster.append(str(b[i]))
     return pd.Series(list_cluster, index=network.buses.index)
 
+
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``kmeans_clustering`` or ``spectral_clustering`` instead.")
 def louvain_clustering(network, **kwds):
-
-    logger.warning(
-        "Function ``louvain_clustering`` is deprecated and will not work a future release. "
-        "Use ``kmeans_clustering`` or ``spectral_clustering`` instead."
-    )
-
     busmap = busmap_by_louvain(network)
     return get_clustering_from_busmap(network, busmap)
 
@@ -505,12 +490,9 @@ def kmeans_clustering(network, bus_weightings, n_clusters, line_length_factor=1.
 ################
 # Rectangular grid clustering
 
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead.")
 def busmap_by_rectangular_grid(buses, divisions=10):
-
-    logger.warning(
-        "Function ``busmap_by_rectangular_grid`` is deprecated and will not work a future release. "
-        "Use ``busmap_by_kmeans`` or ``busmap_by_spectral_clustering`` instead."
-    )
 
     busmap = pd.Series(0, index=buses.index)
     if isinstance(divisions, tuple):
@@ -522,13 +504,9 @@ def busmap_by_rectangular_grid(buses, divisions=10):
         busmap.loc[oks] = nk
     return busmap
 
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``kmeans_clustering`` or ``spectral_clustering`` instead.")
 def rectangular_grid_clustering(network, divisions):
-
-    logger.warning(
-        "Function ``rectangular_grid_clustering`` is deprecated and will not work a future release. "
-        "Use ``kmeans_clustering`` or ``spectral_clustering`` instead."
-    )
-
     busmap = busmap_by_rectangular_grid(network.buses, divisions)
     return get_clustering_from_busmap(network, busmap)
 
@@ -577,6 +555,8 @@ def busmap_by_stubs(network, matching_attrs=None):
             break
     return busmap
 
+@deprecated(deprecated_in="0.19", removed_in="0.20", current_version = pypsa_version,
+            details="Use ``kmeans_clustering`` or ``spectral_clustering`` instead.")
 def stubs_clustering(network,use_reduced_coordinates=True, line_length_factor=1.0):
     """Cluster network by reducing stubs and stubby trees
     (i.e. sequentially reducing dead-ends).
@@ -595,11 +575,6 @@ def stubs_clustering(network,use_reduced_coordinates=True, line_length_factor=1.
     Clustering : named tuple
         A named tuple containing network, busmap and linemap
     """
-
-    logger.warning(
-        "Function ``stubs_clustering`` is deprecated and will not work a future release. "
-        "Use ``kmeans`` or ``spectral`` instead."
-    )
 
     busmap = busmap_by_stubs(network)
 


### PR DESCRIPTION
deprecate all clustering methods that are currently not maintained and have not been evaluated... or are not compatible with e.g. pypsa-eur (such as` louvain_clustering` or `length_clustering`).

will add new methods (e.g. one that maximizes modularity similar to louvains method) later and in a separate pr.