### PR TITLE
Bugfix: don't  modify store carrier attribute when defining operational limits

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,6 +25,8 @@ Release Notes
 
 * Updated environment_doc.yml to include the latest required pip dependencies for the documentation environment.
 
+* Bugfix: calling `create_model` or `optimize` when a global operational limit is defined will no longer set the carrier attribute of stores to the carrier of the bus they are attached to.
+
 PyPSA 0.27.1 (22nd March 2024)
 =================================
 

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -364,8 +364,10 @@ def define_operational_limit(n, sns):
             rhs -= sus.state_of_charge_initial.sum()
 
         # stores
-        n.stores["carrier"] = n.stores.bus.map(n.buses.carrier)
-        stores = n.stores.query("carrier == @glc.carrier_attribute and not e_cyclic")
+        bus_carrier = n.stores.bus.map(n.buses.carrier)
+        stores = n.stores.query(
+            "@bus_carrier == @glc.carrier_attribute and not e_cyclic"
+        )
         if not stores.empty:
             e = m["Store-e"].loc[snapshots, stores.index]
             e = e.ffill("snapshot").isel(snapshot=-1)


### PR DESCRIPTION
Closes https://github.com/PyPSA/PyPSA/issues/877

## Changes proposed in this Pull Request

Fairly self-explanatory (see also the issue).

Before merging this PR, I think it's worth discussing if this is even the behaviour that's desired? As it stands, stores are treated differently from storage units and generators in this constraint, and I'm not sure if that's very helpful -- it seems to me like this mostly has the potential to cause confusion.

Maybe it would be useful to bring up a concrete example where a store plays a role in a global operational constraint in a meaningful way, so it's possible to evaluate the behaviour of this constraint. Subsequently, such an example could also be added to the documentation under https://pypsa.readthedocs.io/en/latest/optimal_power_flow.html#operational-limit (which should be improved anyway).

Off the top of my head, I can actually only imagine scenarios where you want to use the carrier of the store, and _not_ the bus it's attached to, i.e. the "opposite" of the current behaviour. For instance, say you have stores at different nodes representing gas reserves, and you want to introduce a global constraint on the use of gas reserves. You might have buses with carrier `gas`, and stores with carrier `gas reserve`; you would want to add a global constraint with `carrier_attribute == 'gas reserve'`, but with the code as it stands, this doesn't work since the carrier of the stores is mapped to `gas` before being compared to `carrier_attribute`.

So an alternative would be to replace
````python
n.stores["carrier"] = n.stores.bus.map(n.buses.carrier)
stores = n.stores.query("carrier == @glc.carrier_attribute and not e_cyclic")
````
by simply
````python
stores = n.stores.query(cond)
````
(Using the same condition as for storage units)

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
