### PR TITLE
pypsa/plot.py: do not plot buses with zero size

### DIFF
--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -230,7 +230,7 @@ def plot(n, margin=None, ax=None, geomap=True, projection=None,
             c = c.apply(lambda cval: bus_cmap(norm(cval)))
 
         patches = []
-        for b_i in s.index:
+        for b_i in s.index[s != 0]:
             radius = s.at[b_i]**0.5
             patches.append(Circle((x.at[b_i], y.at[b_i]), radius,
                                    facecolor=c.at[b_i], alpha=bus_alpha))


### PR DESCRIPTION
This is a small optimisation to speed up plotting of large networks if only some nodes need to be plotted. Instead of adding a lot of patches with zero radius, just skip the corresponding buses.

In a network with a few thousand nodes of which I need to plot only some, this reduces the plotting time from 4-5 seconds to a fraction of a second.