### PR TITLE
global_constraint: add operational limit constraint

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -33,6 +33,8 @@ Upcoming Release
 
 * Fix an issue appeared when processing networks which were reduced to a set of isolated nodes in course of clustering. Previously, an empty ``Line`` component has lead to problems when processing empty lines-related dataframes. That has been fixed by introducing special treatment in case a lines dataframe is empty.
 
+* A new type of ``GlobalConstraint`` called `operational_limit` is now supported through the `Network.optimize` function. It allows to limit the total production of a carrier analogous to `primary_energy_limit` with the difference that it applies directly to the production of a carrier rather than to an attribute of the primary energy use.
+
 
 PyPSA 0.22.1 (15th February 2023)
 =================================

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -304,6 +304,73 @@ def define_primary_energy_limit(n, sns):
         m.add_constraints(lhs, sign, rhs, f"GlobalConstraint-{name}")
 
 
+def define_operational_limit(n, sns):
+    """
+    Defines operational limit constraints. It limits the net production of a
+    carrier taking into account generator, storage units and stores.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+    sns : list-like
+        Set of snapshots to which the constraint should be applied.
+
+    Returns
+    -------
+    None.
+    """
+    m = n.model
+    weightings = n.snapshot_weightings.loc[sns]
+    glcs = n.global_constraints.query('type == "operational_limit"')
+
+    if n._multi_invest:
+        period_weighting = n.investment_period_weightings.years[sns.unique("period")]
+        weightings = weightings.mul(period_weighting, level=0, axis=0)
+
+    for name, glc in glcs.iterrows():
+        if isnan(glc.investment_period):
+            snapshots = sns
+        else:
+            snapshots = sns[sns.get_loc(glc.investment_period)]
+
+        lhs = []
+        rhs = glc.constant
+
+        # generators
+        gens = n.generators.query("carrier == @glc.carrier_attribute")
+        if not gens.empty:
+            p = m["Generator-p"].loc[snapshots, gens.index]
+            weightings = DataArray(weightings.generators[snapshots])
+            expr = (p * weightings).sum()
+            lhs.append(expr)
+
+        # storage units
+        cond = "carrier == @glc.carrier_attribute and not cyclic_state_of_charge"
+        sus = n.storage_units.query(cond)
+        sus_i = sus.index
+        if not sus.empty:
+            soc = m["StorageUnit-state_of_charge"].loc[snapshots, sus_i]
+            soc = soc.ffill("snapshot").isel(snapshot=-1)
+            lhs.append(-1 * soc.sum())
+            rhs -= sus.state_of_charge_initial.sum()
+
+        # stores
+        n.stores["carrier"] = n.stores.bus.map(n.buses.carrier)
+        stores = n.stores.query("carrier == @glc.carrier_attribute and not e_cyclic")
+        if not stores.empty:
+            e = m["Store-e"].loc[snapshots, stores.index]
+            e = e.ffill("snapshot").isel(snapshot=-1)
+            lhs.append(-e.sum())
+            rhs -= stores.e_initial.sum()
+
+        if not lhs:
+            continue
+
+        lhs = merge(lhs)
+        sign = "=" if glc.sense == "==" else glc.sense
+        m.add_constraints(lhs, sign, rhs, f"GlobalConstraint-{name}")
+
+
 def define_transmission_volume_expansion_limit(n, sns):
     """
     Set a limit for line volume expansion. For the capacity expansion only the

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -35,6 +35,7 @@ from pypsa.optimization.constraints import (
 from pypsa.optimization.global_constraints import (
     define_growth_limit,
     define_nominal_constraints_per_bus_carrier,
+    define_operational_limit,
     define_primary_energy_limit,
     define_tech_capacity_expansion_limit,
     define_transmission_expansion_cost_limit,
@@ -236,6 +237,7 @@ def create_model(
     define_transmission_expansion_cost_limit(n, sns)
     define_transmission_volume_expansion_limit(n, sns)
     define_tech_capacity_expansion_limit(n, sns)
+    define_operational_limit(n, sns)
     define_nominal_constraints_per_bus_carrier(n, sns)
     define_growth_limit(n, sns)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -64,6 +64,19 @@ def ac_dc_network_multiindexed(ac_dc_network):
 
 
 @pytest.fixture(scope="module")
+def storage_hvdc_network():
+    csv_folder = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "examples",
+        "opf-storage-hvdc",
+        "opf-storage-data",
+    )
+    n = pypsa.Network(csv_folder)
+    return n
+
+
+@pytest.fixture(scope="module")
 def pandapower_custom_network():
     net = pp.create_empty_network()
     bus1 = pp.create_bus(net, vn_kv=20.0, name="Bus 1")

--- a/test/test_lopf_global_constraints.py
+++ b/test/test_lopf_global_constraints.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+import pandas as pd
+import pytest
+from conftest import optimize
+
+APIS = ["linopy"]
+
+
+@pytest.mark.parametrize("api", APIS)
+def test_operational_limit_ac_dc_meshed(ac_dc_network, api):
+    n = ac_dc_network
+
+    limit = 30_000
+
+    n.global_constraints.drop(n.global_constraints.index, inplace=True)
+
+    n.add(
+        "GlobalConstraint",
+        "gas_limit",
+        type="operational_limit",
+        carrier_attribute="gas",
+        sense="<=",
+        constant=limit,
+    )
+
+    optimize(n, api)
+    assert n.statistics.supply().loc[:, "gas"].sum().round(3) == limit
+
+
+@pytest.mark.parametrize("api", APIS)
+def test_operational_limit_storage_hvdc(storage_hvdc, api):
+    n = storage_hvdc
+
+    limit = 5_000
+
+    n.global_constraints.drop(n.global_constraints.index, inplace=True)
+
+    n.add(
+        "GlobalConstraint",
+        "battery_limit",
+        type="operational_limit",
+        carrier_attribute="battery",
+        sense="<=",
+        constant=limit,
+    )
+
+    n.storage_units["state_of_charge_initial"] = 1_000
+    n.storage_units.p_nom_extendable = True
+    n.storage_units.cyclic_state_of_charge = False
+
+    optimize(n, api)
+
+    soc_diff = (
+        n.storage_units.state_of_charge_initial.sum()
+        - n.storage_units_t.state_of_charge.sum(1).iloc[-1]
+    )
+    assert soc_diff.round(3) == limit

--- a/test/test_lopf_global_constraints.py
+++ b/test/test_lopf_global_constraints.py
@@ -31,8 +31,8 @@ def test_operational_limit_ac_dc_meshed(ac_dc_network, api):
 
 
 @pytest.mark.parametrize("api", APIS)
-def test_operational_limit_storage_hvdc(storage_hvdc, api):
-    n = storage_hvdc
+def test_operational_limit_storage_hvdc(storage_hvdc_network, api):
+    n = storage_hvdc_network
 
     limit = 5_000
 


### PR DESCRIPTION
Analogous to `primary_energy_limit` but directly working on carrier output. This will help to replace some stores in pypsa-eur (sector-coupled) by light-weight constrained generators.


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
