### PR TITLE
Fix calculation of MGA cost bound

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,8 @@ Release Notes
 
 .. .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* Fixed sometimes-faulty total budget calculation for single-horizon MGA optimisations.
+
 PyPSA 0.27.0 (18th February 2024)
 =================================
 

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -377,7 +377,7 @@ def optimize_mga(
 
     # build budget constraint
     if not multi_investment_periods:
-        optimal_cost = (n.statistics.capex() + n.statistics.opex()).sum()
+        optimal_cost = n.statistics.capex().sum() + n.statistics.opex().sum()
         fixed_cost = n.statistics.installed_capex().sum()
     else:
         w = n.investment_period_weightings.objective


### PR DESCRIPTION
## Changes proposed in this Pull Request

I uncovered another issue with the MGA cost bound calculation; hopefully it really should be fixed now. The code would previously sometimes give the wrong number, but potentially only for a subset of components including already installed capacities or something. Anyway, the addition of the `n.statistics.capex()` and `n.statistics.opex()` dataframes doesn't work as-is and they need to be summed before adding the totals.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
