### PR TITLE
Improve statistics 2.0

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,7 +13,11 @@ Release Notes
   requires disjunct component indices and identical snapshots and snapshot
   weightings.
 
-* The statistics module introduces a new keyword argument `at_port` to all functions. This allows considering the port of a component when calculating statistics. ...
+* The statistics module introduces a new keyword argument `at_port` to all functions. This allows considering the port of a component when calculating statistics. Depending on the function, the default of `at_port` is set to `True` or `False`, for example for the dispatch all ports are considered.
+
+* The statistics module now supports an optional `port` argument in `groupby` functions. This allows to group statistics while considering the port of a component.
+
+* The `statistics.revenue` function introduces a new keyword argument `kind` to optionally calculate the revenue based on the `input` commodity or the `output` commodity of a component.
 
 PyPSA 0.27.1 (22nd March 2024)
 =================================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,8 +13,10 @@ Release Notes
   requires disjunct component indices and identical snapshots and snapshot
   weightings.
 
+* The statistics module introduces a new keyword argument `at_port` to all functions. This allows considering the port of a component when calculating statistics. ...
 
 PyPSA 0.27.1 (22nd March 2024)
+=================================
 
 * Fixed sometimes-faulty total budget calculation for single-horizon MGA optimisations.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,16 @@ Release Notes
 
 .. .. warning:: The features listed below are not released yet, but will be part of the next release! To use the features already you have to install the ``master`` branch, e.g. ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* The statistics module introduces a new keyword argument `at_port` to all functions. This allows considering the port of a component when calculating statistics. Depending on the function, the default of `at_port` is set to `True` or `False`, for example for the dispatch all ports are considered.
+
+* The statistics module now supports an optional `port` argument in `groupby` functions. This allows to group statistics while considering the port of a component.
+
+* The `statistics.revenue` function introduces a new keyword argument `kind` to optionally calculate the revenue based on the `input` commodity or the `output` commodity of a component.
+
+* The `statistics.energy_balance` function introduces a new keyword argument `kind` to optionally calculate the `supply` and `withdrawal` of a component.
+
+* Deprecation warnings are added to the statistics module for the functionalities that will be removed in the next major release.
+
 * A new function ``n.merge()`` was added allowing the components and
   time-dependent data of one network to be added to another network. The
   function is also available via ``n + m`` with default settings. The function
@@ -14,11 +24,6 @@ Release Notes
   weightings.
 
 * Updated environment_doc.yml to include the latest required pip dependencies for the documentation environment.
-* The statistics module introduces a new keyword argument `at_port` to all functions. This allows considering the port of a component when calculating statistics. Depending on the function, the default of `at_port` is set to `True` or `False`, for example for the dispatch all ports are considered.
-
-* The statistics module now supports an optional `port` argument in `groupby` functions. This allows to group statistics while considering the port of a component.
-
-* The `statistics.revenue` function introduces a new keyword argument `kind` to optionally calculate the revenue based on the `input` commodity or the `output` commodity of a component.
 
 PyPSA 0.27.1 (22nd March 2024)
 =================================

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -129,11 +129,6 @@ def get_ports(n, c):
     return [col[3:] for col in n.df(c) if col.startswith("bus")]
 
 
-def get_stacked_ports(n, c):
-    ports = get_ports(n, c)
-    return pd.concat([n.df(c)[f"bus{p}"][lambda ds: ds != ""] for p in ports])
-
-
 def port_mask(n, c, port="", bus_carrier=None):
     """
     Get a mask of components which are optionally connected to a bus with a

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -124,7 +124,7 @@ def get_weightings(n, c):
 
 
 # TODO: remove in 0.29
-@deprecated(removed_in="0.29")
+@deprecated(deprecated_in="0.28", removed_in="0.29")
 def get_ports(n, c):
     """
     Get a list of existent ports of a component.
@@ -801,7 +801,9 @@ class StatisticsAccessor:
         return df
 
     # TODO: remove in 0.29
-    @deprecated(removed_in="0.29", details="Use 'energy_balance' instead.")
+    @deprecated(
+        deprecated_in="0.28", removed_in="0.29", details="Use 'energy_balance' instead."
+    )
     def dispatch(
         self,
         comps=None,
@@ -948,7 +950,7 @@ class StatisticsAccessor:
                     "Argument 'groupby' is ignored when 'aggregate_bus' is set to True. Falling back to default."
                 )
             logger.warning(
-                "Argument 'aggregate_bus' is deprecated and will be removed in the next release. Use grouper `get_bus_and_carrier_and_bus_carrier` instead."
+                "Argument 'aggregate_bus' is deprecated in 0.28 and will be removed in 0.29. Use grouper `get_bus_and_carrier_and_bus_carrier` instead."
             )
             switch = True
             groupby = get_bus_and_carrier_and_bus_carrier

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -745,7 +745,6 @@ class StatisticsAccessor:
                 p = n.pnl(c).p
 
             opex = p * n.get_switchable_as_dense(c, "marginal_cost")
