### PR TITLE
remove `n_mod` output attribute

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,10 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* The output attribute ``n_mod`` introduced in the previous version was removed
+  since it contains duplicate information. Calculate the number of expanded
+  modules with ``p_nom_opt / p_nom_mod`` instead.
+
 PyPSA 0.26.0 (4th December 2023)
 ================================
 

--- a/pypsa/component_attrs/generators.csv
+++ b/pypsa/component_attrs/generators.csv
@@ -36,7 +36,6 @@ weight,float,n/a,1,"Weighting of a generator. Only used for network clustering."
 p,series,MW,0.,active power at bus (positive if net generation),Output
 q,series,MVar,0.,reactive power (positive if net generation),Output
 p_nom_opt,float,MW,0.,Optimised nominal power.,Output
-n_mod,int,n/a,0,Optimised number of modular generators if ``p_nom_mod`` is non-zero.,Output
 status,series,n/a,1,"Status (1 is on, 0 is off). Only outputted if committable is True.",Output
 mu_upper,series,currency/MWh,0.,Shadow price of upper p_nom limit,Output
 mu_lower,series,currency/MWh,0.,Shadow price of lower p_nom limit,Output

--- a/pypsa/component_attrs/lines.csv
+++ b/pypsa/component_attrs/lines.csv
@@ -34,6 +34,5 @@ b_pu,float,per unit,0,Per unit shunt susceptance calculated by PyPSA from b and 
 x_pu_eff,float,per unit,0,"Effective per unit series reactance for linear power flow, calculated by PyPSA from x, tap_ratio for transformers and bus.v_nom.",Output
 r_pu_eff,float,per unit,0,"Effective per unit series resistance for linear power flow, calculated by PyPSA from x, tap_ratio for transformers and bus.v_nom.",Output
 s_nom_opt,float,MVA,0,Optimised capacity for apparent power.,Output
-n_mod,int,n/a,0,Optimised number of modular lines if ``s_nom_mod`` is non-zero.,Output
 mu_lower,series,currency/MVA,0.,Shadow price of lower s_nom limit  -F \leq f. Always non-negative.,Output
 mu_upper,series,currency/MVA,0.,Shadow price of upper s_nom limit f \leq F. Always non-negative.,Output

--- a/pypsa/component_attrs/links.csv
+++ b/pypsa/component_attrs/links.csv
@@ -35,7 +35,6 @@ ramp_limit_shut_down,float,per unit,1,"Maximum decrease at shut down, per unit o
 p0,series,MW,0.,Active power at bus0 (positive if branch is withdrawing power from bus0).,Output
 p1,series,MW,0.,Active power at bus1 (positive if branch is withdrawing power from bus1).,Output
 p_nom_opt,float,MW,0,Optimised capacity for active power.,Output
-n_mod,int,n/a,0,Optimised number of modular links if ``p_nom_mod`` is non-zero.,Output
 status,series,n/a,1.,"Status (1 is on, 0 is off). Only outputted if committable is True.",Output
 mu_lower,series,currency/MW,0.,Shadow price of lower p_nom limit  -F \leq f. Always non-negative.,Output
 mu_upper,series,currency/MW,0.,Shadow price of upper p_nom limit f \leq F. Always non-negative.,Output

--- a/pypsa/component_attrs/storage_units.csv
+++ b/pypsa/component_attrs/storage_units.csv
@@ -36,7 +36,6 @@ q,series,MVar,0,reactive power (positive if net generation),Output
 state_of_charge,series,MWh,NaN,State of charge as calculated by the OPF.,Output
 spill,series,MW,0,Spillage for each snapshot.,Output
 p_nom_opt,float,MW,0,Optimised nominal power.,Output
