### PR TITLE
pandas deprecation: set to list when calling .loc[]

### DIFF
--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -954,7 +954,7 @@ def busmap_by_greedy_modularity(network, n_clusters, buses_i=None):
     )
     busmap = pd.Series(buses_i, buses_i)
     for c in np.arange(len(communities)):
-        busmap.loc[communities[c]] = str(c)
+        busmap.loc[list(communities[c])] = str(c)
     busmap.index = busmap.index.astype(str)
 
     return busmap


### PR DESCRIPTION
small deprecation fix as pandas won't support calling `.loc[]` with a set in the future. must be a list instead.