### PR TITLE
Fix broken link to pypsa.linopt.join_exprs() method

### DIFF
--- a/doc/optimal_power_flow.rst
+++ b/doc/optimal_power_flow.rst
@@ -652,7 +652,7 @@ All variable and constraint references are stored in the network object itself, 
 
 * :py:meth:`pypsa.linopt.get_var` for getting the variables which should be included in the constraint.
 * :py:meth:`pypsa.linopt.linexpr` for creating linear expressions for the left hand side (lhs) of the constraint. Note that only the lhs includes all terms with variables, the rhs is a constant.
-* :py:meth:`pypsa.linopt.join_expr` for summing linear expressions.
+* :py:meth:`pypsa.linopt.join_exprs` for summing linear expressions.
 * :py:meth:`pypsa.linopt.define_constraints` for defining a network constraint.
 
 Once the problem has been built, all names of variable sets are stored in ``n.variables`` and all names of constraint sets in ``n.constraints``.


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Fix typo in link

## Checklist

- <del>Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.</del>
- <del>Unit tests for new features were added (if applicable).</del>
- <del>Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).</del>
- <del>A note for the release notes `doc/release_notes.rst` of the upcoming release is included.</del>
- [x] I consent to the release of this PR's code under the MIT license.
