### PR TITLE
linopf: prevent downcasting of int dtype

### DIFF
--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -492,7 +492,7 @@ def define_storage_unit_constraints(n, sns):
                        soc.shift()[~first_active_snapshot], noncyclic_i)
 
     # rhs set e at beginning of optimization horizon for noncyclic
-    rhs = -get_as_dense(n, c, 'inflow', sns).mul(eh)
+    rhs = -get_as_dense(n, c, 'inflow', sns).mul(eh).astype(float)
 
     rhs[noncyclic_i] = rhs[noncyclic_i].where(~first_active_snapshot,
                                               rhs-n.df(c).state_of_charge_initial, axis=1)
@@ -569,7 +569,7 @@ def define_store_constraints(n, sns):
                        e.shift()[~first_active_snapshot], noncyclic_i)
 
     # rhs set e at beginning of optimization horizon for noncyclic
-    rhs = pd.DataFrame(0, sns, stores_i)
+    rhs = pd.DataFrame(0., sns, stores_i)
 
     rhs[noncyclic_i] = rhs[noncyclic_i].where(~first_active_snapshot, -n.df(c).e_initial, axis=1)
 
@@ -877,7 +877,7 @@ def prepare_lopf(n, snapshots=None, keep_files=False, skip_objective=False,
     n.bounds_f = open(bounds_fn, mode='w')
     n.binaries_f = open(binaries_fn, mode='w')
 
-    n.objective_f.write('\* LOPF *\n\nmin\nobj:\n')
+    n.objective_f.write("\* LOPF *\n\nmin\nobj:\n")
     n.constraints_f.write("\n\ns.t.\n\n")
     n.bounds_f.write("\nbounds\n")
     n.binaries_f.write("\nbinary\n")


### PR DESCRIPTION
This addresses a warning that comes up when running pytest

