### PR TITLE
restore compatibility for pyomo 6.4.1

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -50,6 +50,7 @@ Upcoming Release
         legend_kw=dict(frameon=False, bbox_to_anchor=(1,0.1))
     )
 
+* Compatibility with pyomo 6.4.1.
 
 PyPSA 0.19.3 (22nd April 2022)
 ==============================

--- a/pypsa/opt.py
+++ b/pypsa/opt.py
@@ -195,7 +195,7 @@ def l_constraint(model, name, constraints, *args):
 
     setattr(model, name, Constraint(*args, noruleinit=True))
     v = getattr(model, name)
-    for i in v._index:
+    for i in v._index_set:
         c = constraints[i]
         if isinstance(c, LConstraint):
             variables = c.lhs.variables + [


### PR DESCRIPTION
Closes #405.

## Changes proposed in this Pull Request

Access index via `v._index_set` rather than `v._index`.

This fix has been tested with pyomo 5.7.0 (lower bound in environment.yaml), 6.4.0 (last working version) and 6.4.1 (newest version)
