### PR TITLE
Fix indentation in quick_start.rst

### DIFF
--- a/doc/quick_start.rst
+++ b/doc/quick_start.rst
@@ -29,7 +29,7 @@ The same counts for lines, generators and loads, see the list of all components 
 
 .. code:: python
 
-	#add three lines in a ring
+    #add three lines in a ring
     for i in range(n_buses):
         network.add("Line", "My line {}".format(i),
 		    bus0="My bus {}".format(i),


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes some indentation of a code line in the documentation.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
