### PR TITLE
statistics: fix groupby default argument

### DIFF
--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -268,7 +268,7 @@ class StatisticsAccessor:
         comps=None,
         aggregate_time="mean",
         aggregate_groups="sum",
-        groupby=get_carrier,
+        groupby=None,
     ):
         """
         Calculate the operational expenditure in the network.
@@ -299,7 +299,7 @@ class StatisticsAccessor:
         comps=None,
         aggregate_time="mean",
         aggregate_groups="sum",
-        groupby=get_carrier,
+        groupby=None,
     ):
         """
         Calculate the supply of components in the network.
@@ -330,7 +330,7 @@ class StatisticsAccessor:
         comps=None,
         aggregate_time="mean",
         aggregate_groups="sum",
-        groupby=get_carrier,
+        groupby=None,
     ):
         """
         Calculate the withdrawal of components in the network.
@@ -361,7 +361,7 @@ class StatisticsAccessor:
         comps=None,
         aggregate_time="mean",
         aggregate_groups="sum",
-        groupby=get_carrier,
+        groupby=None,
     ):
         """
         Calculate the curtailment of components in the network.
@@ -388,7 +388,7 @@ class StatisticsAccessor:
         comps=None,
         aggregate_time="mean",
         aggregate_groups="sum",
-        groupby=get_carrier,
+        groupby=None,
     ):
         """
         Calculate the capacity factor of components in the network.
@@ -419,7 +419,7 @@ class StatisticsAccessor:
         comps=None,
         aggregate_time="mean",
         aggregate_groups="sum",
-        groupby=get_carrier,
+        groupby=None,
     ):
         """
         Calculate the revenue of components in the network.
@@ -455,7 +455,7 @@ class StatisticsAccessor:
         comps=None,
         aggregate_time="mean",
         aggregate_groups="sum",
-        groupby=get_carrier,
+        groupby=None,
     ):
         """
         Calculate the market value of components in the network.

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -182,14 +182,16 @@ class StatisticsAccessor:
         return pd.concat(res, axis=1).sort_index(axis=0).sort_index(axis=1)
 
     def get_carrier(self, c):
+        """
+        Get the buses and nice carrier names for a component.
+        """
         return get_carrier(self._parent, c)
 
-    get_carrier.__doc__ = get_carrier.__doc__
-
     def get_bus_and_carrier(self, c):
+        """
+        Get the buses and nice carrier names for a component.
+        """
         return get_bus_and_carrier(self._parent, c)
-
-    get_bus_and_carrier.__doc__ = get_bus_and_carrier.__doc__
 
     def capex(self, comps=None, aggregate_groups="sum", groupby=None):
         """

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -32,10 +32,10 @@ def test_default_solved(ac_dc_network_r):
     df = ac_dc_network_r.statistics()
     assert not df.empty
 
-    df = ac_dc_network_r.capex()
+    df = ac_dc_network_r.statistics.capex()
     assert not df.empty
 
-    df = ac_dc_network_r.opex()
+    df = ac_dc_network_r.statistics.opex()
     assert not df.empty
 
 

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -32,6 +32,12 @@ def test_default_solved(ac_dc_network_r):
     df = ac_dc_network_r.statistics()
     assert not df.empty
 
+    df = ac_dc_network_r.capex()
+    assert not df.empty
+
+    df = ac_dc_network_r.opex()
+    assert not df.empty
+
 
 def test_per_bus_carrier_unsolved(ac_dc_network):
     df = ac_dc_network.statistics(groupby=get_bus_and_carrier)


### PR DESCRIPTION
Follow up fix to #474. I did not notice that when passing a function as a default, it uses class function not the globally defined.