### PR TITLE
Fix budget calculation for MGA on multi-horizon model

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,10 @@ Upcoming Release
 
 * Bugfixes in building of global constraints in multi-horizon optimisations.
 
+* Fixed total budget calculation for MGA on multi-horizon optimisations.
+
+* The `extra_functionality` argument is now also supported in `solve_model` accessor.
+
 PyPSA 0.26.3 (25th January 2024)
 =================================
 

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -371,8 +371,16 @@ def optimize_mga(
     )
 
     # build budget constraint
-    optimal_cost = (n.statistics.capex() + n.statistics.opex()).sum()
-    fixed_cost = n.statistics.installed_capex().sum()
+    if not multi_investment_periods:
+        optimal_cost = (n.statistics.capex() + n.statistics.opex()).sum()
+        fixed_cost = n.statistics.installed_capex().sum()
+    else:
+        w = n.investment_period_weightings.objective
+        optimal_cost = (
+            n.statistics.capex().sum() * w + n.statistics.opex().sum() * w
+        ).sum()
+        fixed_cost = (n.statistics.installed_capex().sum() * w).sum()
+
     objective = m.objective
     if not isinstance(objective, (LinearExpression, QuadraticExpression)):
         objective = objective.expression

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -602,7 +602,12 @@ class OptimizationAccessor:
         return create_model(self._parent, *args, **kwargs)
 
     def solve_model(
-        self, solver_name="glpk", solver_options={}, assign_all_duals=False, **kwargs
+        self,
+        extra_functionality=None,
+        solver_name="glpk",
+        solver_options={},
+        assign_all_duals=False,
+        **kwargs,
     ):
         """
         Solve an already created model and assign its solution to the network.
@@ -621,6 +626,8 @@ class OptimizationAccessor:
             `problem_fn` or solver options directly passed to the solver.
         """
         n = self._parent
+        if extra_functionality:
+            extra_functionality(n, n.snapshots)
         m = n.model
         status, condition = m.solve(solver_name=solver_name, **solver_options, **kwargs)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

The budget calculation for MGA on a multi-horizon model used to lead to an error given that `n.statistics.capex()` etc. would return a series indexed by investment period. Instead, these investment periods should be summed over using the correct investment period weightings.

I've tested the changes locally and it seems to work well.

What's not done yet is to add a test combining MGA with a model with multiple investment horizons.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
