### PR TITLE
store transmission losses via n.lines_t.p{0,1}

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,11 @@ Upcoming Release
 * Bugfix: With line transmission losses there was a sign error in the
   calculation of the line capacity constraints.
 
+* Approximated transmission losses of lines are now stored after optimisation as
+  the difference between ``n.lines_t.p0`` and ``n.lines_t.p1`` so that they
+  appear in the energy balance (e.g. ``n.statistics.energy_balance()``) and when
+  calculating losses with ``n.lines_t.p0 + n.lines_t.p1``.
+
 PyPSA 0.26.2 (31st December 2023)
 =================================
 

--- a/pypsa/linopf.py
+++ b/pypsa/linopf.py
@@ -1479,6 +1479,12 @@ def assign_solution(
     if len(n.loads):
         set_from_frame(n.pnl("Load"), "p", get_as_dense(n, "Load", "p_set", sns))
 
+    # line losses
+    if "Line" in n.sols and "loss" in n.sols["Line"].pnl:
+        losses = n.sols["Line"].pnl["loss"]
+        n.lines_t.p0 += losses / 2
+        n.lines_t.p1 += losses / 2
+
     # clean up vars and cons
     for c in list(n.vars):
         if n.vars[c].df.empty and n.vars[c].pnl == {}:

--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -2048,6 +2048,9 @@ def extract_optimisation_results(
             loss_values = get_values(network.model.loss)
 
             set_from_series(c.pnl.loss, loss_values.loc[c.name])
+
+            c.pnl.p1.loc[snapshots] += c.pnl.loss / 2
+            c.pnl.p0.loc[snapshots] += c.pnl.loss / 2
     del flow_lower, flow_upper
 
     # active branches

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -452,6 +452,12 @@ def post_processing(n):
     if len(n.loads):
         set_from_frame(n, "Load", "p", get_as_dense(n, "Load", "p_set", sns))
 
+    # line losses
+    if "Line-loss" in n.model.variables:
+        losses = n.model["Line-loss"].solution.to_pandas()
+        n.lines_t.p0 += losses / 2
+        n.lines_t.p1 += losses / 2
+
     # recalculate injection
     ca = [
         ("Generator", "p", "bus"),


### PR DESCRIPTION
Example model:

```py
import pypsa
n = pypsa.Network()
n.madd("Bus", ["A", "B"])
n.add("Line", "A-B", x=1, r=0.003, s_nom=50, bus0="A", bus1="B")
n.madd("Load", ["load A", "load B"], bus=["A", "B"], p_set=[20, 40], carrier=["A", "B"])
n.madd("Generator", ["gen A", "gen B"], bus=["A", "B"], carrier=["A", "B"], p_nom=[50, 80], marginal_cost=[10, 40])
n.optimize(solver_name='highs', transmission_losses=3)
n.statistics.energy_balance()
```