### PR TITLE
global_constraints: allow non-one-port components in global carrier c…

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,7 +9,7 @@ Upcoming Release
 
 * If plotting a network map with split buses (``n.plot(bus_split_circles=True)``), the bus sizes are now scaled by factor 2 to account for the fact that the bus sizes are split into half circles. This makes the area scaling of the buses consistent with the area of non-split buses.
 
-* The depreacted functions ``_make_consense``, ``aggregategenerators``, ``get_buses_linemap_and_lines`` and ``get_clustering_from_busmap`` were removed.
+* The deprecated functions ``_make_consense``, ``aggregategenerators``, ``get_buses_linemap_and_lines`` and ``get_clustering_from_busmap`` were removed.
 
 * Bugfixes in building of global constraints in multi-horizon optimisations.
 
@@ -22,6 +22,8 @@ Upcoming Release
 * The minimum ``networkx`` version was bumped from ``1.10`` to ``2``.
 
 * ``pyomo`` is no longer supported for Python 3.12 or higher.
+
+* The global constraint ``define_tech_capacity_expansion_limit`` now also takes branch components into account. If defined per bus, the `bus0` of the branch is considered as a reference bus.
 
 PyPSA 0.26.3 (25th January 2024)
 =================================

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -50,7 +50,7 @@ def define_tech_capacity_expansion_limit(n, sns):
             dim = f"{c}-ext"
             df = n.df(c)
 
-            if c not in n.one_port_components or "carrier" not in df:
+            if "carrier" not in df:
                 continue
 
             ext_i = (
@@ -64,7 +64,8 @@ def define_tech_capacity_expansion_limit(n, sns):
             if ext_i.empty:
                 continue
 
-            busmap = df.loc[ext_i, "bus"].rename(busdim).to_xarray()
+            bus = "bus0" if c in n.branch_components else "bus"
+            busmap = df.loc[ext_i, bus].rename(busdim).to_xarray()
             expr = m[var].loc[ext_i].groupby(busmap).sum()
             lhs_per_bus.append(expr)
 


### PR DESCRIPTION
…apacity limit


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
