### PR TITLE
Port consideration in statistics module

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,7 +13,11 @@ Release Notes
   requires disjunct component indices and identical snapshots and snapshot
   weightings.
 
-* The statistics module introduces a new keyword argument `at_port` to all functions. This allows considering the port of a component when calculating statistics. ...
+* The statistics module introduces a new keyword argument `at_port` to all functions. This allows considering the port of a component when calculating statistics. Depending on the function, the default of `at_port` is set to `True` or `False`, for example for the dispatch all ports are considered.
+
+* The statistics module now supports an optional `port` argument in `groupby` functions. This allows to group statistics while considering the port of a component.
+
+* The `statistics.revenue` function introduces a new keyword argument `kind` to optionally calculate the revenue based on the `input` commodity or the `output` commodity of a component.
 
 PyPSA 0.27.1 (22nd March 2024)
 =================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,8 +13,10 @@ Release Notes
   requires disjunct component indices and identical snapshots and snapshot
   weightings.
 
+* The statistics module introduces a new keyword argument `at_port` to all functions. This allows considering the port of a component when calculating statistics. ...
 
 PyPSA 0.27.1 (22nd March 2024)
+=================================
 
 * Fixed sometimes-faulty total budget calculation for single-horizon MGA optimisations.
 

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -68,6 +68,16 @@ def test_zero_profit_rule_branches(ac_dc_network_r):
     assert np.allclose(revenue[comps], capex[comps])
 
 
+def test_net_and_gross_revenue(ac_dc_network_r):
+    n = ac_dc_network_r
+    target = n.statistics.revenue(aggregate_time="sum")
+    revenue_out = n.statistics.revenue(aggregate_time="sum", kind="output")
+    revenue_in = n.statistics.revenue(aggregate_time="sum", kind="input")
+    revenue = revenue_in.sub(revenue_out, fill_value=0)
+    comps = ["Generator", "Line", "Link"]
+    assert np.allclose(revenue[comps], target[comps])
+
+
 def test_no_grouping(ac_dc_network_r):
     df = ac_dc_network_r.statistics(groupby=False)
     assert not df.empty


### PR DESCRIPTION
* The statistics module introduces a new keyword argument `at_port` to all functions. This allows considering the port of a component when calculating statistics. Depending on the function, the default of `at_port` is set to `True` or `False`, for example for the dispatch all ports are considered.

* The statistics module now supports an optional `port` argument in `groupby` functions. This allows to group statistics while considering the port of a component.

* The `statistics.revenue` function introduces a new keyword argument `kind` to optionally calculate the revenue based on the `input` commodity or the `output` commodity of a component.


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
