### PR TITLE
Fix syntax error in load definition in quickstart example

### DIFF
--- a/doc/quick_start.rst
+++ b/doc/quick_start.rst
@@ -47,7 +47,7 @@ The same counts for lines, generators and loads, see the list of all components 
     #add a load at bus 1
     network.add("Load", "My load",
 		bus="My bus 1",
-		p_set=100
+		p_set=100,
 		q_set=100)
 
 


### PR DESCRIPTION
Closes # (no issue filed).

## Changes proposed in this Pull Request
Fix syntax error in example code on quickstart page.

## Checklist

- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included. (Changes are not noteworthy, I guess :D)
- [x] I consent to the release of this PR's code under the MIT license.
