### PR TITLE
Add warning message for links

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -15,6 +15,8 @@ Upcoming Release
 
 * A new convenience function `Network.get_committable_i` was added. This returns an index containing all committable assets of component `c`. In case that component `c` does not support committable assets, it returns an empty dataframe.    
 
+* A warning message is shown if a network contains one or more links with an :code:`efficiency` smaller than 1 and a negative value for :code:`p_min_pu` [`#320 <https://github.com/PyPSA/PyPSA/pull/320>`_].
+
 * add new features here
 
 

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -995,6 +995,14 @@ def define_nodal_balances(network,snapshots):
 
     efficiency = get_switchable_as_dense(network, 'Link', 'efficiency', snapshots)
 
+    filter = (
+        (get_switchable_as_dense(network, 'Link', 'p_min_pu', snapshots) < 0) &
+        (efficiency < 1)
+    )
+    links = filter[filter].dropna(how='all', axis=1)
+    if links.size > 0:
+        logger.warning("Some bidirectional links have efficiency values lower than 1: '" + "', '".join(links) + "'.")
+
     for cb in network.links.index:
         bus0 = network.links.at[cb,"bus0"]
         bus1 = network.links.at[cb,"bus1"]


### PR DESCRIPTION
Closes #319 

## Changes proposed in this Pull Request
Send a warning to the user, in case bidirectional links have efficiency values smaller than 1. Even if it can be expected from the user, to know what equations are implemented for links in the LP, this warning message might be helpful in case the specification was simply unintended.

Please let me know, if this is an addition you would like to integrate and if so, if it is the correct place to do so. In that case, I would update the `doc/release_notes.rst` as well.

Thanks, have a nice day :)

## Checklist

- <del>Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`</del>.
- <del>Unit tests for new features were added (if applicable)</del>.
- <del>Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable)</del>.
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
