### PR TITLE
add highs solver

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -16,7 +16,9 @@ Upcoming Release
 
 PyPSA 0.18.1 (15th October 2021)
 ================================
-* Add "highs" solver.
+* Add open source "HiGHS" solver: https://github.com/ERGO-Code/HiGHS. See
+  simple performance analysis for HiGHS, cbc, glpk and gurobi here:
+  https://github.com/PyPSA/PyPSA/pull/308#issue-772907717.
 
 * Add assert: CBC solver does not work with '>' and '<'
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,7 @@ Upcoming Release
 
 PyPSA 0.18.1 (15th October 2021)
 ================================
+* Add "highs" solver.
 
 * Compatibility with ``pyomo>=6.1``.
 

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -23,8 +23,8 @@ from .descriptors import (get_bounds_pu, get_extendable_i, get_non_extendable_i,
 
 from .linopt import (linexpr, write_bound, write_constraint, write_objective,
                      set_conref, set_varref, get_con, get_var, join_exprs,
-                     run_and_read_cbc, run_and_read_gurobi, run_and_read_glpk,
-                     run_and_read_cplex, run_and_read_xpress,
+                     run_and_read_highs, run_and_read_cbc, run_and_read_gurobi,
+                     run_and_read_glpk, run_and_read_cplex, run_and_read_xpress,
                      define_constraints, define_variables, define_binaries,
                      align_with_static_component)
 
@@ -1168,7 +1168,7 @@ def network_lopf(n, snapshots=None, solver_name="cbc",
         :func:`pypsa.linopt.get_dual` with corresponding name
 
     """
-    supported_solvers = ["cbc", "gurobi", 'glpk', 'cplex', 'xpress']
+    supported_solvers = ["highs", "cbc", "gurobi", 'glpk', 'cplex', 'xpress']
     if solver_name not in supported_solvers:
         raise NotImplementedError(f"Solver {solver_name} not in "
                                   f"supported solvers: {supported_solvers}")

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -603,7 +603,7 @@ def set_int_index(ser):
 
 
 def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
-                        solver_options, warmstart=None, store_basis=True):
+                        solver_options={}, warmstart=None, store_basis=True):
     """
    Highs solver function. Reads a linear problem file and passes it to the highs
     solver. If the solution is feasible the function returns the objective,
@@ -684,6 +684,7 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     constraints_dual : series
     objective : float
     """
+    logger.warning("The HiGHS solver can potentially solve towards variables that slightly deviate from Gurobi,cbc,glpk")
     options_fn = "highs_options.txt"
     default_dict = {
         "method": "ipm",

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -615,7 +615,7 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     After the "make" run, the 'highs' executables are in highs/build/bin/run/highs
     Once the "ctest" runs make sure you set the path. Path setting notes:
     >>> highs lib folder must be in "LD_LIBRARY_PATH" environment variable
-    >>> To do this, insert the below path at .bashrc (which is hidden in the home folder)
+    >>> To do this, insert the below path in the .bashrc (hidden in the home folder in Linux/Ubuntu)
     >>> LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/<your_path>/HiGHS/build/lib
 
     Architecture
@@ -626,16 +626,15 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     your local terminal helps to identify the raw outputs that are useful for
     developing the interface further.
 
-    All functions below the "process = ..." do only read and saves the outputs
-    generated from the HiGHS solver. These parts needs are solver specific and
+    All functions below the "process = ..." do only read and save the outputs
+    generated from the HiGHS solver. These parts are solver specific and
     depends on the solver output.
 
     Solver options
     ---------------
-    Solver options are read by the 1) command window and the 2) option_file.
+    Solver options are read by the 1) command window and the 2) option_file.txt
 
-    1) Full list of solver options (executable by command window) is given here:
-    https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.set
+    1) An example list of solver options executable by the command window is given here:
     Examples:
     --model_file arg 	File of model to solve.
     --presolve arg 	    Presolve: "choose" by default - "on"/"off" are alternatives.
@@ -645,10 +644,22 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     --options_file arg 	File containing HiGHS options.
     -h, --help 	        Print help.
 
-    2) The options_file is directly written in this function. Note, if you want
-    to make adjustments you need to change the pypsa library in the environment
-    of interest (for instance pypsa in the pypsa-eur needs to be changed in case
-    you want to model smt. with pypsa-eur)
+    2) The options_file.txt gives some more options, see a full list here: 
+    https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.set 
+    By default, we insert a couple of options for the ipm solver. The dictionary
+    can be overwritten by simply giving the new values. For instance in PyPSA-Eur,
+    you could write a dictionary replacing some of the default values or adding new
+    options:
+    ```
+    solving:
+        solver:
+            name: highs,
+            method: ipm,
+            parallel: "on",
+            <option_name>: <value>,
+    ```
+    Note, the <option_name> and <value> must be equivalent to the name convention
+    of HiGHS.
 
     Output
     ------
@@ -679,7 +690,7 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     # update default_dict by solver_dic (i.e. from PyPSA-Eur config.yaml)
     default_dict.update(solver_options)
     method = str(default_dict.pop("method", "ipm"))
-    logger.info(f"Options: \"{default_dict}\". More at: https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.set")
+    logger.info(f"Options: \"{default_dict}\". Docstring of function explains how to add/change options.")
     f1 = open("highs_options.txt","w")
     # write dict to a text file with options in each row
     f1.write(

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -605,18 +605,31 @@ def set_int_index(ser):
 def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
                         solver_options, warmstart=None, store_basis=True):
     """
-    Highs solver function. Reads a linear problem file and passes it to the highs
+   Highs solver function. Reads a linear problem file and passes it to the highs
     solver. If the solution is feasible the function returns the objective,
     solution and dual constraint variables. Highs must be installed for usage.
+    Documentation: https://www.maths.ed.ac.uk/hall/HiGHS/
 
     Installation
     -------------
-    Installation manual: https://www.maths.ed.ac.uk/hall/HiGHS/
-    After the "make" run, the 'highs' executables are in highs/build/bin/run/highs
-    Once the "ctest" runs make sure you set the path. Path setting notes:
-    >>> highs lib folder must be in "LD_LIBRARY_PATH" environment variable
-    >>> To do this, insert the below path in the .bashrc (hidden in the home folder in Linux/Ubuntu)
-    >>> LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/<your_path>/HiGHS/build/lib
+    The script might only work for version HiGHS 1.1.1. Installation steps::
+        sudo apt-get install cmake  # if not installed
+        git clone git@github.com:ERGO-Code/HiGHS.git
+        cd HiGHS
+        git checkout 95342daa73543cc21e5b27db3e0fbf7330007541 # moves to HiGHS 1.1.1
+        mkdir build
+        cd build
+        cmake ..
+        make
+        ctest
+
+    Then in .bashrc add paths of executables and library ::
+        export PATH="${PATH}:/foo/HiGHS/build/bin"
+        export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/foo/HiGHS/build/lib"
+        source .bashrc
+
+    Now when typing ``highs`` in the terminal you should see something like ::
+        Running HiGHS 1.1.1 [date: 2021-11-14, git hash: 95342daa]
 
     Architecture
     -------------
@@ -659,7 +672,8 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
             <option_name>: <value>,
     ```
     Note, the <option_name> and <value> must be equivalent to the name convention
-    of HiGHS.
+    of HiGHS. Some function exist that are not documented, check their GitHub file:
+    \HighsOptions.h
 
     Output
     ------
@@ -671,41 +685,42 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     constraints_dual : series
     objective : float
     """
-    import logging, re, io, subprocess, sys, os
-
+    options_fn = "highs_options.txt"
     default_dict = {
-    "method" : "ipm",
-    "primal_feasibility_tolerance" : 1e-04,
-    "dual_feasibility_tolerance" : 1e-05,
-    "ipm_optimality_tolerance" : 1e-6,
-    "presolve" : "on",
-    "run_crossover" : True,
-    "parallel" : "off",
-    "highs_min_threads" : 1,
-    "highs_max_threads" : 8,
-    "solution_file" : solution_fn,
-    "write_solution_to_file" : True,
-    "write_solution_pretty" : True,
+        "method": "ipm",
+        "primal_feasibility_tolerance": 1e-04,
+        "dual_feasibility_tolerance": 1e-05,
+        "ipm_optimality_tolerance": 1e-6,
+        # "ipm_iteration_limit": 100,
+        "presolve": "on",
+        "run_crossover": True,
+        "parallel": "off",
+        "threads": 4,
+        "solution_file": solution_fn,
+        "write_solution_to_file": True,
+        "write_solution_style": 1,
+        "log_to_console": True,
     }
-    # update default_dict by solver_dic (i.e. from PyPSA-Eur config.yaml)
+    # update default_dict through solver_options and write to file
     default_dict.update(solver_options)
-    method = str(default_dict.pop("method", "ipm"))
-    logger.info(f"Options: \"{default_dict}\". Docstring of function explains how to add/change options.")
-    f1 = open("highs_options.txt","w")
-    # write dict to a text file with options in each row
-    f1.write(
-        ' \n '.join([f"{str(k)} = {str(v)}" for k, v in default_dict.items()])
-    )
+    method = default_dict.pop("method", "ipm")
+    logger.info(f"Options: \"{default_dict}\". List of options: https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.set")
+    f1 = open(options_fn, "w")
+    f1.write('\n'.join([f"{k} = {v}" for k, v in default_dict.items()]))
     f1.close()
 
     # write (terminal) commands
     command = f"highs --model_file {problem_fn} "
     if warmstart:
-        logger.warning("Warmstart, probably not available at HiGHS yet")
-    command += f"--solver {method} --options_file {os.getcwd()}/highs_options.txt"
+        logger.warning("Warmstart, not available in HiGHS. Will be ignored.")
+    command += f"--solver {method} --options_file {options_fn}"
     logger.info(f"Solver command: \"{command}\"")
     # execute command and store command window output
-    process = subprocess.Popen(command.split(' '), stdout=subprocess.PIPE, universal_newlines=True)
+    process = subprocess.Popen(
+        command.split(' '),
+        stdout=subprocess.PIPE,
+        universal_newlines=True
+    )
 
     def read_until_break():
         # Function that reads line by line the command window
@@ -717,19 +732,15 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
                 yield out
 
     # converts stdout (standard terminal output) to pandas dataframe
-    info = io.StringIO(''.join(read_until_break())[:])
-    info = pd.read_csv(info, sep=':',  index_col=0, header=None)[1]
-    # remove options.txt
-    os.remove("highs_options.txt")
-
-    # save raw solver output (info) as log
-    with open(solver_logfile, 'w') as f:
-        pd.options.display.max_colwidth = 100  # Otherwise trunctunated
-        info_as_txt = info.to_string(header=False, index=True)
-        f.write(info_as_txt)
+    log = io.StringIO(''.join(read_until_break())[:])
+    log = pd.read_csv(log, sep=':', index_col=0, header=None)[1].squeeze()
+    if solver_logfile is not None:
+        log.to_csv(solver_logfile, sep="\t")
+    log.index = log.index.str.strip()
+    os.remove(options_fn)
 
     # read out termination_condition from `info`
-    model_status = info[-15].lstrip()  # string with model_status
+    model_status = log["Model   status"].strip().lower()
     if "optimal" in model_status:
         status = "ok"
         termination_condition = model_status
@@ -739,25 +750,24 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     else:
         status = 'warning'
         termination_condition = model_status
-    objective = float(re.sub(r'[^0-9\.\+\-e]+', '', info[-2].lstrip()))
+    objective = float(log["Objective value"])
 
     # read out solution file (.sol)
-    f = open(solution_fn,"rb")
+    f = open(solution_fn, "rb")
     trimed_sol_fn = re.sub(rb'\*\*\s+', b'', f.read())
     f.close()
-    sol = pd.read_csv(io.BytesIO(trimed_sol_fn), header=None, skiprows=[0],
-                      sep=r'\s+', usecols=[0,1,2])
-    sol = sol.rename(columns={0: "primal", 1: "dual", 2: "basis"})
-    # filter primal and dual variables for "Rows" and "Columns"
-    col_no = sol[(sol["primal"] == "Columns")].index[0]
-    row_no = sol[(sol["primal"] == "Rows")].index[0]
-    sol_rows = sol[sol.index > row_no]
-    sol_cols = sol[(sol.index > col_no)&(sol.index < row_no)]
-    constraints_dual = pd.to_numeric(sol_rows["dual"], errors="raise")
-    variables_sol = pd.to_numeric(sol_cols["primal"], errors="raise")
+    
+    sol = pd.read_csv(io.BytesIO(trimed_sol_fn), header=[1], sep=r'\s+')
+    row_no = sol[sol["Index"] == 'Rows'].index[0]
+    sol = sol.drop(row_no+1)  # Removes header line after "Rows"
+    sol_rows = sol[(sol.index > row_no)]
+    sol_cols = sol[(sol.index < row_no)].set_index("Name").pipe(set_int_index)
+    variables_sol = pd.to_numeric(sol_cols["Primal"], errors="raise")
+    constraints_dual = pd.to_numeric(sol_rows["Dual"], errors="raise").reset_index(drop=True)
+    constraints_dual.index += 1
 
-    return(status, termination_condition, variables_sol,
-        constraints_dual, objective)
+    return (status, termination_condition, variables_sol,
+            constraints_dual, objective)
 
 
 def run_and_read_cbc(n, problem_fn, solution_fn, solver_logfile,

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -660,20 +660,19 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     2) The options_file.txt gives some more options, see a full list here: 
     https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.set 
     By default, we insert a couple of options for the ipm solver. The dictionary
-    can be overwritten by simply giving the new values. For instance in PyPSA-Eur,
-    you could write a dictionary replacing some of the default values or adding new
-    options:
+    can be overwritten by simply giving the new values. For instance, you could
+    write a dictionary replacing some of the default values or adding new options:
     ```
-    solving:
-        solver:
-            name: highs,
-            method: ipm,
-            parallel: "on",
-            <option_name>: <value>,
+    solver_options = {
+        name: highs,
+        method: ipm,
+        parallel: "on",
+        <option_name>: <value>,
+    }
     ```
     Note, the <option_name> and <value> must be equivalent to the name convention
     of HiGHS. Some function exist that are not documented, check their GitHub file:
-    \HighsOptions.h
+    https://github.com/ERGO-Code/HiGHS/blob/master/src/lp_data/HighsOptions.h
 
     Output
     ------
@@ -691,7 +690,6 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
         "primal_feasibility_tolerance": 1e-04,
         "dual_feasibility_tolerance": 1e-05,
         "ipm_optimality_tolerance": 1e-6,
-        # "ipm_iteration_limit": 100,
         "presolve": "on",
         "run_crossover": True,
         "parallel": "off",

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -682,7 +682,7 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     if (solver_options is not None) and (solver_options != {}):
         command += solver_options
     command += "--solver ipm --options_file " + os.getcwd() + "/highs_options.txt"
-    logger.info("command: ",command)
+    logger.info(f"Solver command: \"{command}\"")
     # execute command and store command window output
     process = subprocess.Popen(command.split(' '), stdout=subprocess.PIPE, universal_newlines=True)
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
Add open source [HiGHS](https://github.com/ERGO-Code/HiGHS) solver:
![solver_performance_new](https://user-images.githubusercontent.com/61968949/140389255-201a6f7b-e860-4f2e-bed1-a2a598f15f7a.png)

Future work can:
- While the above results look incredible, generally all open source solvers struggle when 1 year is simulated in hourly resolution. I.e. Gurobi solves 5 nodes for 1 year in hourly resolution in 1min, while HiGHS and others may need 2+ hours. This performance drop occurs because open source solvers don't address properly the existence of "dense columns".
- Future work can contribute to the HiGHS solver and implement a method for the IPM that does deal with dense columns.
- Other work could implement (advanced) aggressive scaling techniques into PyPSA (to be useful for all solvers) and/or HiGHS. See some ongoing PyPSA discussion here: https://github.com/PyPSA/PyPSA/issues/309

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
