### PR TITLE
linopf: Allow empty lhs in nodal balance for zero rhs

### DIFF
--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -459,8 +459,6 @@ def define_nodal_balance_constraints(n, sns):
         .reindex(columns=n.buses.index, fill_value="")
     )
 
-    if (lhs == "").any().any():
-        raise ValueError("Empty LHS in nodal balance constraint.")
 
     sense = "="
     rhs = (
@@ -469,7 +467,16 @@ def define_nodal_balance_constraints(n, sns):
         .sum()
         .reindex(columns=n.buses.index, fill_value=0)
     )
-    define_constraints(n, lhs, sense, rhs, "Bus", "marginal_price")
+
+    if (lhs == "").any(axis=None):
+        if ((lhs == "") & (rhs != 0)).any(axis=None):
+            raise ValueError("Empty LHS in nodal balance constraint for non-zero RHS.")
+
+        mask = (lhs != "")
+    else:
+        mask = None
+
+    define_constraints(n, lhs, sense, rhs, "Bus", "marginal_price", mask=mask)
 
 
 def define_kirchhoff_constraints(n, sns):

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -454,17 +454,26 @@ def define_nodal_balance_constraints(n, sns):
     lhs = merge(exprs).reindex(
         Bus=n.buses.index, fill_value=LinearExpression.fill_value
     )
-    if (lhs.vars == -1).all("_term").any():
-        raise ValueError("Empty LHS in nodal balance constraint.")
-
     rhs = (
         (-get_as_dense(n, "Load", "p_set", sns) * n.loads.sign)
         .groupby(n.loads.bus, axis=1)
         .sum()
         .reindex(columns=n.buses.index, fill_value=0)
     )
-    rhs.index.name = "snapshot"  # the name for multi-index is getting lost by groupby
-    n.model.add_constraints(lhs, "=", rhs, "Bus-nodal_balance")
+    # the name for multi-index is getting lost by groupby before pandas 1.4.0
+    # TODO remove once we bump the required pandas version to >= 1.4.0
+    rhs.index.name = "snapshot"  
+    rhs = DataArray(rhs)
+
+    if (empty_nodal_balance := (lhs.vars == -1).all("_term")).any():
+        if (empty_nodal_balance & (rhs != 0)).any().item():
+            raise ValueError("Empty LHS with non-zero RHS in nodal balance constraint.")
+        
+        mask = ~ empty_nodal_balance
+    else:
+        mask = None
+    
+    n.model.add_constraints(lhs, "=", rhs, "Bus-nodal_balance", mask=mask)
 
 
 def define_kirchhoff_voltage_constraints(n, sns):


### PR DESCRIPTION
## Changes proposed in this Pull Request

For multiperiod investment optimisation, it is easy to trigger the `Empty LHS in nodal balance constraint.` exception, since `Bus`es do not have a `build_year`. For example if one models an extendable battery with two links, which have a `build_year` in the future and a bus, then the bus will necessarily be isolated and lead to an all-zero row in the nodal balance constraint matrix part for that bus, which can only be mitigated by add an always present other component to this bus, like a `p_nom=0` non-extendable generator.

In this PR, we instead build a mask that filters out these rows completely.

Implemented for both `linopf` and `linopy`.

## Checklist

- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
