### PR TITLE
Update links.csv

### DIFF
--- a/pypsa/component_attrs/links.csv
+++ b/pypsa/component_attrs/links.csv
@@ -7,10 +7,10 @@ carrier,"string","n/a","","Energy carrier transported by the link: can be ""DC""
 efficiency,static or series,per unit,1,Efficiency of power transfer from bus0 to bus1. (Can be time-dependent to represent temperature-dependent Coefficient of Performance of a heat pump from an electric to a heat bus.),Input (optional)
 build_year,int,year,0,build year,Input (optional)
 lifetime,float,years,inf,lifetime,Input (optional)
-p_nom,float,MVA,0,Limit of active power which can pass through link.,Input (optional)
+p_nom,float,MW,0,Limit of active power which can pass through link.,Input (optional)
 p_nom_extendable,boolean,n/a,False,Switch to allow capacity p_nom to be extended in OPF.,Input (optional)
-p_nom_min,float,MVA,0,"If p_nom is extendable in OPF, set its minimum value.",Input (optional)
-p_nom_max,float,MVA,inf,"If p_nom is extendable in OPF, set its maximum value (e.g. limited by potential).",Input (optional)
+p_nom_min,float,MW,0,"If p_nom is extendable in OPF, set its minimum value.",Input (optional)
+p_nom_max,float,MW,inf,"If p_nom is extendable in OPF, set its maximum value (e.g. limited by potential).",Input (optional)
 p_set,static or series,MW,0,The dispatch set point for p0 of the link in PF.,Input (optional)
 p_min_pu,static or series,per unit of p_nom,0,Minimal dispatch (can also be negative) per unit of p_nom for the link in OPF.,Input (optional)
 p_max_pu,static or series,per unit of p_nom,1,Maximal dispatch (can also be negative) per unit of p_nom for the link in OPF.,Input (optional)
@@ -22,7 +22,7 @@ ramp_limit_up,float,per unit,NaN,"Maximum active power increase from one snapsho
 ramp_limit_down,float,per unit,NaN,"Maximum active power decrease from one snapshot to the next, per unit of the nominal power. Ignored if NaN.",Input (optional)
 p0,series,MW,0,Active power at bus0 (positive if branch is withdrawing power from bus0).,Output
 p1,series,MW,0,Active power at bus1 (positive if branch is withdrawing power from bus1).,Output
-p_nom_opt,float,MVA,0,Optimised capacity for active power.,Output
-mu_lower,series,currency/MVA,0,Shadow price of lower p_nom limit  -F \leq f. Always non-negative.,Output
-mu_upper,series,currency/MVA,0,Shadow price of upper p_nom limit f \leq F. Always non-negative.,Output
+p_nom_opt,float,MW,0,Optimised capacity for active power.,Output
+mu_lower,series,currency/MW,0,Shadow price of lower p_nom limit  -F \leq f. Always non-negative.,Output
+mu_upper,series,currency/MW,0,Shadow price of upper p_nom limit f \leq F. Always non-negative.,Output
 mu_p_set,series,currency/MWh,0,Shadow price of fixed power transmission p_set,Output


### PR DESCRIPTION
Changing units for active power from MVA to MW

Closes #402  (if applicable).

## Changes proposed in this Pull Request
Changing units for active power from MVA to MW of the following attributes:
-p_nom
- p_nom_min
- p_nom_max
- p_nom_opt
- mu_lower
- mu_upper

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
