### PR TITLE
Proposed fix to issue #436

### DIFF
--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -433,6 +433,7 @@ def network_sclopf(
     """
 
     if not skip_pre:
+        network.calculate_dependent_values()
         network.determine_network_topology()
 
     snapshots = _as_snapshots(network, snapshots)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,7 +15,7 @@ import pytest
 import pypsa
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def scipy_network():
     csv_folder = os.path.join(
         os.path.dirname(__file__),

--- a/test/test_sclopf_scigrid.py
+++ b/test/test_sclopf_scigrid.py
@@ -3,11 +3,13 @@
 import numpy as np
 from numpy.testing import assert_almost_equal as equal
 from numpy.testing import assert_array_almost_equal as arr_equal
+import pytest
 
 solver_name = "glpk"
 
 
-def test_sclopf(scipy_network):
+@pytest.mark.parametrize("pyomo", [True, False])
+def test_sclopf_pyomo(scipy_network, pyomo):
     n = scipy_network
 
     # There are some infeasibilities without line extensions
@@ -17,34 +19,29 @@ def test_sclopf(scipy_network):
     # choose the contingencies
     branch_outages = n.lines.index[:2]
 
-    objectives = []
-    for pyomo in [True, False]:
+    n.sclopf(
+        n.snapshots[0],
+        branch_outages=branch_outages,
+        pyomo=pyomo,
+        solver_name=solver_name,
+    )
 
-        n.sclopf(
-            n.snapshots[0],
-            branch_outages=branch_outages,
-            pyomo=pyomo,
-            solver_name=solver_name,
-        )
+    # For the PF, set the P to the optimised P
+    n.generators_t.p_set = n.generators_t.p.copy()
+    n.storage_units_t.p_set = n.storage_units_t.p.copy()
 
-        # For the PF, set the P to the optimised P
-        n.generators_t.p_set = n.generators_t.p.copy()
-        n.storage_units_t.p_set = n.storage_units_t.p.copy()
+    # Check no lines are overloaded with the linear contingency analysis
 
-        # Check no lines are overloaded with the linear contingency analysis
+    p0_test = n.lpf_contingency(n.snapshots[0], branch_outages=branch_outages)
 
-        p0_test = n.lpf_contingency(n.snapshots[0], branch_outages=branch_outages)
+    # check loading as per unit of s_nom in each contingency
 
-        # check loading as per unit of s_nom in each contingency
+    max_loading = (
+        abs(p0_test.divide(n.passive_branches().s_nom, axis=0))
+        .describe()
+        .loc["max"]
+    )
 
-        max_loading = (
-            abs(p0_test.divide(n.passive_branches().s_nom, axis=0))
-            .describe()
-            .loc["max"]
-        )
+    arr_equal(max_loading, np.ones((len(max_loading))), decimal=4)
 
-        arr_equal(max_loading, np.ones((len(max_loading))), decimal=4)
-
-        objectives.append(n.objective)
-
-    equal(*objectives, decimal=1)
+    equal(n.objective, 339758.4578, decimal=1)

--- a/test/test_sclopf_scigrid.py
+++ b/test/test_sclopf_scigrid.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+import pytest
 from numpy.testing import assert_almost_equal as equal
 from numpy.testing import assert_array_almost_equal as arr_equal
-import pytest
 
 solver_name = "glpk"
 
@@ -37,9 +37,7 @@ def test_sclopf_pyomo(scipy_network, pyomo):
     # check loading as per unit of s_nom in each contingency
 
     max_loading = (
-        abs(p0_test.divide(n.passive_branches().s_nom, axis=0))
-        .describe()
-        .loc["max"]
+        abs(p0_test.divide(n.passive_branches().s_nom, axis=0)).describe().loc["max"]
     )
 
     arr_equal(max_loading, np.ones((len(max_loading))), decimal=4)


### PR DESCRIPTION
Closes #436

## Changes proposed in this Pull Request
This pull request fixes a bug in the non-pyomo interface version of sclopf that arises from not having calculated dependent variables before calling `prepare_lopf`.

The fix is a one-line addition of `network.calculate_dependent_values()` to `contingency.py`.

I have also proposed a change to the unit test that missed this bug previously due to being in a loop with the `pyomo=True` version. The proposed change parameterizes the unit test rather than having a for loop inside the test function, _however_ this requires the scope of the `scipy_network` test fixture to be changed to `function` from `module` which I realize may negatively impact the performance of other tests that use it. This change also required me to hard-code the expected value of the objective (previously the test just compared values between pyomo and non-pyomo solutions). I understand if you would prefer not to use a hard-coded value, I just wasn't sure of a more elegant way that maintained the same test coverage.

## Checklist

-  Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
