### PR TITLE
linopt: use .loc for assigning new rows and columns in pd.DataFrame

### DIFF
--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -445,7 +445,7 @@ def join_exprs(df):
 def _add_reference(ref_dict, df, attr, pnl=True):
     if pnl:
         if attr in ref_dict.pnl:
-            ref_dict.pnl[attr][df.columns] = df
+            ref_dict.pnl[attr].loc[df.index, df.columns] = df
         else:
             ref_dict.pnl[attr] = df
     else:
@@ -613,7 +613,7 @@ def run_and_read_highs(n, problem_fn, solution_fn, solver_logfile,
 
     Notes
     -----
-    
+
     The script might only work for version HiGHS 1.1.1. Installation steps::
         sudo apt-get install cmake  # if not installed
         git clone git@github.com:ERGO-Code/HiGHS.git


### PR DESCRIPTION
The new pandas version 1.4 throws out a PerformanceWarning  

```
.../pypsa/linopt.py:448: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`
```
Using `.loc` instead of the standard column setter suppresses the warning. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
