### PR TITLE
Links ramp rate

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,7 +13,9 @@ Upcoming Release
 
 * The snapshot levels of a multi-indexed snapshot were renamed to ['period', 'timestep'], the name of the index was set to 'snapshot'. This makes the snapshot name coherent for single and multi-indexed snapshots.
 
-* A new convenience function `Network.get_committable_i` was added. This returns an index containing all committable assets of component `c`. In case that component `c` does not support committable assets, it returns an empty dataframe.    
+* A new convenience function `Network.get_committable_i` was added. This returns an index containing all committable assets of component `c`. In case that component `c` does not support committable assets, it returns an empty dataframe.  
+
+* The `Link` component has two new attributes, `ramp_limit_up` and `ramp_limit_down`, which limits the marginal power increase equivalent to the implementation for generators. The new attributes are only considered when performing the `lopf` with `pyomo=False`.
 
 * add new features here
 

--- a/pypsa/component_attrs/links.csv
+++ b/pypsa/component_attrs/links.csv
@@ -18,6 +18,8 @@ capital_cost,float,currency/MW,0,Capital cost of extending p_nom by 1 MW.,Input 
 marginal_cost,static or series,currency/MWh,0,Marginal cost of transfering 1 MWh (before efficiency losses) from bus0 to bus1. NB: marginal cost only makes sense in OPF if p_max_pu >= 0.,Input (optional)
 length,float,km,0,"Length of line, useful for calculating the capital cost.",Input (optional)
 terrain_factor,float,per unit,1,Terrain factor for increasing capital cost.,Input (optional)
+ramp_limit_up,float,per unit,NaN,"Maximum active power increase from one snapshot to the next, per unit of the nominal power. Ignored if NaN.",Input (optional)
+ramp_limit_down,float,per unit,NaN,"Maximum active power decrease from one snapshot to the next, per unit of the nominal power. Ignored if NaN.",Input (optional)
 p0,series,MW,0,Active power at bus0 (positive if branch is withdrawing power from bus0).,Output
 p1,series,MW,0,Active power at bus1 (positive if branch is withdrawing power from bus1).,Output
 p_nom_opt,float,MVA,0,Optimised capacity for active power.,Output

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -244,6 +244,10 @@ def define_ramp_limit_constraints(n, sns, c):
         return
     fix_i = get_non_extendable_i(n, c)
     ext_i = get_extendable_i(n, c)
+    if "committable" in n.df(c):
+        com_i = n.df(c).query('committable').index.difference(ext_i)
+    else:
+        com_i = []
     p = get_var(n, c, 'p').loc[sns[1:]]
     p_prev = get_var(n, c, 'p').shift(1).loc[sns[1:]]
     active = get_activity_mask(n, c, sns[1:])
@@ -282,10 +286,7 @@ def define_ramp_limit_constraints(n, sns, c):
         kwargs = dict(spec='ext.', mask=active[gens_i])
         define_constraints(n, lhs, '>=', 0, c, 'mu_ramp_limit_down', **kwargs)
 
