### PR TITLE
bug fix length mismatch error

### DIFF
--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -210,7 +210,7 @@ def aggregatelines(network, buses, interlines, line_length_factor=1.0, with_time
             df_agg = df.loc[:, lines_agg_b.index]
             if not df_agg.empty:
                 if (attr == 's_max_pu') or (attr == "s_min_pu"):
-                    weighting = network.lines.groupby(linemap).s_nom.transform(_normed)
+                    weighting = network.lines.groupby(linemap).s_nom.apply(_normed)
                     df_agg = df_agg.multiply(weighting.loc[df_agg.columns], axis=1)
                 pnl_df = df_agg.groupby(linemap, axis=1).sum()
                 pnl_df.columns = _flatten_multiindex(pnl_df.columns).rename("name")


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Replace pandas function "transform" by "apply". In pandas versions < 1.3.0 the transform method causes a length mismatch error. Functionality of transform and apply is the same for the given use case. 


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
