### PR TITLE
fix statistics bug 

### DIFF
--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -1002,7 +1002,7 @@ class StatisticsAccessor:
                     for port in get_ports(n, c)
                 ]
                 mask = reduce(np.logical_or, masks)
-                p = p.loc[:, mask]
+                p = p.loc[:, mask.astype(bool)]
 
             weights = get_weightings(n, c)
             return aggregate_timeseries(p, weights, agg=aggregate_time)
@@ -1055,7 +1055,7 @@ class StatisticsAccessor:
                     for port in get_ports(n, c)
                 ]
                 mask = reduce(np.logical_or, masks)
-                p = p.loc[:, mask]
+                p = p.loc[:, mask.astype(bool)]
 
             weights = get_weightings(n, c)
             return aggregate_timeseries(p, weights, agg=aggregate_time)


### PR DESCRIPTION
for capacity factor and curtailment, we did not consider one port components in combination with bus_carrier. E.g. `n.statistics.curtailment(bus_carrier='AC')`

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
