### PR TITLE
plot script: fix keyword error in bus sizes

### DIFF
--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -256,7 +256,7 @@ def plot(
             bus_sizes = bus_sizes * projected_area_factor(ax, n.srid) ** 2
 
         patches = []
-        for b_i in bus_sizes.index.levels[0]:
+        for b_i in bus_sizes.index.unique(level=0):
             s = bus_sizes.loc[b_i]
             radius = s.sum() ** 0.5
             if radius == 0.0:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Small fix in the PyPSA plotting script for the networks. Pandas threw a keyword error when iterating through the index of a series and calling the index afterwards (guess that comes from a Pandas bug). 


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] I consent to the release of this PR's code under the MIT license.
