### PR TITLE
networkclustering: remove sklean.cluster.kmeans 1.0 deprecation warning

### DIFF
--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -470,8 +470,8 @@ def busmap_by_kmeans(network, bus_weightings, n_clusters, buses_i=None, ** kwarg
 
     kmeans.fit(points)
 
-    busmap = pd.Series(data=kmeans.predict(network.buses.loc[buses_i, ["x","y"]]),
-                        index=buses_i).astype(str)
+    busmap = pd.Series(data=kmeans.predict(network.buses.loc[buses_i, ["x","y"]].values),
+                       index=buses_i).astype(str)
 
     return busmap
 
@@ -608,7 +608,7 @@ def busmap_by_hac(network, n_clusters, buses_i=None, branch_components=None, fea
 
     return busmap
 
-def hac_clustering(network, n_clusters, buses_i=None, branch_components=["Line", "Link"], feature=None,
+def hac_clustering(network, n_clusters, buses_i=None, branch_components=None, feature=None,
                    affinity='euclidean', linkage='ward', line_length_factor=1.0, **kwargs):
     """
     Cluster the network using Hierarchical Agglomerative Clustering.


### PR DESCRIPTION
sorry for opening a new PR so shortly before the new release, but when checking functionality of other PRs regarding network clustering, this deprecation warning just drove me crazy (appears for every country when applying the clustering in pypsa-eur). we can also include it in a later release, if more convenient for you.
the deprecation is new in the 1.0 release of sklearn, see: https://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html.

it's a small fix. because we don't need the features `.x` and `.y` "feature names", taking the `.values` as darray is good enough and removes the deprecation warning which massively spams the terminal.

in the same go I removed a small bug in the default settings of HAC which were inconsistent with another function.
