### PR TITLE
add discord reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Examples of use](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PyPSA/PyPSA/master?filepath=examples%2Fnotebooks)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/PyPSA/PyPSA/master.svg)](https://results.pre-commit.ci/latest/github/PyPSA/PyPSA/master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Discord](https://img.shields.io/discord/911692131440148490?logo=discord)](https://discord.gg/AnuJBk23FU)
 
 PyPSA stands for "Python for Power System Analysis". It is pronounced
 "pipes-ah".
@@ -174,6 +175,11 @@ releases can be made and questions can be asked.
 To discuss issues and suggest/contribute features for future development
 we prefer ticketing through the [PyPSA Github Issues
 page](https://github.com/PyPSA/PyPSA/issues).
+
+A `Discord server <https://discord.gg/AnuJBk23FU>` hosts every tool
+in the PyPSA ecosystem. We have there public voice and text channels
+that are suitable to organise projects, ask questions,
+share news, or chat with the community.
 
 ## Citing PyPSA
 

--- a/doc/mailing_list.rst
+++ b/doc/mailing_list.rst
@@ -20,7 +20,7 @@ To discuss issues and suggest/contribute features
 for future development we prefer ticketing through the `PyPSA Github Issues page
 <https://github.com/PyPSA/PyPSA/issues>`_.
 
-A `Discord server <https://discord.gg/AnuJBk23FU>` hosts every tool
+A `Discord server <https://discord.gg/AnuJBk23FU>`_ hosts every tool
 in the PyPSA ecosystem. We have there public voice and text channels
 that are suitable to organise projects, ask questions,
 share news, or chat with the community.

--- a/doc/mailing_list.rst
+++ b/doc/mailing_list.rst
@@ -19,3 +19,8 @@ developers directly, so that others can also profit from the answers.
 To discuss issues and suggest/contribute features
 for future development we prefer ticketing through the `PyPSA Github Issues page
 <https://github.com/PyPSA/PyPSA/issues>`_.
+
+A `Discord server <https://discord.gg/AnuJBk23FU>` hosts every tool
+in the PyPSA ecosystem. We have there public voice and text channels
+that are suitable to organise projects, ask questions,
+share news, or chat with the community.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,7 +11,7 @@ Upcoming Release
   <https://pypsa.readthedocs.io/en/latest/examples/optimization-with-linopy.html>`_ a migration guide for extra functionalities can be found at `here
   <https://pypsa.readthedocs.io/en/latest/examples/optimization-with-linopy-migrate-extra-functionalities.html>`_
 * A new module for a quick calculation of system relevant quantities was introduced. It is directly accessible via the new accessor `Network.statistics` which returns a table of values often calculated manually. At the same time `Network.statistics` allows to call individual functions, as `capex`, `opex`, `capacity_factor` etc.
-* Add reference to `Discord server <https://discord.gg/AnuJBk23FU>` for support and discussion.
+* Add reference to `Discord server <https://discord.gg/AnuJBk23FU>`_ for support and discussion.
 
 
 PyPSA 0.20.1 (6th October 2022)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,7 @@ Upcoming Release
   <https://pypsa.readthedocs.io/en/latest/examples/optimization-with-linopy.html>`_ a migration guide for extra functionalities can be found at `here
   <https://pypsa.readthedocs.io/en/latest/examples/optimization-with-linopy-migrate-extra-functionalities.html>`_
 * A new module for a quick calculation of system relevant quantities was introduced. It is directly accessible via the new accessor `Network.statistics` which returns a table of values often calculated manually. At the same time `Network.statistics` allows to call individual functions, as `capex`, `opex`, `capacity_factor` etc.
+* Add reference to `Discord server <https://discord.gg/AnuJBk23FU>` for support and discussion.
 
 
 PyPSA 0.20.1 (6th October 2022)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Googlegroups remains the preference for PyPSA Q&A.
I just add a link to the Discord server such that people
can also explore this chat platform with all tools in the PyPSA ecosystem. 

## Checklist

- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
