### PR TITLE
turn `n_mod` output into float

### DIFF
--- a/pypsa/component_attrs/generators.csv
+++ b/pypsa/component_attrs/generators.csv
@@ -36,7 +36,7 @@ weight,float,n/a,1,"Weighting of a generator. Only used for network clustering."
 p,series,MW,0.,active power at bus (positive if net generation),Output
 q,series,MVar,0.,reactive power (positive if net generation),Output
 p_nom_opt,float,MW,0.,Optimised nominal power.,Output
-n_mod,int,n/a,0,Optimised number of modular generators if ``p_nom_mod`` is non-zero.,Output
+n_mod,float,n/a,0,Optimised number of modular generators if ``p_nom_mod`` is non-zero.,Output
 status,series,n/a,1,"Status (1 is on, 0 is off). Only outputted if committable is True.",Output
 mu_upper,series,currency/MWh,0.,Shadow price of upper p_nom limit,Output
 mu_lower,series,currency/MWh,0.,Shadow price of lower p_nom limit,Output

--- a/pypsa/component_attrs/lines.csv
+++ b/pypsa/component_attrs/lines.csv
@@ -34,6 +34,6 @@ b_pu,float,per unit,0,Per unit shunt susceptance calculated by PyPSA from b and 
 x_pu_eff,float,per unit,0,"Effective per unit series reactance for linear power flow, calculated by PyPSA from x, tap_ratio for transformers and bus.v_nom.",Output
 r_pu_eff,float,per unit,0,"Effective per unit series resistance for linear power flow, calculated by PyPSA from x, tap_ratio for transformers and bus.v_nom.",Output
 s_nom_opt,float,MVA,0,Optimised capacity for apparent power.,Output
-n_mod,int,n/a,0,Optimised number of modular lines if ``s_nom_mod`` is non-zero.,Output
+n_mod,float,n/a,0,Optimised number of modular lines if ``s_nom_mod`` is non-zero.,Output
 mu_lower,series,currency/MVA,0.,Shadow price of lower s_nom limit  -F \leq f. Always non-negative.,Output
 mu_upper,series,currency/MVA,0.,Shadow price of upper s_nom limit f \leq F. Always non-negative.,Output

--- a/pypsa/component_attrs/links.csv
+++ b/pypsa/component_attrs/links.csv
@@ -35,7 +35,7 @@ ramp_limit_shut_down,float,per unit,1,"Maximum decrease at shut down, per unit o
 p0,series,MW,0.,Active power at bus0 (positive if branch is withdrawing power from bus0).,Output
 p1,series,MW,0.,Active power at bus1 (positive if branch is withdrawing power from bus1).,Output
 p_nom_opt,float,MW,0,Optimised capacity for active power.,Output
-n_mod,int,n/a,0,Optimised number of modular links if ``p_nom_mod`` is non-zero.,Output
+n_mod,float,n/a,0,Optimised number of modular links if ``p_nom_mod`` is non-zero.,Output
 status,series,n/a,1.,"Status (1 is on, 0 is off). Only outputted if committable is True.",Output
 mu_lower,series,currency/MW,0.,Shadow price of lower p_nom limit  -F \leq f. Always non-negative.,Output
 mu_upper,series,currency/MW,0.,Shadow price of upper p_nom limit f \leq F. Always non-negative.,Output

--- a/pypsa/component_attrs/storage_units.csv
+++ b/pypsa/component_attrs/storage_units.csv
@@ -36,7 +36,7 @@ q,series,MVar,0,reactive power (positive if net generation),Output
 state_of_charge,series,MWh,NaN,State of charge as calculated by the OPF.,Output
 spill,series,MW,0,Spillage for each snapshot.,Output
 p_nom_opt,float,MW,0,Optimised nominal power.,Output
-n_mod,int,n/a,0,Optimised number of moudaler storage units if ``p_nom_mod`` is non-zero.,Output
+n_mod,float,n/a,0,Optimised number of moudaler storage units if ``p_nom_mod`` is non-zero.,Output
 mu_upper,series,currency/MWh,0,Shadow price of upper p_nom limit,Output
 mu_lower,series,currency/MWh,0,Shadow price of lower p_nom limit,Output
 mu_state_of_charge_set,series,currency/MWh,0,Shadow price of fixed state of charge state_of_charge_set,Output

--- a/pypsa/component_attrs/stores.csv
+++ b/pypsa/component_attrs/stores.csv
@@ -27,7 +27,7 @@ p,series,MW,0,active power at bus (positive if net generation),Output
 q,series,MVar,0,reactive power (positive if net generation),Output
 e,series,MWh,0,Energy as calculated by the OPF.,Output
 e_nom_opt,float,MWh,0,Optimised nominal energy capacity outputed by OPF.,Output
-n_mod,int,n/a,0,Optimised number of modular stores if ``e_nom_mod`` is non-zero.,Output
+n_mod,float,n/a,0,Optimised number of modular stores if ``e_nom_mod`` is non-zero.,Output
 mu_upper,series,currency/MWh,0,Shadow price of upper e_nom limit,Output
 mu_lower,series,currency/MWh,0,Shadow price of lower e_nom limit,Output
 mu_energy_balance,series,currency/MWh,0,Shadow price of storage consistency equations,Output

--- a/pypsa/component_attrs/transformers.csv
+++ b/pypsa/component_attrs/transformers.csv
@@ -36,6 +36,6 @@ b_pu,float,per unit,0,Per unit shunt susceptance calculated by PyPSA from b and 
 x_pu_eff,float,per unit,0,"Effective per unit series reactance for linear power flow, calculated by PyPSA from x, tap_ratio for transformers and bus.v_nom.",Output
 r_pu_eff,float,per unit,0,"Effective per unit series resistance for linear power flow, calculated by PyPSA from x, tap_ratio for transformers and bus.v_nom.",Output
 s_nom_opt,float,MVA,0,Optimised capacity for apparent power.,Output
-n_mod,int,n/a,0,Optimised number of modular transformers if ``s_nom_mod`` is non-zero.,Output
+n_mod,float,n/a,0,Optimised number of modular transformers if ``s_nom_mod`` is non-zero.,Output
 mu_lower,series,currency/MVA,0,Shadow price of lower s_nom limit  -F \leq f. Always non-negative.,Output
 mu_upper,series,currency/MVA,0,Shadow price of upper s_nom limit f \leq F. Always non-negative.,Output


### PR DESCRIPTION
... better even to remove n_mod since it contains duplicate information (can be calculated through s_nom_opt/s_nom_mod)