### PR TITLE
Fixes to multi-decade optimisations

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -23,6 +23,10 @@ Upcoming Release
 
 * Bugfix: Fix primary energy limit and transmission volume limit global constraints for multi-period optimisations.
 
+* Regression fix: Fix multi-decade optimisations in highly meshed networks.
+
+* Enhancement: Allow optimising dispatch of only a subset of investment periods.
+
 PyPSA 0.25.2 (30th September 2023)
 ==================================
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -565,6 +565,8 @@ def define_nodal_balance_constraints(
     if suffix:
         lhs = lhs.rename(Bus=f"Bus{suffix}")
         rhs = rhs.rename(Bus=f"Bus{suffix}")
+        if mask is not None:
+            mask = mask.rename(Bus=f"Bus{suffix}")
     n.model.add_constraints(lhs, "=", rhs, f"Bus{suffix}-nodal_balance", mask=mask)
 
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -751,8 +751,8 @@ def define_storage_unit_constraints(n, sns):
         # We calculate the previous soc per period while cycling within a period
         # Normally, we should use groupby, but is broken for multi-index
         # see https://github.com/pydata/xarray/issues/6836
-        ps = n.investment_periods.rename("period")
-        sl = slice(None, None)
+        ps = sns.unique("period")
+        sl = slice(None)
         previous_soc_pp = [soc.data.sel(snapshot=(p, sl)).roll(snapshot=1) for p in ps]
         previous_soc_pp = concat(previous_soc_pp, dim="snapshot")
 
@@ -825,8 +825,8 @@ def define_store_constraints(n, sns):
         # We calculate the previous e per period while cycling within a period
         # Normally, we should use groupby, but is broken for multi-index
         # see https://github.com/pydata/xarray/issues/6836
-        ps = n.investment_periods.rename("period")
-        sl = slice(None, None)
+        ps = sns.unique("period")
+        sl = slice(None)
         previous_e_pp = [e.data.sel(snapshot=(p, sl)).roll(snapshot=1) for p in ps]
         previous_e_pp = concat(previous_e_pp, dim="snapshot")
 

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -256,8 +256,10 @@ def define_primary_energy_limit(n, sns):
     for name, glc in glcs.iterrows():
         if isnan(glc.investment_period):
             sns_sel = slice(None)
-        else:
+        elif glc.investment_period in sns.unique("period"):
             sns_sel = sns.get_loc(glc.investment_period)
+        else:
+            continue
 
         lhs = []
         rhs = glc.constant


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Regression fix: Fix multi-decade optimisations in highly meshed networks.

* Enhancement: Allow optimising dispatch of only a subset of investment periods.

```python
from pandas_indexing import isin
net.optimize(multi_investment_periods=True, snapshots=net.snapshots.loc[isin(period=2050)])
```

## Checklist

- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
