### PR TITLE
Orient mga weights dict as "list" to allow multiindex json dump

### DIFF
--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -424,7 +424,7 @@ def optimize_mga(
 
     def convert_to_dict(obj):
         if isinstance(obj, (pd.Series, pd.DataFrame)):
-            return obj.to_dict()
+            return obj.to_dict(orient="list")
         elif isinstance(obj, dict):
             return {k: convert_to_dict(v) for k, v in obj.items()}
         else:


### PR DESCRIPTION
## Changes proposed in this Pull Request

In `optimize_mga` the weights are helpfully put in `Network.meta`, but this fails when snapshots are indexed by `Timestamp`s or, especially, when the network is defined over multiple investment periods and the snapshots are indexed by a MultiIndex. In the latter case, conversion of the MultiIndex to a dict results in tuples as keys, which is not supported by json. This then breaks exports to NetCDF.

It's fixed with this commit; I reckon the user will be able to deal with the absence of the index in the weights dict since it's stored elsewhere in the network anyway. (See https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_dict.html for `to_dict` options.)

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
