### PR TITLE
fix aggregate_buses argument

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -18,7 +18,7 @@ PyPSA 0.24.0 (27th June 2023)
 * PyPSA now supports quadratic marginal cost terms. A new column
   `marginal_cost_quadratic` was added to generators, links, stores and storage
   units. The quadratic marginal cost is added to the objective function when
-  calling ``n.optimize()``. This requires a solver that is able to solve quadratic problems, for instance, 
+  calling ``n.optimize()``. This requires a solver that is able to solve quadratic problems, for instance,
   HiGHS, Gurobi, Xpress, or CPLEX.
 * The statistics function now allows calculating energy balances
   ``n.statistics.energy_balance()`` and dispatch ``n.statistics.dispatch()``, as

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -426,7 +426,7 @@ def get_clustering_from_busmap(
             with_time=with_time,
             carriers=aggregate_generators_carriers,
             custom_strategies=generator_strategies,
-            aggregate_buses=aggregate_generators_buses,
+            buses=aggregate_generators_buses,
         )
         io.import_components_from_dataframe(network_c, generators, "Generator")
         if with_time:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Fix error that argument ```aggregate_buses``` not found in  ```aggregategenerators```:
Change argument of method  ```aggregategenerators``` from aggregate_buses to buses inside method ```get_clustering_from_busmap```

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
