### PR TITLE
Bug fix multilink handle

### DIFF
--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -344,7 +344,7 @@ def assign_solution(n):
                     set_from_frame(n, c, f"p{i}", -df * eff)
                     n.pnl(c)[f"p{i}"].loc[
                         sns, n.links.index[n.links[f"bus{i}"] == ""]
-                    ] = n.component_attrs["Link"].loc[f"p{i}", "default"]
+                    ] = float(n.component_attrs["Link"].loc[f"p{i}", "default"])
 
             else:
                 set_from_frame(n, c, attr, df)


### PR DESCRIPTION
in assign solution convert the default values of the additional link ports (e.g. from p2, p3 it is string type "0") to type float to avoid mix of dtypes in the dataframe. 

Currently, this mix of dtypes is causing an error when exporting a solved network.

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
