### PR TITLE
remove numexpr version constraint

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -21,4 +21,3 @@ dependencies:
 - validators
 #  - coincbc
 #  - gurobi::gurobi
-- numexpr<=2.8.4 # until https://github.com/pandas-dev/pandas/issues/54449 resolved

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         "networkx>=1.10",
         "deprecation",
         "validators",
-        "numexpr<=2.8.4",  # until https://github.com/pandas-dev/pandas/issues/54449 resolved
     ],
     extras_require={
         "dev": ["pytest", "pypower", "pandapower", "scikit-learn"],


### PR DESCRIPTION
The bug of numexpr has been fixed in upstream.

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
