### PR TITLE
Update linopf.py

### DIFF
--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -1013,7 +1013,7 @@ def define_objective(n, sns):
     for c, attr in lookup.query("marginal_cost").index:
         cost = (
             get_as_dense(n, c, "marginal_cost", sns)
-            .loc[:, lambda ds: (ds != 0).all()]
+            .loc[:, lambda ds: (ds != 0).any()]
             .mul(weighting, axis=0)
         )
         if cost.empty:


### PR DESCRIPTION
While using pyomo = False marginal_cost timeseries that had at least one zero value were dropped. Causing problems with powerplants as marginal costs as timeseries.

**Mini-Example:**
**Code:**
<img src="https://user-images.githubusercontent.com/83589894/205034278-7a405acc-03e6-4376-bbf8-549369b403ae.png" width="700"/>

**Output:**
<img src="https://user-images.githubusercontent.com/83589894/205034512-329fc1d1-270c-452f-9dc0-a892261328a8.png" width="200"/>


**File:**
[mini_example_marginal_cost_timeseries.zip](https://github.com/PyPSA/PyPSA/files/10131652/mini_example_marginal_cost_timeseries.zip)

Closes # (if applicable).

## Changes proposed in this Pull Request
replace .all() with .any()

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
