### PR TITLE
Change 'default' column in component attributes to object manually

### DIFF
--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -300,6 +300,7 @@ class Network(Basic):
             # make copies to prevent unexpected sharing of variables
             attrs = self.component_attrs[component].copy()
 
+            attrs['default'] = attrs['default'].astype('object')
             attrs["static"] = attrs["type"] != "series"
             attrs["varying"] = attrs["type"].isin({"series", "static or series"})
             attrs["typ"] = (

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -300,7 +300,7 @@ class Network(Basic):
             # make copies to prevent unexpected sharing of variables
             attrs = self.component_attrs[component].copy()
 
-            attrs['default'] = attrs['default'].astype('object')
+            attrs["default"] = attrs["default"].astype("object")
             attrs["static"] = attrs["type"] != "series"
             attrs["varying"] = attrs["type"].isin({"series", "static or series"})
             attrs["typ"] = (


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

When reading component attributes stored in `component_attrs` (like https://github.com/PyPSA/PyPSA/blob/master/pypsa/component_attrs/carriers.csv), the `default` column might be recognized to have `float64` dtype.

In the constructor of `Network`, I encounter the following warning:
```
d:\mambaforge\Lib\site-packages\pypsa\components.py:323: FutureWarning:

Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '[]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
```

It is caused by https://github.com/PyPSA/PyPSA/blob/4514190afca73c8385b8fc50bbd9ad129b7d1c3c/pypsa/components.py#L323

We assign a non-float64 value to column with float64 dtype.

I checked other csv files in `component_attrs` folder, their `default` columns are all with `object` dtype.


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
