### PR TITLE
Component index name followup

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,9 @@ Upcoming Release
 
 * Hierarchical Agglomerative Clustering (HAC) was introduced as new spatial clustering method [`#289 <https://github.com/PyPSA/PyPSA/pull/289>`_].
 
+* The snapshot levels of a multi-indexed snapshot were renamed to ['period', 'timestep'], the name of the index was set to 'snapshot'. This makes the snapshot name coherent for single and multi-indexed snapshots.
+* A new convenience function `Network.get_committable_i` was added. This returns an index containing all committable assets of component `c`. In case that component `c` does not support committable assets, it returns an empty dataframe.    
+
 * add new features here
 
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,7 @@ Upcoming Release
 * Hierarchical Agglomerative Clustering (HAC) was introduced as new spatial clustering method [`#289 <https://github.com/PyPSA/PyPSA/pull/289>`_].
 
 * The snapshot levels of a multi-indexed snapshot were renamed to ['period', 'timestep'], the name of the index was set to 'snapshot'. This makes the snapshot name coherent for single and multi-indexed snapshots.
+
 * A new convenience function `Network.get_committable_i` was added. This returns an index containing all committable assets of component `c`. In case that component `c` does not support committable assets, it returns an empty dataframe.    
 
 * add new features here

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -482,14 +482,15 @@ class Network(Basic):
             # Convenience case:
             logger.info("Repeating time-series for each investment period and "
                         "converting snapshots to a pandas.MultiIndex.")
+            names = ['period', 'timestep']
             for component in self.all_components:
                 pnl = self.pnl(component)
                 attrs = self.components[component]["attrs"]
 
-                for k,default in attrs.default[attrs.varying].iteritems():
-                    pnl[k] = pd.concat({p: pnl[k] for p in periods})
+                for k, default in attrs.default[attrs.varying].iteritems():
+                    pnl[k] = pd.concat({p: pnl[k] for p in periods}, names=names)
+                    pnl[k].index.name = 'snapshot'
 
-            names = ['period', 'timestep']
             self._snapshots = pd.MultiIndex.from_product([periods, self.snapshots],
                                                       names=names)
             self._snapshots.name = 'snapshot'

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -318,8 +318,7 @@ class Network(Basic):
             # but this could be generalised
             pnl = Dict()
             for k in attrs.index[attrs.varying]:
-                dtype = np.dtype(float)
-                df = pd.DataFrame(index=self.snapshots, columns=[], dtype=dtype)
+                df = pd.DataFrame(index=self.snapshots, columns=[], dtype=float)
                 df.index.name = 'snapshot'
                 df.columns.name = component
                 pnl[k] = df
@@ -725,9 +724,7 @@ class Network(Basic):
             elif attrs.at[k,"static"] and not isinstance(v, (pd.Series, pd.DataFrame, np.ndarray, list)):
                 new_df.at[name,k] = typ(v)
             else:
-                ser = pd.Series(data=v, index=self.snapshots, dtype=typ)
-                cls_pnl[k][name] = ser
-
+                cls_pnl[k][name] = pd.Series(data=v, index=self.snapshots, dtype=typ)
 
         for attr in ["bus","bus0","bus1"]:
             if attr in new_df.columns:

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -726,7 +726,6 @@ class Network(Basic):
                 new_df.at[name,k] = typ(v)
             else:
                 ser = pd.Series(data=v, index=self.snapshots, dtype=typ)
-                ser.columns.name = class_name
                 cls_pnl[k][name] = ser
 
 

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -310,17 +310,19 @@ class Network(Basic):
 
             df = pd.DataFrame({k: pd.Series(dtype=d) for k, d in static_dtypes.iteritems()},
                               columns=static_dtypes.index)
-            df.index.name = component
 
+            df.index.name = component
             setattr(self,self.components[component]["list_name"],df)
 
             #it's currently hard to imagine non-float series,
             # but this could be generalised
-            pnl = Dict({k : pd.DataFrame(index=self.snapshots,
-                                         columns=[],
-                                         dtype=np.dtype(float))
-                            .rename_axis(component, axis=1)
-                        for k in attrs.index[attrs.varying]})
+            pnl = Dict()
+            for k in attrs.index[attrs.varying]:
+                dtype = np.dtype(float)
+                df = pd.DataFrame(index=self.snapshots, columns=[], dtype=dtype)
+                df.index.name = 'snapshot'
+                df.columns.name = component
+                pnl[k] = df
 
             setattr(self,self.components[component]["list_name"]+"_t",pnl)
 
@@ -708,6 +710,7 @@ class Network(Basic):
                               columns=static_attrs.index)
         new_df = cls_df.append(obj_df, sort=False)
 
+        new_df.index.name = class_name
         setattr(self, self.components[class_name]["list_name"], new_df)
 
         for k,v in kwargs.items():
@@ -721,7 +724,9 @@ class Network(Basic):
             elif attrs.at[k,"static"] and not isinstance(v, (pd.Series, pd.DataFrame, np.ndarray, list)):
                 new_df.at[name,k] = typ(v)
             else:
