### PR TITLE
statistics: loop over index level instead of n.investment_period

### DIFF
--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -230,7 +230,7 @@ def filter_active_assets(n, c, df: [pd.Series, pd.DataFrame]):
     if not isinstance(n.snapshots, pd.MultiIndex) or isinstance(df, pd.DataFrame):
         return df
     per_period = {}
-    for p in n.investment_periods:
+    for p in n.snapshots.get_level_values(0):
         per_period[p] = df[n.get_active_assets(c, p).loc[df.index]]
     return pd.concat(per_period, axis=1)
 


### PR DESCRIPTION
Makes that an error message is thrown in PyPSA function `get_active_assets(n, c, investment_period)` when the investment_period of the MultiIndex level 0 is not defined. Having a MultiIndex without the investment period is not allowed and this causes an error in n.statistics without the correct reason. With this PR, the error is raised with the message "Investment period not in `network.investment_periods`".
## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
