### PR TITLE
io: speed up import

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,7 +13,7 @@ Upcoming Release
 * A new module for a quick calculation of system relevant quantities was introduced. It is directly accessible via the new accessor `Network.statistics` which returns a table of values often calculated manually. At the same time `Network.statistics` allows to call individual functions, as `capex`, `opex`, `capacity_factor` etc.
 * Add reference to `Discord server <https://discord.gg/AnuJBk23FU>`_ for support and discussion.
 * Restore import of pandapower networks. Issues regarding the transformer component and indexing as well as missing imports for shunts are fixed. [`#332 <https://github.com/PyPSA/PyPSA/pull/332>`_]
-
+* The import performance of networks was improved. With the changes, the import time for standard netcdf imports decreased by roughly 70%.
 
 
 PyPSA 0.20.1 (6th October 2022)

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -489,7 +489,10 @@ class Network(Basic):
             attrs = self.components[component]["attrs"]
 
             for k, default in attrs.default[attrs.varying].items():
-                pnl[k] = pnl[k].reindex(self._snapshots).fillna(default)
+                if pnl[k].empty:  # avoid expensive reindex operation
+                    pnl[k].index = self._snapshots
+                else:
+                    pnl[k] = pnl[k].reindex(self._snapshots, fill_value=default)
 
         # NB: No need to rebind pnl to self, since haven't changed it
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -62,6 +62,12 @@ def test_netcdf_io_multiindexed(ac_dc_network_multiindexed, tmpdir):
     pd.testing.assert_frame_equal(
         m.generators_t.p, ac_dc_network_multiindexed.generators_t.p
     )
+    pd.testing.assert_frame_equal(
+        m.snapshot_weightings,
+        ac_dc_network_multiindexed.snapshot_weightings[
+            m.snapshot_weightings.columns
+        ],  # reset order
+    )
 
 
 def test_csv_io_multiindexed(ac_dc_network_multiindexed, tmpdir):


### PR DESCRIPTION
Some tricks to improve import performance. For pypsa-eur `elec.nc` the import time of 1.7s was brought down to 600ms  

Two additional changes (sorry for mixing this): 

* The warning message for imports of old pypsa networks was written more compact
* The import of hdf5 for pypsa networks < v0.13. is now unsupported 


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
