### PR TITLE
update example url: pypsa.org -> pypsa.readthedocs.io

### DIFF
--- a/examples/notebooks/scigrid-lopf-then-pf.ipynb
+++ b/examples/notebooks/scigrid-lopf-then-pf.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "3. Attaching power plants to the nearest high voltage substation may not reflect reality.\n",
     "\n",
-    "4. There is no proper n-1 security in the calculations - this can either be simulated with a blanket e.g. 70% reduction in thermal limits (as done here) or a proper security constrained OPF (see e.g.  <http://www.pypsa.org/examples/scigrid-sclopf.ipynb>).\n",
+    "4. There is no proper n-1 security in the calculations - this can either be simulated with a blanket e.g. 70% reduction in thermal limits (as done here) or a proper security constrained OPF (see e.g.  <http://pypsa.readthedocs.io/en/latest/examples/scigrid-sclopf.html>).\n",
     "\n",
     "5. The borders and neighbouring countries are not represented.\n",
     "\n",


### PR DESCRIPTION
## Changes proposed in this Pull Request
Fixes the broken link from warning 4 in the [Non-linear power flow after LOPF](https://pypsa.readthedocs.io/en/latest/examples/scigrid-lopf-then-pf.html#Warnings) example

## Checklist

- [x] I consent to the release of this PR's code under the MIT license.