-n_mod,int,n/a,0,Optimised number of moudaler storage units if ``p_nom_mod`` is non-zero.,Output
 mu_upper,series,currency/MWh,0,Shadow price of upper p_nom limit,Output
 mu_lower,series,currency/MWh,0,Shadow price of lower p_nom limit,Output
 mu_state_of_charge_set,series,currency/MWh,0,Shadow price of fixed state of charge state_of_charge_set,Output

--- a/pypsa/component_attrs/stores.csv
+++ b/pypsa/component_attrs/stores.csv
@@ -27,7 +27,6 @@ p,series,MW,0,active power at bus (positive if net generation),Output
 q,series,MVar,0,reactive power (positive if net generation),Output
 e,series,MWh,0,Energy as calculated by the OPF.,Output
 e_nom_opt,float,MWh,0,Optimised nominal energy capacity outputed by OPF.,Output
-n_mod,int,n/a,0,Optimised number of modular stores if ``e_nom_mod`` is non-zero.,Output
 mu_upper,series,currency/MWh,0,Shadow price of upper e_nom limit,Output
 mu_lower,series,currency/MWh,0,Shadow price of lower e_nom limit,Output
 mu_energy_balance,series,currency/MWh,0,Shadow price of storage consistency equations,Output

--- a/pypsa/component_attrs/transformers.csv
+++ b/pypsa/component_attrs/transformers.csv
@@ -36,6 +36,5 @@ b_pu,float,per unit,0,Per unit shunt susceptance calculated by PyPSA from b and 
 x_pu_eff,float,per unit,0,"Effective per unit series reactance for linear power flow, calculated by PyPSA from x, tap_ratio for transformers and bus.v_nom.",Output
 r_pu_eff,float,per unit,0,"Effective per unit series resistance for linear power flow, calculated by PyPSA from x, tap_ratio for transformers and bus.v_nom.",Output
 s_nom_opt,float,MVA,0,Optimised capacity for apparent power.,Output
-n_mod,int,n/a,0,Optimised number of modular transformers if ``s_nom_mod`` is non-zero.,Output
 mu_lower,series,currency/MVA,0,Shadow price of lower s_nom limit  -F \leq f. Always non-negative.,Output
 mu_upper,series,currency/MVA,0,Shadow price of upper s_nom limit f \leq F. Always non-negative.,Output

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -1393,9 +1393,7 @@ def assign_solution(
                 non_ext = n.df(c)[attr]
                 n.df(c)[attr + "_opt"] = sol.reindex(non_ext.index).fillna(non_ext)
             else:
-                if attr.endswith("-n_mod"):
-                    n.df(c)["n_mod"].update(sol)
-                else:
+                if not attr.endswith("-n_mod"):
                     n.sols[c].df[attr] = sol
 
     n.sols = Dict()

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -353,9 +353,7 @@ def assign_solution(n):
 
             else:
                 set_from_frame(n, c, attr, df)
-        elif attr == "n_mod":
-            n.df(c)[attr].update(df)
-        else:
+        elif attr != "n_mod":
             n.df(c)[attr + "_opt"].update(df)
 
     # if nominal capacity was no variable set optimal value to nominal

--- a/test/test_lopf_modularity.py
+++ b/test/test_lopf_modularity.py
@@ -48,8 +48,8 @@ def test_modular_components(api):
 
     optimize(n, api)
 
-    expected_n_opt_gen = np.array([5], dtype=float).T
-    expected_n_opt_store = np.array([10], dtype=float).T
+    expected_p_nom_opt_gen = np.array([5000], dtype=float).T
+    expected_e_nom_opt_store = np.array([1000], dtype=float).T
 
-    equal(n.generators.n_mod, expected_n_opt_gen)
-    equal(n.stores.n_mod, expected_n_opt_store)
+    equal(n.generators.p_nom_opt, expected_p_nom_opt_gen)
+    equal(n.stores.e_nom_opt, expected_e_nom_opt_store)


### PR DESCRIPTION
because:

- it only contains duplicate information (can calculate via `p_nom_opt / p_nom_mod`)
- the `int` output caused problems