### PR TITLE
transpose rhs for check if empty

### DIFF
--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -499,7 +499,7 @@ def define_nodal_balance_constraints(n, sns, buses=None, suffix=""):
 
     empty_nodal_balance = (lhs.vars == -1).all("_term")
     if empty_nodal_balance.any():
-        if (empty_nodal_balance & (rhs != 0)).any().item():
+        if (empty_nodal_balance.T & (rhs != 0)).any().item():
             raise ValueError("Empty LHS with non-zero RHS in nodal balance constraint.")
 
         mask = ~empty_nodal_balance

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -498,8 +498,9 @@ def define_nodal_balance_constraints(n, sns, buses=None, suffix=""):
     rhs.index.name = "snapshot"
 
     empty_nodal_balance = (lhs.vars == -1).all("_term")
+    rhs = DataArray(rhs)
     if empty_nodal_balance.any():
-        if (empty_nodal_balance.T & (rhs != 0)).any().item():
+        if (empty_nodal_balance & (rhs != 0)).any().item():
             raise ValueError("Empty LHS with non-zero RHS in nodal balance constraint.")
 
         mask = ~empty_nodal_balance
@@ -508,7 +509,7 @@ def define_nodal_balance_constraints(n, sns, buses=None, suffix=""):
 
     if suffix:
         lhs = lhs.rename(Bus=f"Bus{suffix}")
-        rhs.columns.name = f"Bus{suffix}"
+        rhs = rhs.rename(Bus=f"Bus{suffix}")
     n.model.add_constraints(lhs, "=", rhs, f"Bus{suffix}-nodal_balance", mask=mask)
 
 


### PR DESCRIPTION
In the nodal balance constraint there is a check if the nodal balance is empty and the rhs!=0. For optimisations with snapshots as a multi-index and an empty nodal balance this currently breaks with the error message ValueError: Unable to coerce to DataFrame
This is due to the fact that the rhs and the empty nodal balance do not align. E.g. empty _nodal_balance
```
<xarray.DataArray 'vars' (Bus: 364, snapshot: 4)>
array([[ True, False, False, False],
       [False, False, False, False],
       [False, False, False, False],
       ...,
       [False, False, False, False],
       [False, False, False, False],
       [False, False, False, False]])
Coordinates:
  * Bus       (Bus) object 'AL1 0 EV battery' ... 'solid biomass for industry'
  * snapshot  (snapshot) object MultiIndex
  * period    (snapshot) int64 2020 2030 2040 2050
  * timestep  (snapshot) datetime64[ns] 2013-01-01 2013-01-01 ... 2013-01-01
```
rhs
```
Bus                AL1 0 EV battery  ...  solid biomass for industry
period timestep                      ...                            
2020   2013-01-01          0.000000  ...                80182.648402
2030   2013-01-01         56.678867  ...                80182.648402
2040   2013-01-01        136.029280  ...                80182.648402
2050   2013-01-01        192.708146  ...                80182.648402

[4 rows x 364 columns]

```
This can be fixed be transposing the empty_nodal_balance as suggested. @FabianHofmann what do you think?

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