-                cls_pnl[k][name] = pd.Series(data=v, index=self.snapshots, dtype=typ)
+                ser = pd.Series(data=v, index=self.snapshots, dtype=typ)
+                ser.columns.name = class_name
+                cls_pnl[k][name] = ser
 
 
         for attr in ["bus","bus0","bus1"]:

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -172,7 +172,7 @@ def get_switchable_as_dense(network, component, attr, snapshots=None, inds=None)
     return (pd.concat([
         pd.DataFrame(np.repeat([df.loc[fixed_i, attr].values], len(snapshots), axis=0),
                      index=snapshots, columns=fixed_i),
-        pnl[attr].reindex(index=snapshots, columns=varying_i)
+        pnl[attr].loc[snapshots, varying_i]
     ], axis=1, sort=False).reindex(index=snapshots, columns=index))
 
 def get_switchable_as_iter(network, component, attr, snapshots, inds=None):

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -172,8 +172,8 @@ def get_switchable_as_dense(network, component, attr, snapshots=None, inds=None)
     return (pd.concat([
         pd.DataFrame(np.repeat([df.loc[fixed_i, attr].values], len(snapshots), axis=0),
                      index=snapshots, columns=fixed_i),
-        pnl[attr].loc[snapshots, varying_i]
-    ], axis=1, sort=False).reindex(columns=index))
+        pnl[attr].reindex(index=snapshots, columns=varying_i)
+    ], axis=1, sort=False).reindex(index=snapshots, columns=index))
 
 def get_switchable_as_iter(network, component, attr, snapshots, inds=None):
     """

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -312,6 +312,18 @@ def get_non_extendable_i(n, c):
     return n.df(c)[lambda ds: ~ds[nominal_attrs[c] + '_extendable']].index
 
 
+def get_committable_i(n, c):
+    """
+    Getter function. Get the index of commitable elements of a given
+    component.
+    """
+    if "committable" not in n.df(c):
+        idx = pd.Index([])
+    else:
+        idx = n.df(c)[lambda ds: ds['committable']].index
+    return idx.rename(f'{c}-com')
+
+
 def get_active_assets(n, c, investment_period):
     """
     Getter function. Get True values for elements of component c which are active

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -618,6 +618,7 @@ def _import_from_importer(network, importer, basename, skip_time=False):
         snapshot_levels = set(["period", "timestep", "snapshot"]).intersection(df.columns)
         if snapshot_levels:
             df.set_index(sorted(snapshot_levels), inplace=True)
+        network.set_snapshots(df.index)
 
         cols = ['objective', 'generators', 'stores']
         if not df.columns.intersection(cols).empty:

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -616,7 +616,7 @@ def _import_from_importer(network, importer, basename, skip_time=False):
         # check if imported snapshots have MultiIndex
         # backwards-compatibility: level "snapshot" was rename to "timestep"
         snapshot_levels = set(["period", "timestep", "snapshot"]).intersection(df.columns)
-        if len(snapshot_levels) == 2:
+        if snapshot_levels:
             df.set_index(sorted(snapshot_levels), inplace=True)
 
         cols = ['objective', 'generators', 'stores']

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -704,7 +704,7 @@ def import_components_from_dataframe(network, dataframe, cls_name):
 
     # Clean dataframe and ensure correct types
     dataframe = pd.DataFrame(dataframe)
-    dataframe.index = dataframe.index.astype(str).rename(cls_name)
+    dataframe.index = dataframe.index.astype(str)
 
     for k in static_attrs.index:
         if k not in dataframe.columns:
@@ -733,6 +733,7 @@ def import_components_from_dataframe(network, dataframe, cls_name):
         logger.error("Error, new components for {} are not unique".format(cls_name))
         return
 
+    new_df.index.name = cls_name
     setattr(network, network.components[cls_name]["list_name"], new_df)
 
     #now deal with time-dependent properties
@@ -783,6 +784,7 @@ def import_series_from_dataframe(network, dataframe, cls_name, attr):
     list_name = network.components[cls_name]["list_name"]
 
     dataframe.columns.name = cls_name
