### PR TITLE
Add option to aggregate carriers in specific buses

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -37,6 +37,16 @@ PyPSA 0.24.0 (27th June 2023)
 * Bug fix in linearized unit commitment implementation correcting sign.
 * The minimum required version of ``linopy`` is now ``0.2.1``.
 * Dropped support for Python 3.8. The minimum required version of Python is now 3.9.
+  deprecated but all functionality will continue to be accessible until the next
+  major version.
+* The function ``n.set_snapshots()`` now takes two optional keyword arguments; ``default_snapshot_weightings``
+  to change the default snapshot weightings, and ``weightings_from_timedelta``
+  to compute the weights if snapshots are of type ``pd.DatetimeIndex``.
+* The statistics function ``n.statistics()`` now also supports the calculation of the ``Market Value`` of components.
+* The function ``pypsa.clustering.spatial.get_clustering_from_busmap`` and ``pypsa.clustering.spatial.aggregategenerators``
+  now allows the passing of a list of buses for which aggregation of __all__ carriers is desired. Generation from
+  a carrier at a bus is aggregated now if: It is __either__ in the passed list of aggregated carriers, __or__ in the
+  list of aggregated buses.
 
 
 PyPSA 0.23.0 (10th May 2023)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -37,12 +37,6 @@ PyPSA 0.24.0 (27th June 2023)
 * Bug fix in linearized unit commitment implementation correcting sign.
 * The minimum required version of ``linopy`` is now ``0.2.1``.
 * Dropped support for Python 3.8. The minimum required version of Python is now 3.9.
-  deprecated but all functionality will continue to be accessible until the next
-  major version.
-* The function ``n.set_snapshots()`` now takes two optional keyword arguments; ``default_snapshot_weightings``
-  to change the default snapshot weightings, and ``weightings_from_timedelta``
-  to compute the weights if snapshots are of type ``pd.DatetimeIndex``.
-* The statistics function ``n.statistics()`` now also supports the calculation of the ``Market Value`` of components.
 * The function ``pypsa.clustering.spatial.get_clustering_from_busmap`` and ``pypsa.clustering.spatial.aggregategenerators``
   now allows the passing of a list of buses for which aggregation of __all__ carriers is desired. Generation from
   a carrier at a bus is aggregated now if: It is __either__ in the passed list of aggregated carriers, __or__ in the

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -395,7 +395,7 @@ def get_clustering_from_busmap(
     bus_strategies=dict(),
     one_port_strategies=dict(),
     generator_strategies=dict(),
-    aggregate_generator_buses=None,
+    aggregate_generators_buses=None,
 ):
     buses, linemap, linemap_p, linemap_n, lines, lines_t = get_buses_linemap_and_lines(
         network, busmap, line_length_factor, bus_strategies, with_time
@@ -426,7 +426,7 @@ def get_clustering_from_busmap(
             with_time=with_time,
             carriers=aggregate_generators_carriers,
             custom_strategies=generator_strategies,
-            aggregate_buses=aggregate_generator_buses,
+            aggregate_buses=aggregate_generators_buses,
         )
         io.import_components_from_dataframe(network_c, generators, "Generator")
         if with_time:

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -66,7 +66,7 @@ def aggregategenerators(
 ):
     if carriers is None:
         carriers = network.generators.carrier.unique()
-    
+
     gens_agg_b = network.generators.carrier.isin(carriers)
 
     if buses is not None:


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR adds a feature to the function `clustering.spatial.get_clustering_from_busmap`, and `aggregategenerators`.
They now would accept the kwarg `aggregate_generator_buses` and `aggregate_buses`, respectively. These are a list of buses (of the origin network), where carriers are aggregated, irrespective of the argument passed for `carriers`.

The motivation here is that this greatly facilitates a feature (for which I will also make a PR) in PyPSA-Eur, that allows generators to be aggregated in a subset of regions. In my case for instance, I would like to model all gas and nuclear generators individually in GB, but I don't wish to model ~100 plants in France and Germany. To me at least, this appears like a features that could easily be useful for studies based on PyPSA-Eur, but currently requires hacking of some quite deep functionalities of `PyPSA`, which might turn off some users. I think this PR would unlock this functionality for non-hackers.

My understanding of `clustering.spatial` is quite partial, so please let me know if the proposed changes will not work as I intend, I am more than happy to amend.

All the best,
Lukas

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [X] Unit tests for new features were added (if applicable).
- [X] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [X] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X] I consent to the release of this PR's code under the MIT license.
