### PR TITLE
Disable Compression per default

### DIFF
--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -658,7 +658,7 @@ def export_to_netcdf(
     network,
     path=None,
     export_standard_types=False,
-    compression={"zlib": True, "complevel": 4},
+    compression=None,
     float32=False,
 ):
     """


### PR DESCRIPTION
Is up to 20 times faster for large networks (while using 3 times more space)
