### PR TITLE
bugfix: sign error in line capacity constraint with losses

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,9 @@ Upcoming Release
 
 .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* Bugfix: With line transmission losses there was a sign error in the
+  calculation of the line capacity constraints.
+
 PyPSA 0.26.2 (31st December 2023)
 =================================
 

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -189,7 +189,7 @@ def define_dispatch_for_extendable_constraints(n, sns, c, attr, transmission_los
     if c in n.passive_branch_components and not n.df(c).empty and transmission_losses:
         loss = get_var(n, c, "loss")[ext_i]
         lhs_upper.append((-1, loss))
-        lhs_lower.append((-1, loss))
+        lhs_lower.append((1, loss))
     lhs, *axes = linexpr(*lhs_upper, return_axes=True)
     define_constraints(n, lhs, ">=", rhs, c, "mu_upper", axes=axes, **kwargs)
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -101,8 +101,8 @@ def define_operational_constraints_for_extendables(
     lhs_upper = (1, dispatch), (-max_pu, capacity)
     if c in n.passive_branch_components and transmission_losses:
         loss = reindex(n.model[f"{c}-loss"], c, ext_i)
-        lhs_upper += ((-1, loss),)
-        lhs_lower += ((1, loss),)
+        lhs_lower += ((-1, loss),)
+        lhs_upper += ((1, loss),)
 
     n.model.add_constraints(lhs_lower, ">=", 0, f"{c}-ext-{attr}-lower", active)
     n.model.add_constraints(lhs_upper, "<=", 0, f"{c}-ext-{attr}-upper", active)

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -101,7 +101,7 @@ def define_operational_constraints_for_extendables(
     lhs_upper = (1, dispatch), (-max_pu, capacity)
     if c in n.passive_branch_components and transmission_losses:
         loss = reindex(n.model[f"{c}-loss"], c, ext_i)
-        lhs_upper += ((1, loss),)
+        lhs_upper += ((-1, loss),)
         lhs_lower += ((1, loss),)
 
     n.model.add_constraints(lhs_lower, ">=", 0, f"{c}-ext-{attr}-lower", active)


### PR DESCRIPTION
This is a relatively minor bug as the sign error only affects the line capacity limits in one direction and only to the level of the transmission losses. Only extendable lines are affected.

The pyomo version is not affected by this. Bug must have been introduced in translation to nomopyomo and then carried over into the linopy backend.

The constraint should mirror: https://arxiv.org/pdf/2008.11510.pdf equation 32