### PR TITLE
Fix preservation of non-aggregated time-dependent variables

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -19,6 +19,8 @@ Upcoming Release
   attributes had to carry identical values for components that were to be
   merged.
 
+* Fix a bug where time-dependant generator variables could be forgotten during aggregation in a particular case.
+
 
 PyPSA 0.22.1 (15th February 2023)
 =================================

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -121,6 +121,9 @@ def aggregategenerators(
         for attr, df in network.generators_t.items():
             pnl_gens_agg_b = df.columns.to_series().map(gens_agg_b)
             df_agg = df.loc[:, pnl_gens_agg_b]
+            # If there are any generators to aggregate, do so and put
+            # the time-varying data for all generators (aggregated and
+            # non-aggregated) into `new_pnl`.
             if not df_agg.empty:
                 if attr == "p_max_pu":
                     df_agg = df_agg.multiply(weighting.loc[df_agg.columns], axis=1)
@@ -129,6 +132,9 @@ def aggregategenerators(
                 new_pnl[attr] = pd.concat(
                     [df.loc[:, ~pnl_gens_agg_b], pnl_df], axis=1, sort=False
                 )
+            # Even if no generators are aggregated, we still need to
+            # put the time-varying data for all non-aggregated
+            # generators into `new_pnl`.
             elif not df.empty:
                 new_pnl[attr] = df
 

--- a/pypsa/networkclustering.py
+++ b/pypsa/networkclustering.py
@@ -129,6 +129,8 @@ def aggregategenerators(
                 new_pnl[attr] = pd.concat(
                     [df.loc[:, ~pnl_gens_agg_b], pnl_df], axis=1, sort=False
                 )
+            elif not df.empty:
+                new_pnl[attr] = df
 
     return new_df, new_pnl
 


### PR DESCRIPTION
When aggregating generators, the current version of the code erroneously only preserves time-dependent variables of generators when some generators with time-dependent variables had been aggregated (the `if not df_agg.empty` statement right about this commit diff). In this case, time-dependent variables of non-aggregated generators are simply forgotten.

The problem arose in the context of building some pypsa-eur network with two clustering steps (for example with wildcards simpl=200 and clusters=100); if the network only has renewable generators which aren't aggregated in the second clustering step, their capacity factors  (`p_max_pu`) would be forgotten. This PR fixes that issue.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
