### PR TITLE
add warning for duals not assigned

### DIFF
--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -332,6 +332,7 @@ def assign_duals(n):
         try:
             c, attr = name.split("-", 1)
         except ValueError:
+            unassigned.append(name)
             continue
 
         if "snapshot" in dual.dims:


### PR DESCRIPTION
constraints with names which are defined not following the syntax ("component-something") are currently not assigned to the network. For these constraints there should be a warning that they are not assigned

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
