### PR TITLE
io: add functionality to read .nc and .h5 files from URL

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,7 +7,7 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
-* new feature
+* NetCDF (``.nc``) and HDF5 (``.h5``) network files can now be read directly from URL: ``pypsa.Network("https://github.com/PyPSA/PyPSA/raw/master/examples/scigrid-de/scigrid-with-load-gen-trafos.nc")``
 * Fixed interference of io routines with linopy optimisation [`#564 <https://github.com/PyPSA/PyPSA/pull/564>`_, `#567 <https://github.com/PyPSA/PyPSA/pull/567>`_]
 
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,5 +16,6 @@ dependencies:
 - glpk
 - linopy>=0.1.1
 - deprecation
+- validators
 #  - coincbc
 #  - gurobi::gurobi

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -17,12 +17,12 @@ __copyright__ = (
 
 import os
 import sys
-import validators
 from collections import namedtuple
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import validators
 from scipy.sparse import csgraph
 
 from pypsa.contingency import calculate_BODF, network_lpf_contingency, network_sclopf

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -17,6 +17,7 @@ __copyright__ = (
 
 import os
 import sys
+import validators
 from collections import namedtuple
 from pathlib import Path
 
@@ -137,7 +138,7 @@ class Network(Basic):
     ----------
     import_name : string, Path
         Path to netCDF file, HDF5 .h5 store or folder of CSV files from which to
-        import network data.
+        import network data. The string could be a URL.
     name : string, default ""
         Network name.
     ignore_standard_types : boolean, default False
@@ -162,6 +163,7 @@ class Network(Basic):
     --------
     >>> nw1 = pypsa.Network("my_store.h5")
     >>> nw2 = pypsa.Network("/my/folder")
+    >>> nw3 = pypsa.Network("https://github.com/PyPSA/PyPSA/raw/master/examples/scigrid-de/scigrid-with-load-gen-trafos.nc")
     """
 
     # Spatial Reference System Identifier (SRID), defaults to longitude and latitude
@@ -332,10 +334,11 @@ class Network(Basic):
             self.read_in_default_standard_types()
 
         if import_name:
-            import_name = Path(import_name)
-            if import_name.suffix == ".h5":
+            if not validators.url(str(import_name)):
+                import_name = Path(import_name)
+            if str(import_name).endswith(".h5"):
                 self.import_from_hdf5(import_name)
-            elif import_name.suffix == ".nc":
+            elif str(import_name).endswith(".nc"):
                 self.import_from_netcdf(import_name)
             elif import_name.is_dir():
                 self.import_from_csv_folder(import_name)

--- a/pypsa/examples.py
+++ b/pypsa/examples.py
@@ -16,27 +16,14 @@ __copyright__ = (
 import logging
 import os
 from pathlib import Path
-from urllib.request import urlretrieve as _retrieve
+from urllib.request import urlretrieve
 
 import pandas as pd
 
 from pypsa.components import Network
+from pypsa.io import _data_dir
 
 logger = logging.getLogger(__name__)
-
-
-# for the writable data directory follow the XDG guidelines
-# https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-_writable_dir = os.path.join(os.path.expanduser("~"), ".local", "share")
-_data_dir = os.path.join(
-    os.environ.get("XDG_DATA_HOME", os.environ.get("APPDATA", _writable_dir)),
-    "pypsa-examples",
-)
-_data_dir = Path(_data_dir)
-try:
-    _data_dir.mkdir(exist_ok=True)
-except FileNotFoundError:
-    os.makedirs(_data_dir)
 
 
 def _repo_url(master=False):
@@ -54,7 +41,7 @@ def _retrieve_if_not_local(name, repofile, update=False, from_master=False):
     if not path.exists() or update:
         url = _repo_url(from_master) + repofile
         logger.info(f"Retrieving network data from {url}")
-        _retrieve(url, path)
+        urlretrieve(url, path)
 
     return str(path)
 

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -19,9 +19,10 @@ logger = logging.getLogger(__name__)
 import json
 import math
 import os
+import validators
 from glob import glob
 from pathlib import Path
-from textwrap import dedent
+from urllib.request import urlretrieve
 
 import numpy as np
 import pandas as pd
@@ -32,6 +33,27 @@ try:
     has_xarray = True
 except ImportError:
     has_xarray = False
+
+
+# for the writable data directory follow the XDG guidelines
+# https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+_writable_dir = os.path.join(os.path.expanduser("~"), ".local", "share")
+_data_dir = os.path.join(
+    os.environ.get("XDG_DATA_HOME", os.environ.get("APPDATA", _writable_dir)),
+    "pypsa-networks",
+)
+_data_dir = Path(_data_dir)
+try:
+    _data_dir.mkdir(exist_ok=True)
+except FileNotFoundError:
+    os.makedirs(_data_dir)
+
+
+def _retrieve_from_url(path):
+    local_path = (_data_dir / os.path.basename(path))
+    logger.info(f"Retrieving network data from {path}")
+    urlretrieve(path, local_path)
+    return str(local_path)
 
 
 class ImpExper(object):
@@ -178,7 +200,11 @@ class ExporterCSV(Exporter):
 
 class ImporterHDF5(Importer):
     def __init__(self, path):
-        self.ds = pd.HDFStore(path, mode="r")
+        self.path = path
+        if isinstance(path, (str, Path)):
+            if validators.url(str(path)):
+                path = _retrieve_from_url(path)
+            self.ds = pd.HDFStore(path, mode="r")
         self.index = {}
 
     def get_attributes(self):
@@ -261,6 +287,8 @@ if has_xarray:
         def __init__(self, path):
             self.path = path
             if isinstance(path, (str, Path)):
+                if validators.url(str(path)):
+                    path = _retrieve_from_url(path)
                 self.ds = xr.open_dataset(path)
             else:
                 self.ds = path
@@ -553,7 +581,7 @@ def import_from_hdf5(network, path, skip_time=False):
     Parameters
     ----------
     path : string, Path
-        Name of HDF5 store
+        Name of HDF5 store. The string could be a URL.
     skip_time : bool, default False
         Skip reading in time dependent attributes
     """
@@ -605,7 +633,8 @@ def import_from_netcdf(network, path, skip_time=False):
     Parameters
     ----------
     path : string|xr.Dataset
-        Path to netCDF dataset or instance of xarray Dataset
+        Path to netCDF dataset or instance of xarray Dataset.
+        The string could be a URL.
     skip_time : bool, default False
         Skip reading in time dependent attributes
     """

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -19,13 +19,13 @@ logger = logging.getLogger(__name__)
 import json
 import math
 import os
-import validators
 from glob import glob
 from pathlib import Path
 from urllib.request import urlretrieve
 
 import numpy as np
 import pandas as pd
+import validators
 
 try:
     import xarray as xr
@@ -50,7 +50,7 @@ except FileNotFoundError:
 
 
 def _retrieve_from_url(path):
-    local_path = (_data_dir / os.path.basename(path))
+    local_path = _data_dir / os.path.basename(path)
     logger.info(f"Retrieving network data from {path}")
     urlretrieve(path, local_path)
     return str(local_path)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "matplotlib",
         "networkx>=1.10",
         "deprecation",
+        "validators",
     ],
     extras_require={
         "dev": ["pytest", "pypower", "pandapower", "scikit-learn"],

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -122,3 +122,8 @@ def test_import_from_pandapower_network(
         assert len(network.loads) == len(net.load)
         assert len(network.transformers) == len(net.trafo)
         assert len(network.shunt_impedances) == len(net.shunt)
+
+
+def test_netcdf_from_url():
+    url = "https://github.com/PyPSA/PyPSA/raw/master/examples/scigrid-de/scigrid-with-load-gen-trafos.nc"
+    pypsa.Network(url)


### PR DESCRIPTION
NetCDF (``.nc``) and HDF5 (``.h5``) network files can now be read directly from URL:

 ```py
url = "https://github.com/PyPSA/PyPSA/raw/master/examples/scigrid-de/scigrid-with-load-gen-trafos.nc"
n  = pypsa.Network(url)
```

I moved the `_data_dir` from `pypsa.examples` to `pypsa.io`. Does that make sense?

Future additions could address caching of downloads similar to the `pypsa.examples`. (e.g. with `update=True` argument or similar). For now, files are downloaded again with every call.