### PR TITLE
Linearised UC additional constraints only if cost equal

### DIFF
--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -233,7 +233,10 @@ def define_operational_constraints_for_committables(n, sns, c):
         n.model.add_constraints(status, "=", 0, name, mask=mask)
 
     # linearized approximation because committable can partly start up and shut down
-    if n._linearized_uc:
+    # only valid additional constraints if start up costs equal to shut down costs
+    cost_equal = all(n.df(c).loc[com_i, "start_up_cost"] == n.df(c).loc[com_i, "shut_down_cost"])
+    if n._linearized_uc and cost_equal:
+        
         # dispatch limit for partly start up/shut down for t-1
         lhs = (
             p.shift(snapshot=1)


### PR DESCRIPTION
Closes #689 .

## Add check if start up costs equal to shut down costs for linearized UC


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
