### PR TITLE
adjust plotting function

### DIFF
--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -309,7 +309,7 @@ def plot(
                 bus_norm = plt.Normalize(vmin=c.min(), vmax=c.max())
             c = c.apply(lambda cval: bus_cmap(bus_norm(cval)))
 
-        for b_i in s.index[s != 0]:
+        for b_i in s.index[(s != 0) & ~s.isna()]:
             radius = s.at[b_i] ** 0.5
             patches.append(
                 Circle(


### PR DESCRIPTION
## Changes proposed in this Pull Request
extends the already merged PR in #752. This allows that if you provide bus_sizes to the n.plot() method that only those buses are plotted. Hence, you can select a number of buses to plot instead of deleting them from the network before plotting the network.
From #752 this was not working, since buses which were not in bus_sizes were handled in the plot routine with nan values (see line 301) and this lead to an error in line 312.  

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
