### PR TITLE
Feature solver options handler

### DIFF
--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -640,7 +640,7 @@ def _solver_options_handler(options):
         return {}
     elif isinstance(options, dict):
         return options
-    else:
+    elif isinstance(options, str):
         logger.info('Solver options can have dictionary type.')
         if isinstance(options, str):
             s = options.split(' ')
@@ -649,6 +649,9 @@ def _solver_options_handler(options):
                 return optionsdict
             else:
                 raise Exception(f'Could not convert solver options string {options} to dictionary. Please keep key:value format. Fill value with empty string if necessary.')
+    else:
+        raise Exception(f'Solver option type not understood, got {options}. Type can be dict (preferred), or string separated by one space.')
+        
 
 def run_and_read_highs(
     n,

--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -37,7 +37,6 @@ import os
 import re
 import subprocess
 from importlib.util import find_spec
-from tkinter import Y
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
I updated the solver options - as far as I understand the functions in linopt are for pyomo=False only. Cbc and glpk expected a string although checking for empty dict. I removed some checks for None type, since now an empty dict would be returned by the handler.

I could not thoroughly check all cases since I only have cbc on this computer! I did also not push a test specific to cbc - how would tests be set up for specific solvers since not everyone has them?

Best, Andreas