### PR TITLE
plot: apply add artist on figure instead of axis

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,7 +10,7 @@ Upcoming Release
 * The model creation for large (sector-coupled) models was sped up.
 * The colors of borders and coastlines can now be controlled with ``n.plot(color_geomap=dict(border='b', coastline='r'))``.
 * The Xpress solver interface now skips loading a basis if there is an error associated with the basis function and continues without it.
-
+* Plotting multiple legends was fixed for applying tight layout with matplotlib versions >=3.6.
 
 PyPSA 0.22.0 (3rd February 2023)
 ================================

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -507,10 +507,10 @@ def draw_map_cartopy(ax, geomap=True, color_geomap=None):
         color_geomap = {}
     elif not isinstance(color_geomap, dict):
         color_geomap = {
-            "ocean"         : "lightblue",
-            "land"          : "whitesmoke",
-            "border"        : "darkgray",
-            "coastline"     : "black"
+            "ocean": "lightblue",
+            "land": "whitesmoke",
+            "border": "darkgray",
+            "coastline": "black",
         }
 
     if "land" in color_geomap:
@@ -588,7 +588,7 @@ def add_legend_lines(ax, sizes, labels, patch_kw={}, legend_kw={}):
 
     legend = ax.legend(handles, labels, **legend_kw)
 
-    ax.add_artist(legend)
+    ax.get_figure().add_artist(legend)
 
 
 def add_legend_patches(ax, colors, labels, patch_kw={}, legend_kw={}):
@@ -616,7 +616,7 @@ def add_legend_patches(ax, colors, labels, patch_kw={}, legend_kw={}):
 
     legend = ax.legend(handles, labels, **legend_kw)
 
-    ax.add_artist(legend)
+    ax.get_figure().add_artist(legend)
 
 
 def add_legend_circles(ax, sizes, labels, srid=4326, patch_kw={}, legend_kw={}):
@@ -650,7 +650,7 @@ def add_legend_circles(ax, sizes, labels, srid=4326, patch_kw={}, legend_kw={}):
         handles, labels, handler_map={Circle: HandlerCircle()}, **legend_kw
     )
 
-    ax.add_artist(legend)
+    ax.get_figure().add_artist(legend)
 
 
 def _flow_ds_from_arg(flow, n, branch_components):


### PR DESCRIPTION
With recent matplotlib versions the legends drawn by the add_legend functions are cut off when applying a tight layout. Adding the artists to the figure object fixes it. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
