### PR TITLE
Fix linopy implementation of nominal capacity per-bus/carrier constraints

### DIFF
--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -368,7 +368,7 @@ def get_active_assets(n, c, investment_period):
         if period not in n.investment_periods:
             raise ValueError("Investment period not in `network.investment_periods`")
         active[period] = n.df(c).eval("build_year <= @period < build_year + lifetime")
-    return pd.DataFrame(active).any(1)
+    return pd.DataFrame(active).any(axis=1)
 
 
 def get_activity_mask(n, c, sns=None, index=None):

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -59,6 +59,7 @@ def define_nominal_constraints_per_bus_carrier(n, sns):
             period = None
         elif isinstance(n.snapshots, pd.MultiIndex):
             carrier, period = remainder.rsplit("_", 1)
+            period = int(period)
             if carrier not in n.carriers.index or period not in sns.unique("period"):
                 logger.warn(msg)
                 continue

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -35,6 +35,7 @@ from pypsa.optimization.global_constraints import (
     define_growth_limit,
     define_nominal_constraints_per_bus_carrier,
     define_primary_energy_limit,
+    define_tech_capacity_expansion_limit,
     define_transmission_expansion_cost_limit,
     define_transmission_volume_expansion_limit,
 )
@@ -225,6 +226,7 @@ def create_model(
     define_primary_energy_limit(n, sns)
     define_transmission_expansion_cost_limit(n, sns)
     define_transmission_volume_expansion_limit(n, sns)
+    define_tech_capacity_expansion_limit(n, sns)
     define_nominal_constraints_per_bus_carrier(n, sns)
     define_growth_limit(n, sns)
 

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -464,7 +464,7 @@ def test_global_constraint_transmission_cost_limit(n, api):
     assert round(lines.eval("s_nom_opt * capital_cost").sum(), 2) == 1000
 
 
-@pytest.mark.parametrize("api", ["native"])
+@pytest.mark.parametrize("api", ["native", "linopy"])
 def test_global_constraint_bus_tech_limit(n, api):
     n.add(
         "GlobalConstraint",

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -512,6 +512,6 @@ def test_nominal_constraint_bus_carrier_expansion_limit(n, api):
 def test_max_growth_constraint(n, api):
     # test generator grow limit
     gen_carrier = n.generators.carrier.unique()[0]
-    n.add("Carrier", name="gencarrier", max_growth=218)
+    n.carriers.at[gen_carrier, "max_growth"] = 218
     status, cond = optimize(n, api, **kwargs)
     assert all(n.generators.p_nom_opt.groupby(n.generators.build_year).sum() <= 218)


### PR DESCRIPTION

Closes #523 .

## Changes proposed in this Pull Request

The linopy implementation affected one_port_components of all carriers not only the selected. Also the period selection was broken.

This PR fixes those.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
