### PR TITLE
`assign_duals`: add storage consistency equations

### DIFF
--- a/pypsa/component_attrs/storage_units.csv
+++ b/pypsa/component_attrs/storage_units.csv
@@ -37,3 +37,4 @@ p_nom_opt,float,MW,0,Optimised nominal power.,Output
 mu_upper,series,currency/MWh,0,Shadow price of upper p_nom limit,Output
 mu_lower,series,currency/MWh,0,Shadow price of lower p_nom limit,Output
 mu_state_of_charge_set,series,currency/MWh,0,Shadow price of fixed state of charge state_of_charge_set,Output
+mu_energy_balance,series,currency/MWh,0,Shadow price of storage consistency equations,Output

--- a/pypsa/component_attrs/stores.csv
+++ b/pypsa/component_attrs/stores.csv
@@ -27,4 +27,4 @@ e,series,MWh,0,Energy as calculated by the OPF.,Output
 e_nom_opt,float,MWh,0,Optimised nominal energy capacity outputed by OPF.,Output
 mu_upper,series,currency/MWh,0,Shadow price of upper e_nom limit,Output
 mu_lower,series,currency/MWh,0,Shadow price of lower e_nom limit,Output
-mu_e_set,series,currency/MWh,0,Shadow price of fixed energy level e_set,Output
+mu_energy_balance,series,currency/MWh,0,Shadow price of storage consistency equations,Output

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -750,7 +750,7 @@ def define_storage_unit_constraints(n, sns):
         )
     lhs += [(eff_stand, previous_soc)]
     rhs = rhs.where(include_previous_soc, rhs - soc_init)
-    m.add_constraints(lhs, "=", rhs, f"{c}-energy-balance", mask=active)
+    m.add_constraints(lhs, "=", rhs, f"{c}-energy_balance", mask=active)
 
 
 def define_store_constraints(n, sns):
@@ -822,7 +822,7 @@ def define_store_constraints(n, sns):
     lhs += [(eff_stand, previous_e)]
     rhs = -e_init.where(~include_previous_e, 0)
 
-    m.add_constraints(lhs, "=", rhs, f"{c}-energy-balance", mask=active)
+    m.add_constraints(lhs, "=", rhs, f"{c}-energy_balance", mask=active)
 
 
 def define_loss_constraints(n, sns, c, transmission_losses):

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -345,15 +345,16 @@ def assign_duals(n):
                     "ramp_limit_up",
                     "ramp_limit_down",
                     "p_set",
-                    "e_set",
-                    "s_set",
                     "state_of_charge_set",
+                    "energy_balance",
                 ]
 
                 if spec in assign:
                     set_from_frame(n, c, "mu_" + spec, df)
                 elif attr.endswith("nodal_balance"):
                     set_from_frame(n, c, "marginal_price", df)
+                else:
+                    unassigned.append(name)
             except:
                 unassigned.append(name)
 


### PR DESCRIPTION
- removed `e_set` and `s_set` because they are not used
- renamed storage consistency equation from `energy-balance` to `energy_balance` for consistency with other constraints
- added `mu_energy_balance` to `n.stores_t` and `n.storage_units_t`
- track missed unassigned dual variables (those that are not matched but also don't cause an error)