+    dataframe.index.name = 'snapshot'
     diff = dataframe.columns.difference(df.index)
     if len(diff) > 0:
         logger.warning(f"Components {diff} for attribute {attr} of {cls_name} "

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -75,8 +75,11 @@ class ImporterCSV(Importer):
         fn = os.path.join(self.csv_folder_name, "snapshots.csv")
         if not os.path.isfile(fn): return None
         df = pd.read_csv(fn, index_col=0, encoding=self.encoding, parse_dates=True)
+        # backwards-compatibility: level "snapshot" was rename to "timestep"
         if "snapshot" in df:
             df["snapshot"] = pd.to_datetime(df.snapshot)
+        if "timestep" in df:
+            df["timestep"] = pd.to_datetime(df.timestep)
         return df
 
     def get_investment_periods(self):
@@ -327,7 +330,7 @@ def _export_to_exporter(network, exporter, basename, export_standard_types=False
 
     #now export snapshots
     if isinstance(network.snapshot_weightings.index, pd.MultiIndex):
-        network.snapshot_weightings.index.rename(["period", "snapshot"], inplace=True)
+        network.snapshot_weightings.index.rename(["period", "timestep"], inplace=True)
     else:
         network.snapshot_weightings.index.rename("snapshot", inplace=True)
     snapshots = network.snapshot_weightings.reset_index()
@@ -610,12 +613,11 @@ def _import_from_importer(network, importer, basename, skip_time=False):
     df = importer.get_snapshots()
 
     if df is not None:
-
         # check if imported snapshots have MultiIndex
-        snapshot_levels = set(["period", "snapshot"]).intersection(df.columns)
-        if snapshot_levels:
+        # backwards-compatibility: level "snapshot" was rename to "timestep"
+        snapshot_levels = set(["period", "timestep", "snapshot"]).intersection(df.columns)
+        if len(snapshot_levels) == 2:
             df.set_index(sorted(snapshot_levels), inplace=True)
-        network.set_snapshots(df.index)
 
         cols = ['objective', 'generators', 'stores']
         if not df.columns.intersection(cols).empty:

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -50,6 +50,7 @@ def _as_snapshots(network, snapshots):
     if not isinstance(snapshots, pd.MultiIndex):
         snapshots = pd.Index(snapshots)
     assert snapshots.isin(network.snapshots).all()
+    snapshots.name = 'snapshot'
     return snapshots
 
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -27,7 +27,8 @@ def network_mi():
     )
     n = pypsa.Network(csv_folder_name)
     n.snapshots = pd.MultiIndex.from_product([[2013], n.snapshots])
-    n.generators_t.p.loc[:,:] = np.random.rand(*n.generators_t.p.shape)
+    gens_i = n.generators.index
+    n.generators_t.p[gens_i] = np.random.rand(len(n.snapshots), len(gens_i))
     return n
 
 
@@ -56,14 +57,14 @@ def test_netcdf_io_multiindexed(network_mi, tmpdir):
     pd.testing.assert_frame_equal(m.generators_t.p, network_mi.generators_t.p)
 
 
-def test_csv_io(network_mi, tmpdir):
+def test_csv_io_multiindexed(network_mi, tmpdir):
     fn = os.path.join(tmpdir, "csv_export")
     network_mi.export_to_csv_folder(fn)
     m = pypsa.Network(fn)
     pd.testing.assert_frame_equal(m.generators_t.p, network_mi.generators_t.p)
 
 
-def test_hdf5_io(network_mi, tmpdir):
+def test_hdf5_io_multiindexed(network_mi, tmpdir):
     fn = os.path.join(tmpdir, "hdf5_export.h5")
     network_mi.export_to_hdf5(fn)
     m = pypsa.Network(fn)

--- a/test/test_multiinvest.py
+++ b/test/test_multiinvest.py
@@ -242,7 +242,7 @@ def test_simple_network_storage_noncyclic_per_period(n_sus):
     soc_initial = (n_sus.storage_units_t.state_of_charge + n_sus.storage_units_t.p).loc[
         idx[:, 0], :
     ]
-    soc_initial = soc_initial.droplevel("snapshot")
+    soc_initial = soc_initial.droplevel("timestep")
     assert soc_initial.loc[2020, "sto1-2020"] == 200
     assert soc_initial.loc[2030, "sto1-2020"] == 200
     assert soc_initial.loc[2040, "sto1-2040"] == 200
@@ -295,7 +295,7 @@ def test_simple_network_store_noncyclic(n_sts):
     assert (n_sts.stores_t.p.loc[[2050], "sto1-2020"] == 0).all()
 
     e_initial = (n_sts.stores_t.e + n_sts.stores_t.p).loc[idx[:, 0], :]
-    e_initial = e_initial.droplevel("snapshot")
+    e_initial = e_initial.droplevel("timestep")
     assert e_initial.loc[2020, "sto1-2020"] == 20
 
 
@@ -311,7 +311,7 @@ def test_simple_network_store_noncyclic_per_period(n_sts):
     assert (n_sts.stores_t.p.loc[[2050], "sto1-2020"] == 0).all()
 
     e_initial = (n_sts.stores_t.e + n_sts.stores_t.p).loc[idx[:, 0], :]
-    e_initial = e_initial.droplevel("snapshot")
+    e_initial = e_initial.droplevel("timestep")
     assert e_initial.loc[2020, "sto1-2020"] == 20
     assert e_initial.loc[2030, "sto1-2020"] == 20
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

* The snapshot levels of a multi-indexed snapshot were renamed to ['period', 'timestep'], the name of the index was set to 'snapshot'. This makes the snapshot name coherent for single and multi-indexed snapshots.

* A new convenience function `Network.get_committable_i` was added. This returns an index containing all committable assets of component `c`. In case that component `c` does not support committable assets, it returns an empty dataframe.    

* This also fixes the naming of the test functions io test_io.py. Before, two functions were skipped in the test due to repeated function names. 


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
