### PR TITLE
fix indexing when iterating over subnetworks components

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,9 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* When iterating over components of a Subnetwork, only a those assets are included in the dataframes which are included in the subnetwork.
+
+
 PyPSA 0.19.3 (22nd April 2022)
 ==============================
 

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -1625,6 +1625,10 @@ class SubNetwork(Common):
         for c in self.network.iterate_components(
             components=components, skip_empty=False
         ):
-            c = Component(*c[:-1], ind=getattr(self, c.list_name + "_i")())
-            if not (skip_empty and len(c.ind) == 0):
+            ind = getattr(self, c.list_name + "_i")()
+            pnl = Dict()
+            for k, v in c.pnl.items():
+                pnl[k] = v[ind.intersection(v.columns)]
+            c = Component(c.name, c.list_name, c.attrs, c.df.loc[ind], pnl, ind)
+            if not (skip_empty and len(ind) == 0):
                 yield c

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -1622,6 +1622,24 @@ class SubNetwork(Common):
         return self.network.storage_units.loc[self.storage_units_i()]
 
     def iterate_components(self, components=None, skip_empty=True):
+        """
+        Iterate over components of the subnetwork and extract corresponding
+        data.
+
+        Parameters
+        ----------
+        components : list-like, optional
+            List of components ('Generator', 'Line', etc.) to iterate over,
+            by default None
+        skip_empty : bool, optional
+            Whether to skip a components with no assigned assets,
+            by default True
+
+        Yields
+        ------
+        Component
+            Container for component data. See Component class for details.
+        """
         for c in self.network.iterate_components(
             components=components, skip_empty=False
         ):

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -110,7 +110,7 @@ def _calculate_controllable_nodal_power_balance(
             c_n_set = get_switchable_as_dense(
                 network, c.name, n + "_set", snapshots, c.ind
             )
-            c.pnl[n].loc[snapshots, c.ind] = c_n_set
+            network.pnl(c.name)[n].loc[snapshots, c.ind] = c_n_set
 
         # set the power injection at each node from controllable components
         network.buses_t[n].loc[snapshots, buses_o] = sum(
@@ -783,10 +783,10 @@ def sub_network_pf(
     for c in sub_network.iterate_components(network.passive_branch_components):
         s0t = s0.loc[:, c.name]
         s1t = s1.loc[:, c.name]
-        c.pnl.p0.loc[snapshots, s0t.columns] = s0t.values.real
-        c.pnl.q0.loc[snapshots, s0t.columns] = s0t.values.imag
-        c.pnl.p1.loc[snapshots, s1t.columns] = s1t.values.real
-        c.pnl.q1.loc[snapshots, s1t.columns] = s1t.values.imag
+        network.pnl(c.name).p0.loc[snapshots, s0t.columns] = s0t.values.real
+        network.pnl(c.name).q0.loc[snapshots, s0t.columns] = s0t.values.imag
+        network.pnl(c.name).p1.loc[snapshots, s1t.columns] = s1t.values.real
+        network.pnl(c.name).q1.loc[snapshots, s1t.columns] = s1t.values.imag
 
     s_calc = np.empty((len(snapshots), len(buses_o)), dtype=complex)
     for i in np.arange(len(snapshots)):
@@ -1531,7 +1531,7 @@ def sub_network_lpf(sub_network, snapshots=None, skip_pre=False):
     # allow all one ports to dispatch as set
     for c in sub_network.iterate_components(network.controllable_one_port_components):
         c_p_set = get_switchable_as_dense(network, c.name, "p_set", snapshots, c.ind)
-        c.pnl.p.loc[snapshots, c.ind] = c_p_set
+        network.pnl(c.name).p.loc[snapshots, c.ind] = c_p_set
 
     # set the power injection at each node
     network.buses_t.p.loc[snapshots, buses_o] = sum(
@@ -1574,8 +1574,8 @@ def sub_network_lpf(sub_network, snapshots=None, skip_pre=False):
 
         for c in sub_network.iterate_components(network.passive_branch_components):
             f = flows.loc[:, c.name]
-            c.pnl.p0.loc[snapshots, f.columns] = f
-            c.pnl.p1.loc[snapshots, f.columns] = -f
+            network.pnl(c.name).p0.loc[snapshots, f.columns] = f
+            network.pnl(c.name).p1.loc[snapshots, f.columns] = -f
 
     if network.sub_networks.at[sub_network.name, "carrier"] == "DC":
         network.buses_t.v_mag_pu.loc[snapshots, buses_o] = 1 + v_diff


### PR DESCRIPTION
Closes #380 

Some of the `pf.py` code had to be adjusted where data was assigned to the network dataframes. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
