### PR TITLE
add Python 3.12 to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
         - 3.9
         - "3.10"
         - "3.11"
+        - "3.12"
         os:
         - ubuntu-latest
         - macos-latest


### PR DESCRIPTION
release was on 2 Oct 23