### PR TITLE
Fixed bug for duplicate constraints in SCLOPT with multiple subnetworks

### DIFF
--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -213,7 +213,7 @@ def optimize_security_constrained(
         )
 
     # Allow existing constraints to carry through
-    if 'model' in dir(n):
+    if "model" in dir(n):
         m = n.model
     else:
         m = n.optimize.create_model(

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -237,7 +237,7 @@ def optimize_security_constrained(
             bodf = xr.DataArray(bodf, dims=[c_affected + "-affected", c_outage])
             additional_flow = (bodf * flow).rename({c_outage: c_outage + "-outage"})
             for bound, kind in product(("lower", "upper"), ("fix", "ext")):
-                constraint = c_affected + "-" + kind + "-s-" + bound
+                constraint = c_affected + "-" + kind + "-s-" + bound + '-' +str(sn)
                 if constraint not in m.constraints:
                     continue
                 lhs = m.constraints[constraint].lhs

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -212,11 +212,15 @@ def optimize_security_constrained(
             **kwargs,
         )
 
-    m = n.optimize.create_model(
-        snapshots=snapshots,
-        multi_investment_periods=multi_investment_periods,
-        **model_kwargs,
-    )
+    # Allow existing constraints to carry through
+    if 'model' in dir(n):
+        m = n.model
+    else:
+        m = n.optimize.create_model(
+            snapshots=snapshots,
+            multi_investment_periods=multi_investment_periods,
+            **model_kwargs,
+        )
 
     for sn in n.sub_networks.obj:
         branches_i = sn.branches_i()


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Added subnetwork name to constraints added in optimize_security_constrained to avoid repetition with multiple subnetworks

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
