### PR TITLE
Fix IO bug

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,6 @@ dependencies:
 - pytables
 - matplotlib
 - networkx>=1.10
-- linopy
 - pyomo>=5.7.0
 - cartopy>=0.16
 - glpk

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -412,8 +412,8 @@ def _export_to_exporter(network, exporter, basename, export_standard_types=False
         list_name = network.components[component]["list_name"]
         attrs = network.components[component]["attrs"]
 
-        df = network.df(component)
-        pnl = network.pnl(component)
+        df = network.df(component).copy()
+        pnl = network.pnl(component).copy()
 
         if not export_standard_types and component in network.standard_type_components:
             df = df.drop(network.components[component]["standard_types"].index)


### PR DESCRIPTION
Closes # (if applicable).

## Change IO function to avoid renaming of the index
Currently, when exporting a network the index is rename, e.g. for Links index name before export is "`Link`", index after export is "`links_i`". This causes an error in the nodal balance constraint if the network is solved with linopy (`n.optimize)`, if one for example first exports the presolved network and then runs the optimisation in the same script.

In general, export functions should not change the index names or structure of the network.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