-            opex = opex.loc[:, (opex != 0).any()]
             weights = get_weightings(n, c)
             return aggregate_timeseries(opex, weights, agg=aggregate_time)
 
@@ -863,6 +862,10 @@ class StatisticsAccessor:
             Note that for {'mean', 'sum'} the time series are aggregated to MWh
             using snapshot weightings. With False the time series is given in MW. Defaults to 'sum'.
         """
+        logging.warning(
+            "Method 'dispatch' is deprecated and will be removed in the next release. Use 'energy_balance' instead."
+        )
+
         n = self._parent
 
         df = self.energy_balance(
@@ -983,12 +986,12 @@ class StatisticsAccessor:
             weights = get_weightings(n, c)
             p = sign * n.pnl(c)[f"p{port}"]
             if kind == "supply":
-                p = sign * n.pnl(c)[f"p{port}"].clip(upper=0)
+                p = p.clip(lower=0)
             elif kind == "withdrawal":
-                p = -sign * n.pnl(c)[f"p{port}"].clip(lower=0)
+                p = -p.clip(upper=0)
             elif kind != None:
                 logger.warning(
-                    f"Argument 'kind' is not recognized. Falling back to dispatch."
+                    f"Argument 'kind' is not recognized. Falling back to energy balance."
                 )
             return aggregate_timeseries(p, weights, agg=aggregate_time)
 
@@ -1161,7 +1164,6 @@ class StatisticsAccessor:
                         f"Argument 'kind' must be 'input', 'output' or None, got {kind}"
                     )
             revenue = df * prices
-            revenue = revenue.loc[:, (revenue != 0).any()]
             weights = get_weightings(n, c)
             return aggregate_timeseries(revenue, weights, agg=aggregate_time)
 

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -73,9 +73,18 @@ def test_net_and_gross_revenue(ac_dc_network_r):
     target = n.statistics.revenue(aggregate_time="sum")
     revenue_out = n.statistics.revenue(aggregate_time="sum", kind="output")
     revenue_in = n.statistics.revenue(aggregate_time="sum", kind="input")
-    revenue = revenue_in.sub(revenue_out, fill_value=0)
+    revenue = revenue_in.add(revenue_out, fill_value=0)
     comps = ["Generator", "Line", "Link"]
     assert np.allclose(revenue[comps], target[comps])
+
+
+def test_supply_withdrawal(ac_dc_network_r):
+    n = ac_dc_network_r
+    target = n.statistics.energy_balance()
+    supply = n.statistics.energy_balance(kind="supply")
+    withdrawal = n.statistics.energy_balance(kind="withdrawal")
+    energy_balance = supply.sub(withdrawal, fill_value=0)
+    assert np.allclose(energy_balance.reindex(target.index), target)
 
 
 def test_no_grouping(ac_dc_network_r):

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -68,6 +68,16 @@ def test_zero_profit_rule_branches(ac_dc_network_r):
     assert np.allclose(revenue[comps], capex[comps])
 
 
+def test_net_and_gross_revenue(ac_dc_network_r):
+    n = ac_dc_network_r
+    target = n.statistics.revenue(aggregate_time="sum")
+    revenue_out = n.statistics.revenue(aggregate_time="sum", kind="output")
+    revenue_in = n.statistics.revenue(aggregate_time="sum", kind="input")
+    revenue = revenue_in.sub(revenue_out, fill_value=0)
+    comps = ["Generator", "Line", "Link"]
+    assert np.allclose(revenue[comps], target[comps])
+
+
 def test_no_grouping(ac_dc_network_r):
     df = ac_dc_network_r.statistics(groupby=False)
     assert not df.empty


### PR DESCRIPTION
This combines the features from #860 and #851 to have a final version with all the new features while providing backwards compatibility. The only change which is not backward compatible is the default grouper from all `energy_balance` related features like `supply`, `withdrawal`, `dispatch`. But we think it is better to have the new grouper which retains the information on the bus carrier instead of summing different bus carriers (e.g. electricity and heat energy). 

I validated the PR against the current statistics module, and it provides the same values for the combination of statistics methods and groupers.

Closes PR #860 

## Changes proposed in this Pull Request



## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
