### PR TITLE
Fix warning for missing max growth implementation in native optimization

### DIFF
--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -740,7 +740,7 @@ def define_growth_limit(n, sns, c, attr):
     if "carrier" not in n.df(c) or n.df(c).empty:
         return
 
-    if n.carriers.max_relative_growth.notnull().any():
+    if (n.carriers.max_relative_growth > 0).any():
         logger.warning(
             "Max relative growth is not implemented for the native pypsa optimization framework. "
             "Use the linopy framework with `n.optimize` instead."

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -224,7 +224,7 @@ def define_growth_limit(n, sns):
         return
 
     lhs = merge(lhs)
-    rhs = max_absolute_growth
+    rhs = max_absolute_growth.reindex_like(lhs)
 
     m.add_constraints(lhs, "<=", rhs, "Carrier-growth_limit")
 


### PR DESCRIPTION
additional: global_constraints: reindex lhs like rhs
