### PR TITLE
statistics: sum as default for opex, curtailment, supply, withdrawal,…

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,7 +7,7 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
-* new feature
+* Time aggregation for OPEX, curtailment, supply, withdrawal, and revenue now default to 'sum' rather than 'mean'.
 * Fixed interference of io routines with linopy optimisation [`#564 <https://github.com/PyPSA/PyPSA/pull/564>`_, `#567 <https://github.com/PyPSA/PyPSA/pull/567>`_]
 
 

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -268,7 +268,7 @@ class StatisticsAccessor:
     def opex(
         self,
         comps=None,
-        aggregate_time="mean",
+        aggregate_time="sum",
         aggregate_groups="sum",
         groupby=None,
     ):
@@ -299,7 +299,7 @@ class StatisticsAccessor:
     def supply(
         self,
         comps=None,
-        aggregate_time="mean",
+        aggregate_time="sum",
         aggregate_groups="sum",
         groupby=None,
     ):
@@ -330,7 +330,7 @@ class StatisticsAccessor:
     def withdrawal(
         self,
         comps=None,
-        aggregate_time="mean",
+        aggregate_time="sum",
         aggregate_groups="sum",
         groupby=None,
     ):
@@ -361,7 +361,7 @@ class StatisticsAccessor:
     def curtailment(
         self,
         comps=None,
-        aggregate_time="mean",
+        aggregate_time="sum",
         aggregate_groups="sum",
         groupby=None,
     ):
@@ -423,7 +423,7 @@ class StatisticsAccessor:
     def revenue(
         self,
         comps=None,
-        aggregate_time="mean",
+        aggregate_time="sum",
         aggregate_groups="sum",
         groupby=None,
     ):


### PR DESCRIPTION
… revenue

For these statistics, it's much more likely you are interested in the sum over time than the average.
