### PR TITLE
Netcdf compression

### DIFF
--- a/doc/import_export.rst
+++ b/doc/import_export.rst
@@ -58,6 +58,24 @@ float precision to save space and supports lazy loading.
 To export network and components to a netCDF file run
 :py:meth:`pypsa.Network.export_to_netcdf`.
 
+To enable lossless compression, set the ``complevel`` argument to an
+integer between 1 and 9 (inclusive). Lower values result in faster
+export times, while higher values give a better compression ratio.
+Improvements to the compression ratio are usually marginal with higher
+compression levels, so start by trying a compression level of 1.
+Regardless, this will make exporting the network a bit slower.
+
+Additionally, you may set the ``least_significant_digit`` option,
+which compresses the network further by effectively rounding all time
+series values to the given number of digits after the decimal point,
+throwing away the remaining digits (although the exact implementation
+is a bit more complicated). For example, when this value is set to 2,
+the value 42.12345 can become 42.12. The rounding is only applied to
+time-varying data. This is a lossy type of compression, but can save a
+significant amount of space. Compared to lossless compression, this
+can also save some time, although it is still slower than exporting
+without compression altogether.
+
 
 Import from netCDF
 ==================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -33,7 +33,7 @@ Upcoming Release
 
 * Fix an issue appeared when processing networks which were reduced to a set of isolated nodes in course of clustering. Previously, an empty ``Line`` component has lead to problems when processing empty lines-related dataframes. That has been fixed by introducing special treatment in case a lines dataframe is empty.
 
-* Fix network compression using ``least_significant_digit`` option of ``Network.export_to_netcdf`` function, and add new ``complevel`` option (compression level between 1 and 9) to the same function, enabling lossless compression. 
+* Fix network compression using ``least_significant_digit`` option of ``Network.export_to_netcdf`` function, and add new ``complevel`` option (compression level between 1 and 9) to the same function, enabling lossless compression.
 
 
 PyPSA 0.22.1 (15th February 2023)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -33,6 +33,8 @@ Upcoming Release
 
 * Fix an issue appeared when processing networks which were reduced to a set of isolated nodes in course of clustering. Previously, an empty ``Line`` component has lead to problems when processing empty lines-related dataframes. That has been fixed by introducing special treatment in case a lines dataframe is empty.
 
+* Fix network compression using ``least_significant_digit`` option of ``Network.export_to_netcdf`` function, and add new ``complevel`` option (compression level between 1 and 9) to the same function, enabling lossless compression. 
+
 
 PyPSA 0.22.1 (15th February 2023)
 =================================

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -24,6 +24,32 @@ def test_netcdf_io_Path(scipy_network, tmpdir):
     pypsa.Network(fn)
 
 
+def test_netcdf_lossless_compress(scipy_network, tmpdir):
+    fn = Path(os.path.join(tmpdir, "netcdf_export_lossless.nc"))
+    scipy_network.export_to_netcdf(fn, complevel=1)
+    scipy_network_compressed = pypsa.Network(fn)
+    assert (
+        (scipy_network.loads_t.p_set == scipy_network_compressed.loads_t.p_set)
+        .all()
+        .all()
+    )
+
+
+def test_netcdf_lossy_compress(scipy_network, tmpdir):
+    fn = Path(os.path.join(tmpdir, "netcdf_export_lossy.nc"))
+    digits = 2
+    scipy_network.export_to_netcdf(fn, complevel=1, least_significant_digit=digits)
+    scipy_network_compressed = pypsa.Network(fn)
+    assert (
+        (
+            (scipy_network.loads_t.p_set - scipy_network_compressed.loads_t.p_set).abs()
+            < 1 / 10**digits
+        )
+        .all()
+        .all()
+    )
+
+
 def test_netcdf_io_datetime(tmpdir):
     fn = os.path.join(tmpdir, "temp.nc")
     exported_sns = pd.date_range(start="2013-03-01", end="2013-03-02", freq="h")


### PR DESCRIPTION
## Changes proposed in this Pull Request

I was running into some disk space issues and decided to take a look at netCDF compression. There was already mention of a "least_significant_digit" option in the `export_to_netcdf` function; with this pull request it finally works. The space savings can amount to a factor of 4-5 with a least significant digit of 3 in my tests! (Tested using a pypsa-eur network that was originally 370MB, got it down to around 80-90MB.)

I also added an option for lossless compression (a new argument `complevel`, which can be set independently of `least_significant_digit`), which can reduce disk space by around 30% at the expense of some longer export times; could be of interest to some people.

I tried writing some simple tests, but I'm not so familiar with the test framework so I hope they work.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
