### PR TITLE
Save shadow price for CO2Limit global constraint as positive

### DIFF
--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -417,7 +417,10 @@ def assign_duals(n, assign_all_duals=False):
         elif (c == "GlobalConstraint") and (
             (assign_all_duals or attr in n.df(c).index)
         ):
-            n.df(c).loc[attr, "mu"] = dual
+            if attr == 'CO2Limit':
+                n.df(c).loc[attr, "mu"] = dual*n.carriers.co2_emissions["co2"]
+            else:
+                n.df(c).loc[attr, "mu"] = dual
 
     if unassigned:
         logger.info(


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

The dual of the CO2Limit global constraint was saved as negative due to[ the co2_emissions defined as -1](https://github.com/PyPSA/pypsa-eur/blob/a0436372febd158155fa469ce74a4cb69199c300/scripts/prepare_sector_network.py#L601). This PR forces the shadow CO2 price to be saved as a positive number. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
