### PR TITLE
Aggregation of per unit timeseries of one port components 

### DIFF
--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -175,15 +175,24 @@ def aggregateoneport(
     new_df.index = _flatten_multiindex(new_df.index).rename("name")
 
     new_pnl = dict()
+    def normed_or_uniform(x):
+        return x/x.sum() if x.sum(skipna=False) > 0 else pd.Series(1./len(x), x.index)
+
+    if "e_nom" in new_df.columns:
+        weighting = old_df.e_nom.groupby(grouper, axis=0).transform(normed_or_uniform)
+    elif "p_nom" in new_df.columns:
+        weighting = old_df.p_nom.groupby(grouper, axis=0).transform(normed_or_uniform)
+
     if with_time:
         old_pnl = network.pnl(component)
         for attr, df in old_pnl.items():
             if not df.empty:
+                if attr in ["e_min_pu", "e_max_pu", "p_min_pu", "p_max_pu"]:
+                    df = df.multiply(weighting.loc[df.columns], axis=1)
                 pnl_df = df.groupby(grouper, axis=1).sum()
                 pnl_df.columns = _flatten_multiindex(pnl_df.columns).rename("name")
                 new_pnl[attr] = pnl_df
     return new_df, new_pnl
-
 
 def aggregatebuses(network, busmap, custom_strategies=dict()):
     attrs = network.components["Bus"]["attrs"]


### PR DESCRIPTION
## Changes proposed in this Pull Request
All time series attributes of one port components are summed up when thy are aggregated in networkclustering.py. From my understanding, all per unit time series should be aggregated using a weighted average considering the installed capacities. It is also done like this for other components. 
I adjusted the aggregation of one port time series accordingly in this branch. I am looking forward to your feedback.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
