### PR TITLE
Deprecate n.lopf(pyomo=True) default in favour of n.lopf(pyomo=False)

### DIFF
--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -620,6 +620,11 @@ class Network(Basic):
         pyomo : bool, default True
             Whether to use pyomo for building and solving the model, setting
             this to False saves a lot of memory and time.
+
+            .. deprecated:: 0.20
+  
+               In PyPSA version 0.21 the default will change to ``pyomo=False``.
+
         solver_name : string
             Must be a solver name that pyomo recognises and that is
             installed, e.g. "glpk", "gurobi"
@@ -730,6 +735,10 @@ class Network(Basic):
             )
 
         if pyomo:
+            logger.warning(
+                "Solving optimisation problem with pyomo."
+                "In PyPSA version 0.21 the default will change to ``n.lopf(pyomo=False)``"
+            )
             return network_lopf(self, **args)
         else:
             return network_lopf_lowmem(self, **args)

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -737,7 +737,8 @@ class Network(Basic):
         if pyomo:
             logger.warning(
                 "Solving optimisation problem with pyomo."
-                "In PyPSA version 0.21 the default will change to ``n.lopf(pyomo=False)``"
+                "In PyPSA version 0.21 the default will change to ``n.lopf(pyomo=False)``."
+                "Explicitly set ``n.lopf(pyomo=True)`` to retain current behaviour."
             )
             return network_lopf(self, **args)
         else:

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -409,6 +409,11 @@ def network_sclopf(
     pyomo : bool, default True
         Whether to use pyomo for building and solving the model, setting
         this to False saves a lot of memory and time.
+
+        .. deprecated:: 0.20
+
+            In PyPSA version 0.21 the default will change to ``pyomo=False``.
+
     skip_pre : bool, default False
         Skip the preliminary steps of computing topology, calculating
         dependent values and finding bus controls.


### PR DESCRIPTION
## Changes proposed in this Pull Request

Deprecate `n.lopf(pyomo=True)` default in favour of `n.lopf(pyomo=False)`.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- ~[ ] Unit tests for new features were added (if applicable).~
- ~[] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).~
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
