### PR TITLE
Discrete investment

### DIFF
--- a/pypsa/component_attrs/generators.csv
+++ b/pypsa/component_attrs/generators.csv
@@ -29,6 +29,9 @@ ramp_limit_up,float,per unit,NaN,"Maximum active power increase from one snapsho
 ramp_limit_down,float,per unit,NaN,"Maximum active power decrease from one snapshot to the next, per unit of the nominal power. Ignored if NaN.",Input (optional)
 ramp_limit_start_up,float,per unit,1,"Maximum active power increase at start up, per unit of the nominal power.   Only read if committable is True.",Input (optional)
 ramp_limit_shut_down,float,per unit,1,"Maximum active power decrease at shut down, per unit of the nominal power.   Only read if committable is True.",Input (optional)
+buildable,boolean,n/a,False,"Discrete build decision (only possible if p_nom is not extendable).",Input (optional)
+retirable,boolean,n/a,False,"Can be retired before lifetime (only meaningful for end of multi investment)",Input (optional)
+fom_cost,float,currency/MW,0,"Saved operation and maintenance per year and capacity at early retirement",Input (optional)
 p,series,MW,0,active power at bus (positive if net generation),Output
 q,series,MVar,0,reactive power (positive if net generation),Output
 p_nom_opt,float,MW,0,Optimised nominal power.,Output

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -311,6 +311,25 @@ def get_non_extendable_i(n, c):
     """
     return n.df(c)[lambda ds: ~ds[nominal_attrs[c] + '_extendable']].index
 
+def get_buildable_i(n, c):
+    """
+    Getter function. Get the index of buildable elements of a given component.
+    """
+    if "buildable" not in n.df(c):
+        idx = pd.Index([])
+    else:
+        idx = n.df(c)[lambda ds: ds['buildable']].index
+    return idx.rename(f'{c}-bld')
+
+def get_retirable_i(n, c):
+    """
+    Getter function. Get the index of retirable elements of a given component.
+    """
+    if "retirable" not in n.df(c) or not n._multi_invest:
+        idx = pd.Index([])
+    else:
+        idx = n.df(c)[lambda ds: ds['retirable']].index
+    return idx.rename(f'{c}-ret')
 
 def get_committable_i(n, c):
     """

--- a/pypsa/opt.py
+++ b/pypsa/opt.py
@@ -29,7 +29,7 @@ from pyomo.core.base.constraint import _GeneralConstraintData
 
 import pyomo
 from contextlib import contextmanager
-from six.moves import cPickle as pickle
+import pickle
 import gc, os, tempfile
 
 

--- a/pypsa/variables.csv
+++ b/pypsa/variables.csv
@@ -1,7 +1,9 @@
 component,variable,marginal_cost,nominal,handle_separately
 Generator,p,True,False,False
-Generator,status,False,False,True
 Generator,p_nom,False,True,False
+Generator,status,False,False,True
+Generator,built,False, False,True
+Generator,nonretired,False,False,True
 Line,s,False,False,False
 Line,s_nom,False,True,False
 Transformer,s,False,False,False


### PR DESCRIPTION
Alternative to #371.

## Changes proposed in this Pull Request

Extends lowmem lopf for generators by 3 new attributes:

- `buildable`
- `retirable`
- `fom_cost`

`buildable` allows a fixed capacity power plant to be built as proposed or not. `retirable` allows a fixed capacity power plant to be retired before the actual lifetime, salvaging fom_cost * years of early retirement.

This is an untested draft.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
