### PR TITLE
assign_duals: don't overwrite existing values

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,7 @@ Upcoming Release
 * Bugfix in power flow distributed slack if ``p_nom`` or ``p_nom_opt`` are used as weights.
 * Add example in documentation for the statistics module.
 * Add option to enable or disable nice carrier name in the statistics module (e.g.``n.statistics(nice_name=False)``).
+* After the optimization the rhs and sign of global constraints were overwritten by altered values. This is now fixed.
 
 PyPSA 0.25.1 (27th July 2023)
 =============================

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -411,8 +411,6 @@ def assign_duals(n, assign_all_duals=False):
             (assign_all_duals or attr in n.df(c).index)
         ):
             n.df(c).loc[attr, "mu"] = dual
-            n.df(c).loc[attr, "sense"] = m.constraints[name].sign.values.item()
-            n.df(c).loc[attr, "constant"] = m.constraints[name].rhs.values.item()
 
     if unassigned:
         logger.info(


### PR DESCRIPTION
## Changes proposed in this Pull Request

Don't overwrite `constant` and `sign` of existing entries in global constraint. The previous behaviour lead to non-reproducable network optimization as the constant would be updated by a new value. An example can be found for CO2 limits which take the initial state of charge of stores in the right hand side into account. 
