### PR TITLE
Hotfix of #360

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,7 +7,10 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
-* new features will be added here
+**Bugs and Compatibility**
+
+* When setting ramp limits for links and calling ``Network.lopf`` with ``pyomo=False``, an unexpected KeyError was raised. This was fixed by correctly accessing the data frame referring to the power dispatch of links.   
+
 
 PyPSA 0.19.0 (11th February 2022)
 =================================

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -251,7 +251,10 @@ def define_ramp_limit_constraints(n, sns, c):
 
     # Check if ramping is not at start of n.snapshots
     start_i = n.snapshots.get_loc(sns[0]) - 1
-    p_prev_fix = n.pnl(c)['p'].iloc[start_i]
+    pnl = n.pnl(c)
+    # get dispatch for either one or two ports
+    attr = ({'p', 'p0'} & set(pnl)).pop()
+    p_prev_fix = pnl[attr].iloc[start_i]
     is_rolling_horizon = (sns[0] != n.snapshots[0]) and not p_prev_fix.empty
 
     if is_rolling_horizon:


### PR DESCRIPTION
Closes #360

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
