### PR TITLE
linopf: fix ramp limits for rolling horizons

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -36,6 +36,7 @@ Upcoming Release
 
 * Combatibility with pandas 1.4.
 
+* When performing a `lopf` with ``pyomo=False``, the ramp limits did not take the time step right before the optimization horizon into account (relevant for rolling horizon optimization). This is now fixed.  
 
 PyPSA 0.18.1 (15th October 2021)
 ================================

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -390,10 +390,11 @@ def linexpr(*tuples, as_pandas=True, return_axes=False):
     expr = np.repeat('', np.prod(shape)).reshape(shape).astype(object)
     if np.prod(shape):
         for coeff, var in tuples:
-            expr = expr + _str_array(coeff) + ' x' + _str_array(var, True) + '\n'
+            newexpr = _str_array(coeff) + ' x' + _str_array(var, True) + '\n'
             if isinstance(expr, np.ndarray):
                 isna = np.isnan(coeff) | np.isnan(var) | (var == -1)
-                expr = np.where(isna, '', expr)
+                newexpr = np.where(isna, '', newexpr)
+            expr = expr + newexpr
     if return_axes:
         return (expr, *axes)
     if as_pandas:
@@ -657,8 +658,8 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     --options_file arg 	File containing HiGHS options.
     -h, --help 	        Print help.
 
-    2) The options_file.txt gives some more options, see a full list here: 
-    https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.set 
+    2) The options_file.txt gives some more options, see a full list here:
+    https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.set
     By default, we insert a couple of options for the ipm solver. The dictionary
     can be overwritten by simply giving the new values. For instance, you could
     write a dictionary replacing some of the default values or adding new options:
@@ -679,7 +680,7 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     status : string,
         "ok" or "warning"
     termination_condition : string,
-        Contains "optimal", "infeasible", 
+        Contains "optimal", "infeasible",
     variables_sol : series
     constraints_dual : series
     objective : float
@@ -755,7 +756,7 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
     f = open(solution_fn, "rb")
     trimed_sol_fn = re.sub(rb'\*\*\s+', b'', f.read())
     f.close()
-    
+
     sol = pd.read_csv(io.BytesIO(trimed_sol_fn), header=[1], sep=r'\s+')
     row_no = sol[sol["Index"] == 'Rows'].index[0]
     sol = sol.drop(row_no+1)  # Removes header line after "Rows"

--- a/test/test_lopf_rolling_horizon.py
+++ b/test/test_lopf_rolling_horizon.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Feb 10 19:08:25 2022
+
+@author: fabian
+"""
+
+import pypsa
+import pandas as pd
+import numpy as np
+import pytest
+
+solver_name = "glpk"
+
+
+@pytest.mark.parametrize("pyomo", [True, False])
+@pytest.mark.parametrize("committable", [True, False])
+def test_rolling_horizon(pyomo, committable):
+    n = pypsa.Network(snapshots=range(12))
+
+    n.add("Bus", "bus")
+
+    n.add("Generator", "coal",
+        bus="bus",
+        ramp_limit_up=0.1,
+        ramp_limit_down=0.3,
+        marginal_cost=20,
+        capital_cost=200,
+        p_nom=1000,
+        committable=committable
+        )
+
+    n.add("Generator", "gas",
+        bus="bus",
+        ramp_limit_up=0.5,
+        ramp_limit_down=0.5,
+        marginal_cost=40,
+        capital_cost=200,
+        p_nom=1000,
+        committable=committable
+        )
+
+
+    n.add("Load", "load",
+        bus="bus",
+        p_set=[400,600,500,800] * 3)
+
+    # now rolling horizon
+    for sns in np.array_split(n.snapshots, 4):
+        status, condition = n.lopf(sns, solver_name=solver_name, pyomo=pyomo)
+        assert status == 'ok'
+
+    ramping = n.generators_t.p.diff().fillna(0)
+    assert (ramping <= n.generators.eval('ramp_limit_up * p_nom_opt')).all().all()
+    assert (ramping >= -n.generators.eval('ramp_limit_down * p_nom_opt')).all().all()


### PR DESCRIPTION
This is a quiet important bug fix: 

When performing a `lopf` with ``pyomo=False``, the ramp limits did not take the time step right before the optimization horizon into account (relevant for rolling horizon optimization). This is now fixed. 


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
