### PR TITLE
Tiny Bugfix: Improved warning for geomap plotting when requests package is missing

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,6 +25,8 @@ Release Notes
 
 * Updated environment_doc.yml to include the latest required pip dependencies for the documentation environment.
 
+* Added useful warning to `plot.py` to handle the case where the `requests` dependency is missing
+
 PyPSA 0.27.1 (22nd March 2024)
 =================================
 

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -29,9 +29,14 @@ try:
     import cartopy
     import cartopy.crs as ccrs
     import cartopy.mpl.geoaxes
-    import requests
 except ImportError:
     cartopy_present = False
+
+requests_present = True
+try:
+    import requests
+except ImportError:
+    requests_present = False
 
 pltly_present = True
 try:
@@ -199,9 +204,13 @@ def plot(
             zip(*compute_bbox_with_margins(margin, x[buses], y[buses])), ()
         )
 
-    if geomap and not cartopy_present:
-        logger.warning("Cartopy needs to be installed to use `geomap=True`.")
-        geomap = False
+    if geomap:
+        if not cartopy_present:
+            logger.warning("Cartopy needs to be installed to use `geomap=True`.")
+            geomap = False
+        if not requests_present:
+            logger.warning("Requests needs to be installed to use `geomap=True`.")
+            geomap = False
 
     if geomap:
         transform = get_projection_from_crs(n.srid)


### PR DESCRIPTION
Closes #881 

## Changes proposed in this Pull Request
Made a clearer warning to explain why geomap fails if the requests package is not installed

## Checklist

- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.