### PR TITLE
follow-up: default multilinks, default efficiencies and style of comp…

### DIFF
--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -445,7 +445,9 @@ def update_linkports_component_attrs(n, where=None):
         to_replace = "1"
         j = "1" if attr != "efficiency" else ""
         n.components[c]["attrs"].loc[target] = (
-            n.components[c]["attrs"].loc[attr + j].apply(doc_changes, args=(to_replace, i))
+            n.components[c]["attrs"]
+            .loc[attr + j]
+            .apply(doc_changes, args=(to_replace, i))
         )
         n.component_attrs[c].loc[target] = (
             n.component_attrs[c].loc[attr + j].apply(doc_changes, args=(to_replace, i))

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -436,18 +436,19 @@ def update_linkports_component_attrs(n, where=None):
     c = "Link"
 
     def doc_changes(s, j, i):
-        if not isinstance(s, str):
+        if not isinstance(s, str) or len(s) == 1:
             return s
         return s.replace(j, str(i)).replace("required", "optional")
 
     for i, attr in product(ports, ["bus", "efficiency", "p"]):
         target = f"{attr}{i}"
+        to_replace = "1"
         j = "1" if attr != "efficiency" else ""
         n.components[c]["attrs"].loc[target] = (
-            n.components[c]["attrs"].loc[attr + j].apply(doc_changes, args=(j, i))
+            n.components[c]["attrs"].loc[attr + j].apply(doc_changes, args=(to_replace, i))
         )
         n.component_attrs[c].loc[target] = (
-            n.component_attrs[c].loc[attr + j].apply(doc_changes, args=(j, i))
+            n.component_attrs[c].loc[attr + j].apply(doc_changes, args=(to_replace, i))
         )
         if attr in ["efficiency", "p"] and not target in n.pnl(c).keys():
             df = pd.DataFrame(index=n.snapshots, columns=[], dtype=float)


### PR DESCRIPTION
…onent_attr text

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
