### PR TITLE
Fix-up of "Avoid changing axis names on io exports"

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,6 +8,7 @@ Upcoming Release
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
 * new feature
+* Fixed interference of io routines with linopy optimisation [`#564 <https://github.com/PyPSA/PyPSA/pull/564>`_, `#567 <https://github.com/PyPSA/PyPSA/pull/567>`_]
 
 
 PyPSA 0.22.1 (15th February 2023)

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -346,12 +346,9 @@ if has_xarray:
                 self.ds[list_name + "_" + attr] = df[attr]
 
         def save_series(self, list_name, attr, df):
-            # pd.DataFrame.rename_axis will not set a common name of a multi-index,
-            # therefore we have to work-around. Note that this does not copy data
-            index = df.index.copy()
-            index.name = "snapshots"
-            columns = df.columns.rename(list_name + "_t_" + attr + "_i")
-            df = pd.DataFrame(df, index=index, columns=columns)
+            df = df.rename_axis(
+                index="snapshots", columns=list_name + "_t_" + attr + "_i"
+            )
 
             self.ds[list_name + "_t_" + attr] = df
             if self.least_significant_digit is not None:
@@ -426,7 +423,7 @@ def _export_to_exporter(network, exporter, basename, export_standard_types=False
             df = df.drop(network.components[component]["standard_types"].index)
 
         # first do static attributes
-        df.index.name = "name"
+        df = df.rename_axis(index="name")
         if df.empty:
             exporter.remove_static(list_name)
             continue


### PR DESCRIPTION
Follow-up to #564.

Sorry for the noise.

Did not see that due to
https://github.com/PyPSA/PyPSA/blob/68294f7bd52ae324b87c0d619410fb7449d3fd6a/pypsa/io.py#L410-L411
and
https://github.com/PyPSA/PyPSA/blob/68294f7bd52ae324b87c0d619410fb7449d3fd6a/pypsa/io.py#L469-L470
there are no multi-indices left in the `save_snapshot` and `save_series` methods, so that this can be quite simple.

Also addressed forgotten inplace rename.

## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
