### PR TITLE
Update pyomo version range to include 6.7 

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,7 +12,6 @@ dependencies:
 - pytables
 - matplotlib
 - networkx>=1.10
-- pyomo
 - cartopy>=0.16
 - coincbc
 - glpk

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -18,6 +18,8 @@ Upcoming Release
 
 * `optimize_mga` now returns the solver termination status and condition.
 
+* Updated pyomo dependency to include version 6.7 to be able to use latest pypsa version with python 3.12.
+
 
 PyPSA 0.26.3 (25th January 2024)
 =================================

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
 - pytables
 - matplotlib
 - networkx>=1.10
-- pyomo>=5.7.0,<6.6.2
+- pyomo>=5.7.0,<=6.7
 - cartopy>=0.16
 - geopandas>=0.9
 - glpk

--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -14,7 +14,7 @@ dependencies:
 - pytables
 - matplotlib
 - networkx>=1.10
-- pyomo>=5.7.0,<6.6.2
+- pyomo>=5.7.0,<=6.7
 - cartopy>=0.16
 - geopandas>=0.9
 - glpk

--- a/environment_docs.yml
+++ b/environment_docs.yml
@@ -15,7 +15,7 @@ dependencies:
 - pytables
 - matplotlib
 - networkx>=1.10
-- pyomo<6.6.2
+- pyomo<=6.7
 - cartopy>=0.16
 - geopandas>=0.9
 - coincbc

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "xarray",
         "netcdf4",
         "tables",
-        "pyomo>=5.7,<6.6.2",
+        "pyomo>=5.7,<=6.7",
         "linopy>=0.2.1",
         "matplotlib",
         "geopandas>=0.9",


### PR DESCRIPTION
Closes #829 

## Changes proposed in this Pull Request
Updated pyomo range to 6.7 to be able to use the latest version of pypsa with python 3.12, since pyomo 3.7 is the first one supported on python 3.12.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ x] I consent to the release of this PR's code under the MIT license.
