### PR TITLE
fix broken import with pyomo 6.4.3

### DIFF
--- a/pypsa/opt.py
+++ b/pypsa/opt.py
@@ -28,7 +28,7 @@ from contextlib import contextmanager
 
 from pyomo.core.base.constraint import _GeneralConstraintData
 from pyomo.core.expr.numeric_expr import LinearExpression
-from pyomo.environ import Constraint, Objective, Var, minimize, inequality
+from pyomo.environ import Constraint, Objective, Var, inequality, minimize
 from six.moves import cPickle as pickle
 
 # =============================================================================

--- a/pypsa/opt.py
+++ b/pypsa/opt.py
@@ -27,9 +27,8 @@ import tempfile
 from contextlib import contextmanager
 
 from pyomo.core.base.constraint import _GeneralConstraintData
-from pyomo.core.expr.logical_expr import inequality
 from pyomo.core.expr.numeric_expr import LinearExpression
-from pyomo.environ import Constraint, Objective, Var, minimize
+from pyomo.environ import Constraint, Objective, Var, minimize, inequality
 from six.moves import cPickle as pickle
 
 # =============================================================================


### PR DESCRIPTION
Closes #511  (if applicable).

## Changes proposed in this Pull Request

fix import error by using a less specific import file, which exists in older pyomo versions and the latest version, so that we don't break backwards compatibility.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
