### PR TITLE
Minor hac clustering fixes

### DIFF
--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -575,7 +575,7 @@ def busmap_by_hac(network, n_clusters, buses_i=None, branch_components=None, fea
 
     buses_x = network.buses.index.get_indexer(buses_i)
 
-    A = network.adjacency_matrix(branch_components=["Line", "Link"]).tocsc()[buses_x][:, buses_x]
+    A = network.adjacency_matrix(branch_components=branch_components).tocsc()[buses_x][:, buses_x]
 
     labels = HAC(n_clusters=n_clusters,
                  connectivity=A,

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -547,7 +547,7 @@ def busmap_by_hac(network, n_clusters, buses_i=None, branch_components=None, fea
     Returns
     -------
     busmap : pandas.Series
-        Mapping of network.buses to k-means clusters (indexed by
+        Mapping of network.buses to clusters (indexed by
         non-negative integers).
     """
 


### PR DESCRIPTION
Thank you for adding the new HAC clustering method!

Noticed two minor issues:
- The docstring of the busmap_by_hac function probably should not mention k-means in the description of the return value.
- Hardcoded branch_components instead of using the kwarg.