### PR TITLE
repair CI

### DIFF
--- a/.codespell.ignore
+++ b/.codespell.ignore
@@ -1,3 +1,4 @@
 ines
 psace
 datas
+fom

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,14 +5,14 @@ dependencies:
 - python>=3.9
 - numpy
 - scipy
-- pandas>=0.24.0
+- pandas>=0.24.0,<2.1
 - xarray
 - netcdf4
 - libnetcdf
 - pytables
 - matplotlib
 - networkx>=1.10
-- pyomo>=5.7.0
+- pyomo>=5.7.0,<6.6.2
 - cartopy>=0.16
 - glpk
 - linopy>=0.2

--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -7,14 +7,14 @@ dependencies:
 # Copy from regular environment.yaml
 - numpy
 - scipy
-- pandas>=0.24.0
+- pandas>=0.24.0,<2.1
 - xarray
 - netcdf4
 - libnetcdf
 - pytables
 - matplotlib
 - networkx>=1.10
-- pyomo>=5.7.0
+- pyomo>=5.7.0,<6.6.2
 - cartopy>=0.16
 - glpk
 - linopy>=0.2

--- a/environment_docs.yml
+++ b/environment_docs.yml
@@ -15,7 +15,7 @@ dependencies:
 - pytables
 - matplotlib
 - networkx>=1.10
-- pyomo,<6.6.2
+- pyomo<6.6.2
 - cartopy>=0.16
 - coincbc
 - glpk

--- a/environment_docs.yml
+++ b/environment_docs.yml
@@ -9,13 +9,13 @@ dependencies:
 - numpy
 - pyomo>=5.7.0
 - scipy
-- pandas>=1.1.0
+- pandas>=1.1.0,<2.1
 - xarray
 - netcdf4
 - pytables
 - matplotlib
 - networkx>=1.10
-- pyomo
+- pyomo,<6.6.2
 - cartopy>=0.16
 - coincbc
 - glpk

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ setup(
     install_requires=[
         "numpy",
         "scipy",
-        "pandas>=0.24",
+        "pandas>=0.24,<2.1",
         "xarray",
         "netcdf4",
         "tables",
-        "pyomo>=5.7",
+        "pyomo>=5.7,<6.6.2",
         "linopy>=0.2.1",
         "matplotlib",
         "networkx>=1.10",


### PR DESCRIPTION
## Changes proposed in this Pull Request 
Build on PR https://github.com/PyPSA/PyPSA/pull/724 but adding pandas constraint. 
We probably have to delve into the pandas warning to use the newer pandas versions:
```
FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas.
Value '[-1.34291453e-13 -9.58966072e-14]' has dtype incompatible with int64,
please explicitly cast to a compatible dtype first.
    network.buses_t.p.loc[snapshots, sn_buses] = s_calc.real[
```
Collab with @drifter089 on this PR.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] I consent to the release of this PR's code under the MIT license.