### PR TITLE
Add missing market_value reference

### DIFF
--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -171,6 +171,7 @@ class StatisticsAccessor:
             self.curtailment,
             self.capacity_factor,
             self.revenue,
+            self.market_value,
         ]
         kwargs = dict(comps=comps, aggregate_groups=aggregate_groups, groupby=groupby)
         res = []


### PR DESCRIPTION
`market_value` is implemented but missing from the statistics accessor.

## Checklist

- [n/a] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [n/a] Unit tests for new features were added (if applicable).
- [n/a ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
