### PR TITLE
 doc: fix two links to related projects

### DIFF
--- a/doc/comparable_software.rst
+++ b/doc/comparable_software.rst
@@ -25,11 +25,11 @@ Free software
 - `SWITCH <http://rael.berkeley.edu/old_drupal/switch>`_
 - `PowerGAMA <https://bitbucket.org/harald_g_svendsen/powergama/wiki/Home>`_
 - `NEMO <https://nemo.ozlabs.org/>`_
-- `Mosaik-PYPOWER <https://bitbucket.org/mosaik/mosaik-pypower>`_
+- `Mosaik-PYPOWER <https://mosaik.offis.de/>`_
 - `OpenDSS <http://sourceforge.net/projects/electricdss/>`_
 - `MatDyn <http://www.esat.kuleuven.be/electa/teaching/matdyn/>`_
 - `GridLAB-D <http://sourceforge.net/projects/gridlab-d/>`_
-- `PyCIM <http://www.pycim.org>`_
+- `CIMpy    <http://sogno.energy/cimpy/>`_
 - `vSPD <https://github.com/ElectricityAuthority/vSPD>`_ - Vectorised Scheduling, Pricing and Dispatch (vSPD) - an audited, mathematical replica of SPD, the pricing and dispatch engine used in the New Zealand electricity market.
 
 


### PR DESCRIPTION
This is a followup to #587.

Note that there are three more broken links:

- [DiSC](http://kom.aau.dk/project/SmartGridControl/DiSC/documentation.html) - is it this [project by NREL](https://www.nrel.gov/grid/solar-resource/disc.html)?
- [IEEE OSS list](http://ewh.ieee.org/cmte/psace/CAMS_taskforce/links.htm)
- [SWITCH](http://rael.berkeley.edu/old_drupal/switch)

Not sure if these projects are still available.