### PR TITLE
Multiports addition

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -14,6 +14,11 @@ Release Notes
 
 * Bugfix: Retain investment periods and weightings when clustering networks.
 
+* When adding components with bus ports greater than 1, e.g. `bus2`, pypsa checks if the bus exists and prints a warning if it does not.
+
+* When adding bus ports on the fly with `add` methods, the dtype of the freshly created column is now fixed to `string`.
+
+
 PyPSA 0.28.0 (8th May 2024)
 =================================
 

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -289,9 +289,6 @@ class Network(Basic):
 
         self.statistics = StatisticsAccessor(self)
 
-        # TODO: here we create two copies of the same data, which is not ideal!
-        # we should only have data source, either in components[c]["attrs"]
-        # or in component_attrs[c], see https://github.com/PyPSA/PyPSA/issues/892
         for component in self.components:
             # make copies to prevent unexpected sharing of variables
             attrs = self.component_attrs[component].copy()
@@ -334,6 +331,7 @@ class Network(Basic):
                         typ
                     )
 
+            self.component_attrs[component] = attrs
             self.components[component]["attrs"] = attrs
 
         self._build_dataframes()

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -405,14 +405,18 @@ def update_linkports_component_attrs(n, where=None):
             .loc[attr + j]
             .apply(doc_changes, args=(to_replace, i))
         )
-        n.component_attrs[c].loc[target] = (
-            n.component_attrs[c].loc[attr + j].apply(doc_changes, args=(to_replace, i))
+        n.components[c]["attrs"].loc[target] = (
+            n.components[c]["attrs"]
+            .loc[attr + j]
+            .apply(doc_changes, args=(to_replace, i))
         )
         if attr in ["efficiency", "p"] and target not in n.pnl(c).keys():
             df = pd.DataFrame(index=n.snapshots, columns=[], dtype=float)
             df.index.name = "snapshot"
             df.columns.name = c
             n.pnl(c)[target] = df
+        elif attr == "bus" and target not in n.df(c).columns:
+            n.df(c)[target] = n.components[c]["attrs"].loc[target, "default"]
 
 
 def additional_linkports(n, where=None):

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -914,15 +914,19 @@ def import_components_from_dataframe(network, dataframe, cls_name):
                     dataframe[k] = dataframe[k].astype(static_attrs.at[k, "typ"])
 
     # check all the buses are well-defined
-    for attr in ["bus", "bus0", "bus1"]:
-        if attr in dataframe.columns:
-            missing = dataframe.index[~dataframe[attr].isin(network.buses.index)]
-            if len(missing) > 0:
-                logger.warning(
-                    "The following %s have buses which are not defined:\n%s",
-                    cls_name,
-                    missing,
-                )
+    for attr in [attr for attr in dataframe if attr.startswith("bus")]:
+        # allow empty buses for multi-ports
+        port = int(attr[-1]) if attr[-1].isdigit() else 0
+        mask = ~dataframe[attr].isin(network.buses.index)
+        if port > 1:
+            mask |= dataframe[attr].nq("")
+        missing = dataframe.index[mask]
+        if len(missing) > 0:
+            logger.warning(
+                "The following %s have buses which are not defined:\n%s",
+                cls_name,
+                missing,
+            )
 
     non_static_attrs_in_df = non_static_attrs.index.intersection(dataframe.columns)
     old_df = network.df(cls_name)

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -349,7 +349,7 @@ def assign_solution(n):
                     set_from_frame(n, c, f"p{i}", -df * eff)
                     n.pnl(c)[f"p{i}"].loc[
                         sns, n.links.index[n.links[f"bus{i}"] == ""]
-                    ] = float(n.component_attrs["Link"].loc[f"p{i}", "default"])
+                    ] = float(n.components["Link"]["attrs"].loc[f"p{i}", "default"])
 
             else:
                 set_from_frame(n, c, attr, df)


### PR DESCRIPTION
From release notes

* When adding components with bus ports greater than 1, e.g. `bus2`, pypsa checks if the bus exists and prints a warning if it does not.

* When adding bus ports on the fly with `add` methods, the dtype of the freshly created column is now fixed to `string`.


closes #892 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] ~Unit tests for new features were added (if applicable).~
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
