### PR TITLE
Update opf.py must_stay_down_too_long

### DIFF
--- a/pypsa/opf.py
+++ b/pypsa/opf.py
@@ -361,7 +361,7 @@ def define_generator_variables_constraints(network, snapshots):
             "gen_down_time_force_{}".format(gen_i),
             Constraint(range(must_stay_down), rule=force_down),
         )
-        
+
         blocks = range(must_stay_down, len(snapshots) - 1)
 
         def gen_rule(model, i):


### PR DESCRIPTION
Previously, the code only have `must_stay_up_too_long`, doesn't have `must_stay_down_too_long`, which may occur index out of bound error when total calculation snapshots length + down_time_before < min_down_time.

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
