### PR TITLE
bugfix: retain investment periods and weightings when clustering

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,8 @@ Release Notes
 
 * HiGHS becomes the new default solver for ``n.optimize()``.
 
+* Bugfix: Retain investment periods and weightings when clustering networks.
+
 PyPSA 0.28.0 (8th May 2024)
 =================================
 

--- a/examples/notebooks/scigrid-sclopf.ipynb
+++ b/examples/notebooks/scigrid-sclopf.ipynb
@@ -61,9 +61,7 @@
    "outputs": [],
    "source": [
     "branch_outages = network.lines.index[:15]\n",
-    "network.optimize.optimize_security_constrained(\n",
-    "    now, branch_outages=branch_outages\n",
-    ")"
+    "network.optimize.optimize_security_constrained(now, branch_outages=branch_outages)"
    ]
   },
   {

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -489,7 +489,9 @@ def get_clustering_from_busmap(
 
     if with_time:
         clustered.set_snapshots(n.snapshots)
+        clustered.set_investment_periods(n.investment_periods)
         clustered.snapshot_weightings = n.snapshot_weightings.copy()
+        clustered.investment_period_weightings = n.investment_period_weightings.copy()
         for attr, df in lines_t.items():
             if not df.empty:
                 io.import_series_from_dataframe(clustered, df, "Line", attr)

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -492,7 +492,9 @@ def get_clustering_from_busmap(
         clustered.snapshot_weightings = n.snapshot_weightings.copy()
         if not n.investment_periods.empty:
             clustered.set_investment_periods(n.investment_periods)
-            clustered.investment_period_weightings = n.investment_period_weightings.copy()
+            clustered.investment_period_weightings = (
+                n.investment_period_weightings.copy()
+            )
         for attr, df in lines_t.items():
             if not df.empty:
                 io.import_series_from_dataframe(clustered, df, "Line", attr)

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -489,9 +489,10 @@ def get_clustering_from_busmap(
 
     if with_time:
         clustered.set_snapshots(n.snapshots)
-        clustered.set_investment_periods(n.investment_periods)
         clustered.snapshot_weightings = n.snapshot_weightings.copy()
-        clustered.investment_period_weightings = n.investment_period_weightings.copy()
+        if not n.investment_periods.empty:
+            clustered.set_investment_periods(n.investment_periods)
+            clustered.investment_period_weightings = n.investment_period_weightings.copy()
         for attr, df in lines_t.items():
             if not df.empty:
                 io.import_series_from_dataframe(clustered, df, "Line", attr)

--- a/test/test_bugs.py
+++ b/test/test_bugs.py
@@ -1,8 +1,32 @@
 # -*- coding: utf-8 -*-
 import numpy as np
+import pandas as pd
 
 import pypsa
 
+from numpy.testing import assert_array_almost_equal as almost_equal
+
+def test_890():
+
+    n = pypsa.examples.scigrid_de()
+    n.calculate_dependent_values()
+
+    n.lines = n.lines.reindex(columns=n.components["Line"]["attrs"].index[1:])
+    n.lines["type"] = np.nan
+    n.buses = n.buses.reindex(columns=n.components["Bus"]["attrs"].index[1:])
+    n.buses["frequency"] = 50
+
+    n.set_investment_periods([2020, 2030])
+
+    weighting = pd.Series(1, n.buses.index)
+    busmap = n.cluster.busmap_by_kmeans(bus_weightings=weighting, n_clusters=50)
+    nc = n.cluster.cluster_by_busmap(busmap)
+
+    C = n.cluster.get_clustering_from_busmap(busmap)
+    nc = C.network
+
+    almost_equal(n.investment_periods, nc.investment_periods)
+    almost_equal(n.investment_period_weightings, nc.investment_period_weightings)
 
 def test_331():
     n = pypsa.Network()

--- a/test/test_bugs.py
+++ b/test/test_bugs.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 import pandas as pd
+from numpy.testing import assert_array_almost_equal as almost_equal
 
 import pypsa
 
-from numpy.testing import assert_array_almost_equal as almost_equal
 
 def test_890():
 
@@ -27,6 +27,7 @@ def test_890():
 
     almost_equal(n.investment_periods, nc.investment_periods)
     almost_equal(n.investment_period_weightings, nc.investment_period_weightings)
+
 
 def test_331():
     n = pypsa.Network()


### PR DESCRIPTION
closes #890