### PR TITLE
Refactor: Use relevant errors for user sanity checks

### DIFF
--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -548,9 +548,9 @@ class Network(Basic):
         None
         """
         if isinstance(snapshots, pd.MultiIndex):
-            assert (
-                snapshots.nlevels == 2
-            ), "Maximally two levels of MultiIndex supported"
+            if snapshots.nlevels != 2:
+                msg = "Maximally two levels of MultiIndex supported"
+                raise ValueError(msg)
             snapshots = snapshots.rename(["period", "timestep"])
             snapshots.name = "snapshot"
             self._snapshots = snapshots
@@ -752,17 +752,22 @@ class Network(Basic):
         >>> network.add("Bus", "my_bus_1", v_nom=380)
         >>> network.add("Line", "my_line_name", bus0="my_bus_0", bus1="my_bus_1", length=34, r=2, x=4)
         """
-        assert class_name in self.components, f"Component class {class_name} not found"
+        if class_name not in self.components:
+            msg = f"Component class {class_name} not found"
+            raise ValueError(msg)
 
         cls_df = self.df(class_name)
         cls_pnl = self.pnl(class_name)
 
         name = str(name)
 
-        assert name not in cls_df.index, (
-            f"Failed to add {class_name} component {name} because there is already "
-            f"an object with this name in {self.components[class_name]['list_name']}"
-        )
+        if name in cls_df.index:
+            msg = (
+                f"Failed to add {class_name} component {name} because there is "
+                f"already an object with this name in "
+                f"{self.components[class_name]['list_name']}"
+            )
+            raise ValueError(msg)
 
         if class_name == "Link":
             update_linkports_component_attrs(self, kwargs.keys())

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -156,10 +156,12 @@ def optimize_transmission_expansion_iteratively(
 
         s_nom_prev = n.lines.s_nom_opt.copy() if iteration else n.lines.s_nom.copy()
         status, termination_condition = n.optimize(snapshots, **kwargs)
-        assert status == "ok", (
-            f"Optimization failed with status {status}"
-            f"and termination {termination_condition}"
-        )
+        if status != "ok":
+            msg = (
+                f"Optimization failed with status {status} and termination "
+                f"{termination_condition}"
+            )
+            raise RuntimeError(msg)
         if track_iterations:
             save_optimal_capacities(n, iteration, status)
 
@@ -427,9 +429,9 @@ def optimize_mga(
         weights = dict(Generator=dict(p_nom=pd.Series(1, index=n.generators.index)))
 
     # check that network has been solved
-    assert hasattr(
-        n, "objective"
-    ), "Network needs to be solved with `n.optimize()` before running MGA."
+    if not hasattr(n, "objective"):
+        msg = "Network needs to be solved with `n.optimize()` before running MGA."
+        raise ValueError(msg)
 
     # create basic model
     m = n.optimize.create_model(

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -919,9 +919,12 @@ def define_loss_constraints(n, sns, c, transmission_losses):
         n.df(c)["s_nom_extendable"], n.df(c)["s_nom"]
     )
 
-    assert isfinite(
-        s_nom_max
-    ).all(), f"Loss approximation requires finite 's_nom_max' for extendable branches:\n {s_nom_max[~isfinite(s_nom_max)]}"
+    if not isfinite(s_nom_max).all():
+        msg = (
+            f"Loss approximation requires finite 's_nom_max' for extendable "
+            f"branches:\n {s_nom_max[~isfinite(s_nom_max)]}"
+        )
+        raise ValueError(msg)
 
     r_pu_eff = n.df(c)["r_pu_eff"]
 

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -376,9 +376,9 @@ def sub_network_pf_singlebus(
     if distribute_slack:
         for bus, group in sub_network.generators().groupby("bus"):
             if slack_weights in ["p_nom", "p_nom_opt"]:
-                assert not all(
-                    network.generators[slack_weights] == 0
-                ), f"Invalid slack weights! Generator attribute {slack_weights} is always zero."
+                if all(network.generators[slack_weights] == 0):
+                    msg = f"Invalid slack weights! Generator attribute {slack_weights} is always zero."
+                    raise ValueError(msg)
                 bus_generator_shares = (
                     network.generators[slack_weights]
                     .loc[group.index]
@@ -389,12 +389,19 @@ def sub_network_pf_singlebus(
                 generators_t_p_choice = get_as_dense(
                     network, "Generator", slack_weights, snapshots
                 )
-                assert (
-                    not generators_t_p_choice.isna().all().all()
-                ), f"Invalid slack weights! Generator attribute {slack_weights} is always NaN."
-                assert (
-                    not (generators_t_p_choice == 0).all().all()
-                ), f"Invalid slack weights! Generator attribute {slack_weights} is always zero."
+                if generators_t_p_choice.isna().all().all():
+                    msg = (
+                        f"Invalid slack weights! Generator attribute {slack_weights}"
+                        f" is always NaN."
+                    )
+                    raise ValueError(msg)
+                if (generators_t_p_choice == 0).all().all():
+                    msg = (
+                        f"Invalid slack weights! Generator attribute {slack_weights}"
+                        f" is always zero."
+                    )
+                    raise ValueError(msg)
+
                 bus_generator_shares = (
                     generators_t_p_choice.loc[snapshots, group.index]
                     .apply(normed, axis=1)
@@ -464,21 +471,23 @@ def sub_network_pf(
     remaining error, and convergence status for each snapshot
     """
 
-    assert isinstance(
-        slack_weights, (str, pd.Series, dict)
-    ), "Type of 'slack_weights' must be string, pd.Series or dict. Is {}.".format(
-        type(slack_weights)
-    )
+    if not isinstance(slack_weights, (str, pd.Series, dict)):
+        msg = (
+            f"Type of 'slack_weights' must be string, pd.Series or dict. Got "
+            f"{type(slack_weights)}."
+        )
+        raise TypeError(msg)
 
     if isinstance(slack_weights, dict):
         slack_weights = pd.Series(slack_weights)
     elif isinstance(slack_weights, str):
         valid_strings = ["p_nom", "p_nom_opt", "p_set"]
-        assert (
-            slack_weights in valid_strings
-        ), "String value for 'slack_weights' must be one of {}. Is {}.".format(
-            valid_strings, slack_weights
-        )
+        if slack_weights not in valid_strings:
+            msg = (
+                f"String value for 'slack_weights' must be one of {valid_strings}. "
+                f"Is {slack_weights}."
+            )
+            raise ValueError(msg)
 
     snapshots = _as_snapshots(sub_network.network, snapshots)
     logger.info(
@@ -511,7 +520,7 @@ def sub_network_pf(
         elif all(i in sn_buses for i in slack_weights.index):
             bus_slack_weights_b = True
         else:
-            raise AssertionError(
+            raise ValueError(
                 "Custom slack weights pd.Series/dict must only have the",
                 "generators or buses of the subnetwork as index/keys.",
             )
@@ -631,11 +640,13 @@ def sub_network_pf(
             )
 
         elif isinstance(slack_weights, str) and slack_weights in ["p_nom", "p_nom_opt"]:
-            assert not all(
-                network.generators[slack_weights] == 0
-            ), "Invalid slack weights! Generator attribute {} is always zero.".format(
-                slack_weights
-            )
+            if all(network.generators[slack_weights] == 0):
+                msg = (
+                    f"Invalid slack weights! Generator attribute {slack_weights} is "
+                    f"always zero."
+                )
+                raise ValueError(msg)
+
             slack_weights_calc = (
                 network.generators.groupby("bus")[slack_weights]
                 .sum()
@@ -870,9 +881,12 @@ def apply_line_types(network):
     missing_types = pd.Index(
         network.lines.loc[lines_with_types_b, "type"].unique()
     ).difference(network.line_types.index)
-    assert (
-        missing_types.empty
-    ), f'The type(s) {", ".join(missing_types)} do(es) not exist in network.line_types'
+    if not missing_types.empty:
+        msg = (
+            f'The type(s) {", ".join(missing_types)} do(es) not exist in '
+            f"network.line_types"
+        )
+        raise ValueError(msg)
 
     # Get a copy of the lines data
     l = network.lines.loc[lines_with_types_b, ["type", "length", "num_parallel"]].join(
@@ -907,9 +921,12 @@ def apply_transformer_types(network):
     missing_types = pd.Index(
         network.transformers.loc[trafos_with_types_b, "type"].unique()
     ).difference(network.transformer_types.index)
-    assert (
-        missing_types.empty
-    ), f'The type(s) {", ".join(missing_types)} do(es) not exist in network.transformer_types'
+    if not missing_types.empty:
+        msg = (
+            f'The type(s) {", ".join(missing_types)} do(es) not exist in '
+            f"network.transformer_types"
+        )
+        raise ValueError(msg)
 
     # Get a copy of the transformers data
     # (joining pulls in "phase_shift", "s_nom", "tap_side" from TransformerType)

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -217,19 +217,19 @@ def plot(
         if projection is None:
             projection = transform
         else:
-            assert isinstance(
-                projection, cartopy.crs.Projection
-            ), "The passed projection is not a cartopy.crs.Projection"
+            if not isinstance(projection, cartopy.crs.Projection):
+                msg = "The passed projection is not a cartopy.crs.Projection"
+                raise ValueError(msg)
 
         if ax is None:
             ax = plt.axes(projection=projection)
         else:
-            assert isinstance(ax, cartopy.mpl.geoaxes.GeoAxesSubplot), (
-                "The passed axis is not a GeoAxesSubplot. You can "
+            if not isinstance(ax, cartopy.mpl.geoaxes.GeoAxesSubplot):
+                msg = "The passed axis is not a GeoAxesSubplot. You can "
                 "create one with: \nimport cartopy.crs as ccrs \n"
                 "fig, ax = plt.subplots("
                 'subplot_kw={"projection":ccrs.PlateCarree()})'
-            )
+                raise ValueError(msg)
 
         x_, y_, _ = ax.projection.transform_points(transform, x.values, y.values).T
         x, y = pd.Series(x_, x.index), pd.Series(y_, y.index)
@@ -259,19 +259,19 @@ def plot(
     patches = []
     if isinstance(bus_sizes, pd.Series) and isinstance(bus_sizes.index, pd.MultiIndex):
         # We are drawing pies to show all the different shares
-        assert (
-            len(bus_sizes.index.unique(level=0).difference(n.buses.index)) == 0
-        ), "The first MultiIndex level of bus_sizes must contain buses"
+        if len(bus_sizes.index.unique(level=0).difference(n.buses.index)) != 0:
+            msg = "The first MultiIndex level of bus_sizes must contain buses"
+            raise ValueError(msg)
         if isinstance(bus_colors, dict):
             bus_colors = pd.Series(bus_colors)
         # case bus_colors isn't a series or dict: look in n.carriers for existent colors
         if not isinstance(bus_colors, pd.Series):
             bus_colors = n.carriers.color.dropna()
-        assert bus_sizes.index.unique(level=1).isin(bus_colors.index).all(), (
-            "Colors not defined for all elements in the second MultiIndex "
+        if not bus_sizes.index.unique(level=1).isin(bus_colors.index).all():
+            msg = "Colors not defined for all elements in the second MultiIndex "
             "level of bus_sizes, please make sure that all the elements are "
             "included in bus_colors or in n.carriers.color"
-        )
+            raise ValueError(msg)
 
         bus_sizes = bus_sizes.sort_index(level=0, sort_remaining=False)
         if geomap:
@@ -426,10 +426,10 @@ def plot(
             from shapely.wkt import loads
 
             linestrings = c.df.geometry[lambda ds: ds != ""].map(loads)
-            assert all(isinstance(ls, LineString) for ls in linestrings), (
-                "The WKT-encoded geometry in the 'geometry' column must be "
+            if not all(isinstance(ls, LineString) for ls in linestrings):
+                msg = "The WKT-encoded geometry in the 'geometry' column must be "
                 "composed of LineStrings"
-            )
+                raise ValueError(msg)
             segments = np.asarray(list(linestrings.map(np.asarray)))
 
         if b_flow is not None:
@@ -479,10 +479,10 @@ def plot(
 
 def as_branch_series(ser, arg, c, n):
     ser = pd.Series(ser, index=n.df(c).index)
-    assert not ser.isnull().any(), (
-        f"{c}_{arg}s does not specify all "
+    if ser.isnull().any():
+        msg = f"{c}_{arg}s does not specify all "
         f"entries. Missing values for {c}: {list(ser[ser.isnull()].index)}"
-    )
+        raise ValueError(msg)
     return ser
 
 
@@ -540,11 +540,9 @@ def projected_area_factor(ax, original_crs=4326):
 
 def draw_map_cartopy(ax, geomap=True, color_geomap=None):
     resolution = "50m" if isinstance(geomap, bool) else geomap
-    assert resolution in [
-        "10m",
-        "50m",
-        "110m",
-    ], "Resolution has to be one of '10m', '50m', '110m'"
+    if resolution not in ["10m", "50m", "110m"]:
+        msg = "Resolution has to be one of '10m', '50m', '110m'"
+        raise ValueError(msg)
 
     if not color_geomap:
         color_geomap = {}
@@ -623,7 +621,9 @@ def add_legend_lines(ax, sizes, labels, patch_kw={}, legend_kw={}):
     sizes = np.atleast_1d(sizes)
     labels = np.atleast_1d(labels)
 
-    assert len(sizes) == len(labels), "Sizes and labels must have the same length."
+    if len(sizes) != len(labels):
+        msg = "Sizes and labels must have the same length."
+        raise ValueError(msg)
 
     handles = [plt.Line2D([0], [0], linewidth=s, **patch_kw) for s in sizes]
 
@@ -651,7 +651,9 @@ def add_legend_patches(ax, colors, labels, patch_kw={}, legend_kw={}):
     colors = np.atleast_1d(colors)
     labels = np.atleast_1d(labels)
 
-    assert len(colors) == len(labels), "Colors and labels must have the same length."
+    if len(colors) != len(labels):
+        msg = "Colors and labels must have the same length."
+        raise ValueError(msg)
 
     handles = [Patch(facecolor=c, **patch_kw) for c in colors]
 
@@ -679,7 +681,9 @@ def add_legend_circles(ax, sizes, labels, srid=4326, patch_kw={}, legend_kw={}):
     sizes = np.atleast_1d(sizes)
     labels = np.atleast_1d(labels)
 
-    assert len(sizes) == len(labels), "Sizes and labels must have the same length."
+    if len(sizes) != len(labels):
+        msg = "Sizes and labels must have the same length."
+        raise ValueError(msg)
 
     if hasattr(ax, "projection"):
         area_correction = projected_area_factor(ax, srid) ** 2
@@ -1106,7 +1110,9 @@ def iplot(
     fig["layout"].update(dict(title=title, hovermode="closest", showlegend=False))
 
     if size is not None:
-        assert len(size) == 2, "Parameter size must specify a tuple (width, height)."
+        if len(size) != 2:
+            msg = "Parameter size must specify a tuple (width, height)."
+            raise ValueError(msg)
         fig["layout"].update(dict(width=size[0], height=size[1]))
 
     if mapbox:
@@ -1116,11 +1122,13 @@ def iplot(
         mapbox_parameters.setdefault("style", mapbox_style)
 
         if mapbox_parameters["style"] in _token_required_mb_styles:
-            assert "accesstoken" in mapbox_parameters.keys(), (
-                "Using Mapbox "
-                "layout styles requires a valid access token from https://www.mapbox.com/, "
-                f"style which do not require a token are:\n{', '.join(_open__mb_styles)}."
-            )
+            if "accesstoken" not in mapbox_parameters.keys():
+                msg = (
+                    "Using Mapbox layout styles requires a valid access token from "
+                    "https://www.mapbox.com/, style which do not require a token "
+                    "are:\n{', '.join(_open__mb_styles)}."
+                )
+                raise ValueError(msg)
 
         if "center" not in mapbox_parameters.keys():
             lon = (n.buses.x.min() + n.buses.x.max()) / 2

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -261,7 +261,7 @@ def test_add_network_with_time(ac_dc_network, empty_network_5_buses):
     THEN    the first network should now contain its original buses and
     also the buses in the second network
     """
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         ac_dc_network.merge(empty_network_5_buses, with_time=True)
 
     empty_network_5_buses.set_snapshots(ac_dc_network.snapshots)

--- a/test/test_lopf_mga.py
+++ b/test/test_lopf_mga.py
@@ -31,7 +31,7 @@ def test_mga():
     n.add("Load", "load", bus="bus", p_set=100)
 
     # can only run MGA on solved networks
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         n.optimize.optimize_mga()
 
     n.optimize()

--- a/test/test_plotting.py
+++ b/test/test_plotting.py
@@ -54,7 +54,7 @@ def test_plot_on_axis_wo_geomap(ac_dc_network):
 def test_plot_on_axis_w_geomap(ac_dc_network):
     n = ac_dc_network
     fig, ax = plt.subplots()
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         n.plot(ax=ax, geomap=True)
         plt.close()
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
An `AssertionError` is for debugging during the dev workflow and not for production. User sanity checks should use `ValueError`, `TypeError`, `FileNotFoundError` etc. This PR fixes that and provides more readable error messages.

## Checklist

- [-] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [-] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [-] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