-    if "committable" in n.df(c):
-        com_i = n.df(c).query('committable').index.difference(ext_i)
-    else:
-        com_i = []
+
 
     # com up
     gens_i = rup_i.intersection(com_i)

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -902,8 +902,8 @@ def prepare_lopf(n, snapshots=None, keep_files=False, skip_objective=False,
     define_fixed_variable_constraints(n, snapshots, 'StorageUnit', 'state_of_charge')
     define_fixed_variable_constraints(n, snapshots, 'Store', 'e')
 
-    define_ramp_limit_constraints(n, snapshots, c='Generator', commitable=True)
-    define_ramp_limit_constraints(n, snapshots, c='Link', commitable=False)
+    define_ramp_limit_constraints(n, snapshots, c='Generator')
+    define_ramp_limit_constraints(n, snapshots, c='Link')
     define_storage_unit_constraints(n, snapshots)
     define_store_constraints(n, snapshots)
     define_kirchhoff_constraints(n, snapshots)

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -269,6 +269,19 @@ def define_ramp_limit_constraints(n, sns, c):
         kwargs = dict(spec='ext.', mask=active[gens_i])
         define_constraints(n, lhs, '<=', 0, c, 'mu_ramp_limit_up', **kwargs)
 
+    # com up
+    gens_i = rup_i.intersection(com_i)
+    if not gens_i.empty:
+        limit_start = n.df(c).loc[gens_i].eval('ramp_limit_start_up * p_nom')
+        limit_up = n.df(c).loc[gens_i].eval('ramp_limit_up * p_nom')
+        status = get_var(n, c, 'status').loc[sns[1:], gens_i]
+        status_prev = get_var(n, c, 'status').shift(1).loc[sns[1:], gens_i]
+        lhs = linexpr((1, p[gens_i]), (-1, p_prev[gens_i]),
+                    (limit_start - limit_up, status_prev),
+                    (- limit_start, status))
+        kwargs = dict(spec='com.', mask=active[gens_i])
+        define_constraints(n, lhs, '<=', 0, c, 'mu_ramp_limit_up', **kwargs)
+
     # fix down
     gens_i = rdown_i.intersection(fix_i)
     if not gens_i.empty:
@@ -285,21 +298,6 @@ def define_ramp_limit_constraints(n, sns, c):
         lhs = linexpr((1, p[gens_i]), (-1, p_prev[gens_i]), (limit_pu, p_nom))
         kwargs = dict(spec='ext.', mask=active[gens_i])
         define_constraints(n, lhs, '>=', 0, c, 'mu_ramp_limit_down', **kwargs)
-
-
-
-    # com up
-    gens_i = rup_i.intersection(com_i)
-    if not gens_i.empty:
-        limit_start = n.df(c).loc[gens_i].eval('ramp_limit_start_up * p_nom')
-        limit_up = n.df(c).loc[gens_i].eval('ramp_limit_up * p_nom')
-        status = get_var(n, c, 'status').loc[sns[1:], gens_i]
-        status_prev = get_var(n, c, 'status').shift(1).loc[sns[1:], gens_i]
-        lhs = linexpr((1, p[gens_i]), (-1, p_prev[gens_i]),
-                    (limit_start - limit_up, status_prev),
-                    (- limit_start, status))
-        kwargs = dict(spec='com.', mask=active[gens_i])
-        define_constraints(n, lhs, '<=', 0, c, 'mu_ramp_limit_up', **kwargs)
 
     # com down
     gens_i = rdown_i.intersection(com_i)

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -905,7 +905,6 @@ def prepare_lopf(n, snapshots=None, keep_files=False, skip_objective=False,
     define_fixed_variable_constraints(n, snapshots, 'StorageUnit', 'state_of_charge')
     define_fixed_variable_constraints(n, snapshots, 'Store', 'e')
 
-    define_committable_generator_constraints(n, snapshots)
     define_ramp_limit_constraints(n, snapshots, c='Generator', commitable=True)
     define_ramp_limit_constraints(n, snapshots, c='Link', commitable=False)
     define_storage_unit_constraints(n, snapshots)

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -235,7 +235,7 @@ def define_committable_generator_constraints(n, sns):
 
 def define_ramp_limit_constraints(n, sns, c):
     """
-    Defines ramp limits for generators and links with valid ramplimit.
+    Defines ramp limits for a given component with valid ramplimit.
 
     """
     test_components = ['Generator', 'Link']

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -282,36 +282,36 @@ def define_ramp_limit_constraints(n, sns, c):
         kwargs = dict(spec='ext.', mask=active[gens_i])
         define_constraints(n, lhs, '>=', 0, c, 'mu_ramp_limit_down', **kwargs)
 
-    if commitable:
-        assert c=='Generator', 'Commitable contraints were only tested for Generator.'
-
+    if "committable" in n.df(c):
         com_i = n.df(c).query('committable').index.difference(ext_i)
+    else:
+        com_i = []
 
-        # com up
-        gens_i = rup_i.intersection(com_i)
-        if not gens_i.empty:
-            limit_start = n.df(c).loc[gens_i].eval('ramp_limit_start_up * p_nom')
-            limit_up = n.df(c).loc[gens_i].eval('ramp_limit_up * p_nom')
-            status = get_var(n, c, 'status').loc[sns[1:], gens_i]
-            status_prev = get_var(n, c, 'status').shift(1).loc[sns[1:], gens_i]
-            lhs = linexpr((1, p[gens_i]), (-1, p_prev[gens_i]),
-                        (limit_start - limit_up, status_prev),
-                        (- limit_start, status))
-            kwargs = dict(spec='com.', mask=active[gens_i])
-            define_constraints(n, lhs, '<=', 0, c, 'mu_ramp_limit_up', **kwargs)
+    # com up
+    gens_i = rup_i.intersection(com_i)
+    if not gens_i.empty:
+        limit_start = n.df(c).loc[gens_i].eval('ramp_limit_start_up * p_nom')
+        limit_up = n.df(c).loc[gens_i].eval('ramp_limit_up * p_nom')
+        status = get_var(n, c, 'status').loc[sns[1:], gens_i]
+        status_prev = get_var(n, c, 'status').shift(1).loc[sns[1:], gens_i]
+        lhs = linexpr((1, p[gens_i]), (-1, p_prev[gens_i]),
+                    (limit_start - limit_up, status_prev),
+                    (- limit_start, status))
+        kwargs = dict(spec='com.', mask=active[gens_i])
+        define_constraints(n, lhs, '<=', 0, c, 'mu_ramp_limit_up', **kwargs)
 
-        # com down
-        gens_i = rdown_i.intersection(com_i)
-        if not gens_i.empty:
-            limit_shut = n.df(c).loc[gens_i].eval('ramp_limit_shut_down * p_nom')
-            limit_down = n.df(c).loc[gens_i].eval('ramp_limit_down * p_nom')
-            status = get_var(n, c, 'status').loc[sns[1:], gens_i]
-            status_prev = get_var(n, c, 'status').shift(1).loc[sns[1:], gens_i]
-            lhs = linexpr((1, p[gens_i]), (-1, p_prev[gens_i]),
-                        (limit_down - limit_shut, status),
-                        (limit_shut, status_prev))
-            kwargs = dict(spec='com.', mask=active[gens_i])
-            define_constraints(n, lhs, '>=', 0, c, 'mu_ramp_limit_down', **kwargs)
+    # com down
+    gens_i = rdown_i.intersection(com_i)
+    if not gens_i.empty:
+        limit_shut = n.df(c).loc[gens_i].eval('ramp_limit_shut_down * p_nom')
+        limit_down = n.df(c).loc[gens_i].eval('ramp_limit_down * p_nom')
+        status = get_var(n, c, 'status').loc[sns[1:], gens_i]
+        status_prev = get_var(n, c, 'status').shift(1).loc[sns[1:], gens_i]
+        lhs = linexpr((1, p[gens_i]), (-1, p_prev[gens_i]),
+                    (limit_down - limit_shut, status),
+                    (limit_shut, status_prev))
+        kwargs = dict(spec='com.', mask=active[gens_i])
+        define_constraints(n, lhs, '>=', 0, c, 'mu_ramp_limit_down', **kwargs)
 
 
 def define_nominal_constraints_per_bus_carrier(n, sns):

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -233,7 +233,7 @@ def define_committable_generator_constraints(n, sns):
 
 
 
-def define_ramp_limit_constraints(n, sns, c='Generator', commitable=True):
+def define_ramp_limit_constraints(n, sns, c):
     """
     Defines ramp limits for generators and links with valid ramplimit.
 

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -238,9 +238,6 @@ def define_ramp_limit_constraints(n, sns, c):
     Defines ramp limits for a given component with valid ramplimit.
 
     """
-    test_components = ['Generator', 'Link']
-    assert c in test_components, 'Ramp limit constraints were only tested for Generator and Link.'
-
     rup_i = n.df(c).query('ramp_limit_up == ramp_limit_up').index
     rdown_i = n.df(c).query('ramp_limit_down == ramp_limit_down').index
     if rup_i.empty & rdown_i.empty:

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -903,6 +903,7 @@ def prepare_lopf(n, snapshots=None, keep_files=False, skip_objective=False,
     define_fixed_variable_constraints(n, snapshots, 'StorageUnit', 'state_of_charge')
     define_fixed_variable_constraints(n, snapshots, 'Store', 'e')
 
+    define_committable_generator_constraints(n, snapshots)
     define_ramp_limit_constraints(n, snapshots, c='Generator')
     define_ramp_limit_constraints(n, snapshots, c='Link')
     define_storage_unit_constraints(n, snapshots)

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -1646,6 +1646,8 @@ def network_lopf(network, snapshots=None, solver_name="glpk", solver_io=None,
         raise NotImplementedError("Multi period invesmtent is only supported for pyomo=False")
     if (type(network.snapshots)==pd.MultiIndex):
         raise NotImplementedError("Multi indexed snapshots is only supported for pyomo=False")
+    if network.links[['ramp_limit_up', 'ramp_limit_down']].notnull().any().any():
+        logger.warning("Encountered nonzero ramp limits for links. These are ignored when running the optimization with `pyomo=True`.")
 
 
     snapshots = _as_snapshots(network, snapshots)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Added ramp rate limits for links. The functionality is limited to non-committable links. 

As suggested, I reused the code for the Generators. I modified `define_ramp_limit_constraints` to include links as valid `component` input. However, I am not sure how to incorporate the committable functionality at the moment since it uses several variables; thus, a flag for `committable` was added to keep this functionality in Generators but not in Links. 

Kindly advised for necessary tests. I used it for my own purpose (representing hydrogen power plant using store and links) and it was able to limit the ramp rate for both up and down. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
