### PR TITLE
Add `nan` checks in `n.consistency_check()`

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -20,6 +20,8 @@ Release Notes
 
 * Add functionality to provide individual colors for lines in legend during plot.
 
+* Also check for missing values of default attributes in the `n.consistency_check()` function. (https://github.com/PyPSA/PyPSA/pull/903)
+
 PyPSA 0.28.0 (8th May 2024)
 =================================
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -18,6 +18,7 @@ Release Notes
 
 * When adding bus ports on the fly with `add` methods, the dtype of the freshly created column is now fixed to `string`.
 
+* Add functionality to provide individual colors for lines in legend during plot.
 
 PyPSA 0.28.0 (8th May 2024)
 =================================

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -1,6 +1,4 @@
-"""
-Power system components.
-"""
+"""Power system components."""
 
 from weakref import ref
 
@@ -28,6 +26,21 @@ import validators
 from pyproj import CRS, Transformer
 from scipy.sparse import csgraph
 
+from pypsa.consistency import (
+    check_assets,
+    check_dtypes_,
+    check_for_disconnected_buses,
+    check_for_unknown_buses,
+    check_for_zero_impedances,
+    check_for_zero_s_nom,
+    check_generators,
+    check_investment_periods,
+    check_nans_for_component_default_attrs,
+    check_shapes,
+    check_static_power_attributes,
+    check_time_series,
+    check_time_series_power_attributes,
+)
 from pypsa.contingency import calculate_BODF, network_lpf_contingency
 from pypsa.descriptors import (
     Dict,
@@ -97,9 +110,7 @@ del component
 
 
 class Basic:
-    """
-    Common to every object.
-    """
+    """Common to every object."""
 
     name = ""
 
@@ -111,9 +122,7 @@ class Basic:
 
 
 class Common(Basic):
-    """
-    Common to all objects inside Network object.
-    """
+    """Common to all objects inside Network object."""
 
     network = None
 
@@ -163,6 +172,7 @@ class Network(Basic):
     >>> nw1 = pypsa.Network("my_store.h5")
     >>> nw2 = pypsa.Network("/my/folder")
     >>> nw3 = pypsa.Network("https://github.com/PyPSA/PyPSA/raw/master/examples/scigrid-de/scigrid-with-load-gen-trafos.nc")
+
     """
 
     _crs = CRS.from_epsg(4326)
@@ -371,9 +381,7 @@ class Network(Basic):
         return header + content
 
     def __add__(self, other):
-        """
-        Merge all components of two networks.
-        """
+        """Merge all components of two networks."""
         self.merge(other)
 
     def _build_dataframes(self):
@@ -440,6 +448,7 @@ class Network(Basic):
         Returns
         -------
         pandas.DataFrame
+
         """
         return getattr(self, self.components[component_name]["list_name"])
 
@@ -455,14 +464,13 @@ class Network(Basic):
         Returns
         -------
         dict of pandas.DataFrame
+
         """
         return getattr(self, self.components[component_name]["list_name"] + "_t")
 
     @property
     def meta(self):
-        """
-        Dictionary of the network meta data.
-        """
+        """Dictionary of the network meta data."""
         return self._meta
 
     @meta.setter
@@ -473,9 +481,7 @@ class Network(Basic):
 
     @property
     def crs(self):
-        """
-        Coordinate reference system of the network's geometries (n.shapes).
-        """
+        """Coordinate reference system of the network's geometries (n.shapes)."""
         return self._crs
 
     @crs.setter
@@ -543,6 +549,7 @@ class Network(Basic):
         Returns
         -------
         None
+
         """
         if isinstance(snapshots, pd.MultiIndex):
             if snapshots.nlevels != 2:
@@ -636,6 +643,7 @@ class Network(Basic):
         Returns
         -------
         None.
+
         """
         periods = pd.Index(periods)
         if not (
@@ -748,6 +756,7 @@ class Network(Basic):
         >>> network.add("Bus", "my_bus_0")
         >>> network.add("Bus", "my_bus_1", v_nom=380)
         >>> network.add("Line", "my_line_name", bus0="my_bus_0", bus1="my_bus_1", length=34, r=2, x=4)
+
         """
         if class_name not in self.components:
             msg = f"Component class {class_name} not found"
@@ -825,6 +834,7 @@ class Network(Basic):
         Examples
         --------
         >>> network.remove("Line", "my_line 12345")
+
         """
         if class_name not in self.components:
             logger.error(f"Component class {class_name} not found")
@@ -904,6 +914,7 @@ class Network(Basic):
         ...        p_nom_extendable=True,
         ...        capital_cost=1e5,
         ...        p_max_pu=wind)
+
         """
         if class_name not in self.components:
             logger.error(f"Component class {class_name} not found")
@@ -954,6 +965,7 @@ class Network(Basic):
         Examples
         --------
         >>> network.mremove("Line", ["line x", "line y"])
+
         """
         if class_name not in self.components:
             logger.error(f"Component class {class_name} not found")
@@ -1016,6 +1028,7 @@ class Network(Basic):
         Examples
         --------
         >>> network_copy = network.copy()
+
         """
         (
             override_components,
@@ -1088,6 +1101,7 @@ class Network(Basic):
         >>> sub_network_0 = network[network.buses.sub_network = "0"]
 
         >>> sub_network_0_with_only_10_snapshots = network[:10, network.buses.sub_network = "0"]
+
         """
         if isinstance(key, tuple):
             time_i, key = key
@@ -1271,339 +1285,8 @@ class Network(Basic):
         Examples
         --------
         >>> network.consistency_check()
+
         """
-
-        def _bus_columns(df: pd.DataFrame) -> pd.Index:
-            return df.columns[df.columns.str.startswith("bus")]
-
-        def check_for_unknown_buses(component: Component) -> None:
-            """
-            Check if buses are attached to components but are not defined.
-            """
-            for attr in _bus_columns(component.df):
-                missing = ~component.df[attr].isin(self.buses.index)
-                # if bus2, bus3... contain empty strings do not warn
-                if component.name in self.branch_components and int(attr[-1]) > 1:
-                    missing &= component.df[attr] != ""
-                if missing.any():
-                    msg = "The following %s have %s which are not defined:\n%s"
-                    logger.warning(
-                        msg, component.list_name, attr, component.df.index[missing]
-                    )
-
-        def check_for_disconnected_buses() -> None:
-            connected_buses = set()
-            for component in self.iterate_components():
-                for attr in _bus_columns(component.df):
-                    connected_buses.update(component.df[attr])
-
-            disconnected_buses = set(self.buses.index) - connected_buses
-            if disconnected_buses:
-                msg = "The following buses have no attached components, which can break the lopf:\n%s"
-                logger.warning(msg, disconnected_buses)
-
-        def check_for_zero_impedances(component: Component) -> None:
-            if component.name in self.passive_branch_components:
-                for attr in ["x", "r"]:
-                    bad = component.df[attr] == 0
-                    if bad.any():
-                        msg = (
-                            "The following %s have zero %s, which "
-                            "could break the linear load flow:\n%s"
-                        )
-                        logger.warning(
-                            msg, component.list_name, attr, component.df.index[bad]
-                        )
-
-        def check_for_zero_s_nom(component: Component) -> None:
-            if component.name in {"Transformer"}:
-                bad = component.df["s_nom"] == 0
-                if bad.any():
-                    logger.warning(
-                        "The following %s have zero s_nom, which is used "
-                        "to define the impedance and will thus break "
-                        "the load flow:\n%s",
-                        component.list_name,
-                        component.df.index[bad],
-                    )
-
-        def check_time_series(component: Component) -> None:
-            for attr in component.attrs.index[
-                component.attrs.varying & component.attrs.static
-            ]:
-                attr_df = component.pnl[attr]
-
-                diff = attr_df.columns.difference(component.df.index)
-                if len(diff):
-                    logger.warning(
-                        "The following %s have time series defined "
-                        "for attribute %s in network.%s_t, but are "
-                        "not defined in network.%s:\n%s",
-                        component.list_name,
-                        attr,
-                        component.list_name,
-                        component.list_name,
-                        diff,
-                    )
-
-                if not self.snapshots.equals(attr_df.index):
-                    logger.warning(
-                        "The index of the time-dependent Dataframe for attribute "
-                        "%s of network.%s_t is not aligned with network snapshots",
-                        attr,
-                        component.list_name,
-                    )
-
-        def check_static_power_attributes(component: Component) -> None:
-            """
-            Check static attrs p_now, s_nom, e_nom in any component.
-            """
-            static_attrs = ["p_nom", "s_nom", "e_nom"]
-            if component.name in self.all_components - {"TransformerType"}:
-                static_attr = component.attrs.query("static").index.intersection(
-                    static_attrs
-                )
-                if len(static_attr):
-                    attr = static_attr[0]
-                    bad = component.df[attr + "_max"] < component.df[attr + "_min"]
-                    if bad.any():
-                        logger.warning(
-                            "The following %s have smaller maximum than "
-                            "minimum expansion limit which can lead to "
-                            "infeasibilty:\n%s",
-                            component.list_name,
-                            component.df.index[bad],
-                        )
-
-                    attr = static_attr[0]
-                    for col in [attr + "_min", attr + "_max"]:
-                        if (
-                            component.df[col][component.df[attr + "_extendable"]]
-                            .isna()
-                            .any()
-                        ):
-                            logger.warning(
-                                "Encountered nan's in column %s of component '%s'.",
-                                col,
-                                component.name,
-                            )
-
-        def check_time_series_power_attributes(component: Component) -> None:
-            """
-            Check time series attributes `p_max_pu` and `e_max_pu` for any component
-            except TransformerTypes.
-            """
-            varying_attrs = ["p_max_pu", "e_max_pu"]
-            if component.name in self.all_components - {"TransformerType"}:
-                varying_attr = component.attrs.query("varying").index.intersection(
-                    varying_attrs
-                )
-
-                if len(varying_attr):
-                    attr = varying_attr[0][0]
-                    max_pu = self.get_switchable_as_dense(
-                        component.name, attr + "_max_pu"
-                    )
-                    min_pu = self.get_switchable_as_dense(
-                        component.name, attr + "_min_pu"
-                    )
-
-                    # check for NaN values:
-                    if max_pu.isna().to_numpy().any():
-                        for col in max_pu.columns[max_pu.isna().any()]:
-                            logger.warning(
-                                "The attribute %s of element %s of %s has "
-                                "NaN values for the following snapshots:\n%s",
-                                attr + "_max_pu",
-                                col,
-                                component.list_name,
-                                max_pu.index[max_pu[col].isna()],
-                            )
-                    if min_pu.isna().to_numpy().any():
-                        for col in min_pu.columns[min_pu.isna().any()]:
-                            logger.warning(
-                                "The attribute %s of element %s of %s has "
-                                "NaN values for the following snapshots:\n%s",
-                                attr + "_min_pu",
-                                col,
-                                component.list_name,
-                                min_pu.index[min_pu[col].isna()],
-                            )
-
-                    # check for infinite values
-                    if np.isinf(max_pu).to_numpy().any():
-                        for col in max_pu.columns[np.isinf(max_pu).any()]:
-                            logger.warning(
-                                "The attribute %s of element %s of %s has "
-                                "infinite values for the following snapshots:\n%s",
-                                attr + "_max_pu",
-                                col,
-                                component.list_name,
-                                max_pu.index[np.isinf(max_pu[col])],
-                            )
-                    if np.isinf(min_pu).to_numpy().any():
-                        for col in min_pu.columns[np.isinf(min_pu).any()]:
-                            logger.warning(
-                                "The attribute %s of element %s of %s has "
-                                "infinite values for the following snapshots:\n%s",
-                                attr + "_min_pu",
-                                col,
-                                component.list_name,
-                                min_pu.index[np.isinf(min_pu[col])],
-                            )
-
-                    diff = max_pu - min_pu
-                    diff = diff[diff < 0].dropna(axis=1, how="all")
-                    for col in diff.columns:
-                        logger.warning(
-                            "The element %s of %s has a smaller maximum "
-                            "than minimum operational limit which can "
-                            "lead to infeasibility for the following snapshots:\n%s",
-                            col,
-                            component.list_name,
-                            diff[col].dropna().index,
-                        )
-
-        def check_assets(component: Component) -> None:
-            if component.name in {"Generator", "Link"}:
-                committables = self.get_committable_i(component.name)
-                extendables = self.get_extendable_i(component.name)
-                intersection = committables.intersection(extendables)
-                if not intersection.empty:
-                    logger.warning(
-                        "Assets can only be committable or extendable. Found "
-                        f"assets in component {c} which are both:"
-                        f"\n\n\t{', '.join(intersection)}"
-                    )
-
-        def check_generators(component: Component) -> None:
-            """
-            Check static attrs p_now, s_nom, e_nom in generator components.
-            """
-            if component.name in {"Generator"}:
-                bad_uc_gens = component.df.index[
-                    component.df.committable
-                    & (component.df.up_time_before > 0)
-                    & (component.df.down_time_before > 0)
-                ]
-                if not bad_uc_gens.empty:
-                    logger.warning(
-                        "The following committable generators were both up and down"
-                        f" before the simulation: {bad_uc_gens}."
-                        " This could cause an infeasibility."
-                    )
-
-        def check_dtypes_(component: Component) -> None:
-            # first check static attributes
-
-            dtypes_soll = component.attrs.loc[component.attrs["static"], "dtype"].drop(
-                "name"
-            )
-            unmatched = component.df.dtypes[dtypes_soll.index] != dtypes_soll
-
-            if unmatched.any():
-                logger.warning(
-                    "The following attributes of the dataframe %s "
-                    "have the wrong dtype:\n%s\n"
-                    "They are:\n%s\nbut should be:\n%s",
-                    component.list_name,
-                    unmatched.index[unmatched],
-                    component.df.dtypes[dtypes_soll.index[unmatched]],
-                    dtypes_soll[unmatched],
-                )
-
-            # now check varying attributes
-
-            types_soll = component.attrs.loc[
-                component.attrs["varying"], ["typ", "dtype"]
-            ]
-
-            for attr, typ, dtype in types_soll.itertuples():
-                if component.pnl[attr].empty:
-                    continue
-
-                unmatched = component.pnl[attr].dtypes != dtype
-
-                if unmatched.any():
-                    logger.warning(
-                        "The following columns of time-varying attribute "
-                        "%s in %s_t have the wrong dtype:\n%s\n"
-                        "They are:\n%s\nbut should be:\n%s",
-                        attr,
-                        component.list_name,
-                        unmatched.index[unmatched],
-                        component.pnl[attr].dtypes[unmatched],
-                        typ,
-                    )
-
-        def check_investment_periods() -> None:
-            constraint_periods = set(
-                self.global_constraints.investment_period.dropna().unique()
-            )
-            if isinstance(self.snapshots, pd.MultiIndex):
-                if not constraint_periods.issubset(self.snapshots.unique("period")):
-                    msg = (
-                        "The global constraints contain investment periods which "
-                        "are not in the set of optimized snapshots."
-                    )
-                    raise ValueError(msg)
-            else:
-                if constraint_periods:
-                    msg = (
-                        "The global constraints contain investment periods but "
-                        "snapshots are not multi-indexed."
-                    )
-                    raise ValueError(msg)
-
-        def check_shapes() -> None:
-            shape_components = self.shapes.component.unique()
-            for c in set(shape_components) & set(self.all_components):
-                geos = self.shapes.query("component == @c")
-                not_included = geos.index[~geos.idx.isin(self.df(c).index)]
-
-                if not not_included.empty:
-                    logger.warning(
-                        f"The following shapes are related to component {c} and have"
-                        f" idx values that are not included in the component's index:\n"
-                        f"{not_included}"
-                    )
-
-        def check_nans_for_component_default_attrs(component: Component) -> None:
-            """
-            Check for all static and varying attributes if there are nan values but
-            the default value is not nan.
-
-            """
-            # Get non-NA default attributes for the current component
-            not_na_component_attrs = self.component_attrs[component.name][
-                self.component_attrs[component.name]
-                .replace("", np.nan)["default"]
-                .notna()
-            ].index
-
-            # Remove attributes that are not in the component's static data
-            relevant_static_df = component.df[
-                list(set(component.df.columns).intersection(not_na_component_attrs))
-            ]
-
-            # Remove attributes that are not in the component's time series data (if
-            # there is any)
-            relevant_series_dfs = [
-                value
-                for key, value in component.pnl.items()
-                if key in not_na_component_attrs and not value.empty
-            ]
-
-            # Run the check for nan values on relevant data
-            for values_df in [relevant_static_df] + relevant_series_dfs:
-                if values_df.isna().to_numpy().any():
-                    nan_cols = values_df.columns[values_df.isna().any()]
-                    logger.warning(
-                        "Encountered nan's in columns %s of component '%s'.",
-                        nan_cols,
-                        component.name,
-                    )
-
         self.calculate_dependent_values()
 
         # TODO: Check for bidirectional links with efficiency < 1.
@@ -1612,17 +1295,17 @@ class Network(Basic):
         # Per component checks
         for c in self.iterate_components():
             # Checks all components
-            check_for_unknown_buses(c)
-            check_time_series(c)
-            check_static_power_attributes(c)
-            check_time_series_power_attributes(c)
-            check_nans_for_component_default_attrs(c)
+            check_for_unknown_buses(self, c)
+            check_time_series(self, c)
+            check_static_power_attributes(self, c)
+            check_time_series_power_attributes(self, c)
+            check_nans_for_component_default_attrs(self, c)
             # Checks passive_branch_components
-            check_for_zero_impedances(c)
+            check_for_zero_impedances(self, c)
             # Checks transformers
             check_for_zero_s_nom(c)
             # Checks generators and links
-            check_assets(c)
+            check_assets(self, c)
             # Checks generators
             check_generators(c)
 
@@ -1630,9 +1313,9 @@ class Network(Basic):
                 check_dtypes_(c)
 
         # Combined checks
-        check_for_disconnected_buses()
-        check_investment_periods()
-        check_shapes()
+        check_for_disconnected_buses(self)
+        check_investment_periods(self)
+        check_shapes(self)
 
 
 class SubNetwork(Common):
@@ -1747,6 +1430,7 @@ class SubNetwork(Common):
         ------
         Component
             Container for component data. See Component class for details.
+
         """
         for c in self.network.iterate_components(
             components=components, skip_empty=False

--- a/pypsa/consistency.py
+++ b/pypsa/consistency.py
@@ -1,0 +1,462 @@
+"""
+Consistency check functions for PyPSA networks.
+
+Mainly used in the `Network.consistency_check()` method.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from pypsa.components import Component, Network
+
+logger = logging.getLogger(__name__)
+
+
+def _bus_columns(df: pd.DataFrame) -> pd.Index:
+    return df.columns[df.columns.str.startswith("bus")]
+
+
+def check_for_unknown_buses(network: Network, component: Component) -> None:
+    """
+    Check if buses are attached to component but are not defined in the network.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+    component : pypsa.Component
+        The component to check.
+
+    """
+    for attr in _bus_columns(component.df):
+        missing = ~component.df[attr].isin(network.buses.index)
+        # if bus2, bus3... contain empty strings do not warn
+        if component.name in network.branch_components and int(attr[-1]) > 1:
+            missing &= component.df[attr] != ""
+        if missing.any():
+            logger.warning(
+                "The following %s have %s which are not defined:\n%s",
+                component.list_name,
+                attr,
+                component.df.index[missing],
+            )
+
+
+def check_for_disconnected_buses(network: Network) -> None:
+    """
+    Check if network has buses that are not connected to any component.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+
+    """
+    connected_buses = set()
+    for component in network.iterate_components():
+        for attr in _bus_columns(component.df):
+            connected_buses.update(component.df[attr])
+
+    disconnected_buses = set(network.buses.index) - connected_buses
+    if disconnected_buses:
+        logger.warning(
+            "The following buses have no attached components, which can break the "
+            "lopf:\n%s",
+            disconnected_buses,
+        )
+
+
+def check_for_zero_impedances(network: Network, component: Component) -> None:
+    """
+    Check if component has zero impedances. Only checks passive branch components.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+    component : pypsa.Component
+        The component to check.
+
+    """
+    if component.name in network.passive_branch_components:
+        for attr in ["x", "r"]:
+            bad = component.df[attr] == 0
+            if bad.any():
+                logger.warning(
+                    "The following %s have zero %s, which "
+                    "could break the linear load flow:\n%s",
+                    component.list_name,
+                    attr,
+                    component.df.index[bad],
+                )
+
+
+def check_for_zero_s_nom(component: Component) -> None:
+    """
+    Check if component has zero s_nom. Only checks transformers.
+
+    Parameters
+    ----------
+    component : pypsa.Component
+        The component to check.
+
+    """
+    if component.name in {"Transformer"}:
+        bad = component.df["s_nom"] == 0
+        if bad.any():
+            logger.warning(
+                "The following %s have zero s_nom, which is used "
+                "to define the impedance and will thus break "
+                "the load flow:\n%s",
+                component.list_name,
+                component.df.index[bad],
+            )
+
+
+def check_time_series(network: Network, component: Component) -> None:
+    """
+    Check if time series of component are aligned with network snapshots.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+    component : pypsa.Component
+        The component to check.
+
+    """
+    for attr in component.attrs.index[component.attrs.varying & component.attrs.static]:
+        attr_df = component.pnl[attr]
+
+        diff = attr_df.columns.difference(component.df.index)
+        if len(diff):
+            logger.warning(
+                "The following %s have time series defined "
+                "for attribute %s in network.%s_t, but are "
+                "not defined in network.%s:\n%s",
+                component.list_name,
+                attr,
+                component.list_name,
+                component.list_name,
+                diff,
+            )
+
+        if not network.snapshots.equals(attr_df.index):
+            logger.warning(
+                "The index of the time-dependent Dataframe for attribute "
+                "%s of network.%s_t is not aligned with network snapshots",
+                attr,
+                component.list_name,
+            )
+
+
+def check_static_power_attributes(network: Network, component: Component) -> None:
+    """
+    Check static attrs p_now, s_nom, e_nom in any component.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+    component : pypsa.Component
+        The component to check.
+
+    """
+    static_attrs = ["p_nom", "s_nom", "e_nom"]
+    if component.name in network.all_components - {"TransformerType"}:
+        static_attr = component.attrs.query("static").index.intersection(static_attrs)
+        if len(static_attr):
+            attr = static_attr[0]
+            bad = component.df[attr + "_max"] < component.df[attr + "_min"]
+            if bad.any():
+                logger.warning(
+                    "The following %s have smaller maximum than "
+                    "minimum expansion limit which can lead to "
+                    "infeasibilty:\n%s",
+                    component.list_name,
+                    component.df.index[bad],
+                )
+
+            attr = static_attr[0]
+            for col in [attr + "_min", attr + "_max"]:
+                if component.df[col][component.df[attr + "_extendable"]].isna().any():
+                    logger.warning(
+                        "Encountered nan's in column %s of component '%s'.",
+                        col,
+                        component.name,
+                    )
+
+
+def check_time_series_power_attributes(network: Network, component: Component) -> None:
+    """
+    Check `p_max_pu` and `e_max_pu` nan and infinite values in time series.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+    component : pypsa.Component
+        The component to check.
+
+    """
+    varying_attrs = ["p_max_pu", "e_max_pu"]
+    if component.name in network.all_components - {"TransformerType"}:
+        varying_attr = component.attrs.query("varying").index.intersection(
+            varying_attrs
+        )
+
+        if len(varying_attr):
+            attr = varying_attr[0][0]
+            max_pu = network.get_switchable_as_dense(component.name, attr + "_max_pu")
+            min_pu = network.get_switchable_as_dense(component.name, attr + "_min_pu")
+
+            # check for NaN values:
+            if max_pu.isna().to_numpy().any():
+                for col in max_pu.columns[max_pu.isna().any()]:
+                    logger.warning(
+                        "The attribute %s of element %s of %s has "
+                        "NaN values for the following snapshots:\n%s",
+                        attr + "_max_pu",
+                        col,
+                        component.list_name,
+                        max_pu.index[max_pu[col].isna()],
+                    )
+            if min_pu.isna().to_numpy().any():
+                for col in min_pu.columns[min_pu.isna().any()]:
+                    logger.warning(
+                        "The attribute %s of element %s of %s has "
+                        "NaN values for the following snapshots:\n%s",
+                        attr + "_min_pu",
+                        col,
+                        component.list_name,
+                        min_pu.index[min_pu[col].isna()],
+                    )
+
+            # check for infinite values
+            if np.isinf(max_pu).to_numpy().any():
+                for col in max_pu.columns[np.isinf(max_pu).any()]:
+                    logger.warning(
+                        "The attribute %s of element %s of %s has "
+                        "infinite values for the following snapshots:\n%s",
+                        attr + "_max_pu",
+                        col,
+                        component.list_name,
+                        max_pu.index[np.isinf(max_pu[col])],
+                    )
+            if np.isinf(min_pu).to_numpy().any():
+                for col in min_pu.columns[np.isinf(min_pu).any()]:
+                    logger.warning(
+                        "The attribute %s of element %s of %s has "
+                        "infinite values for the following snapshots:\n%s",
+                        attr + "_min_pu",
+                        col,
+                        component.list_name,
+                        min_pu.index[np.isinf(min_pu[col])],
+                    )
+
+            diff = max_pu - min_pu
+            diff = diff[diff < 0].dropna(axis=1, how="all")
+            for col in diff.columns:
+                logger.warning(
+                    "The element %s of %s has a smaller maximum "
+                    "than minimum operational limit which can "
+                    "lead to infeasibility for the following snapshots:\n%s",
+                    col,
+                    component.list_name,
+                    diff[col].dropna().index,
+                )
+
+
+def check_assets(network: Network, component: Component) -> None:
+    """
+    Check if assets are only committable or extendable, but not both.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+    component : pypsa.Component
+        The component to check.
+
+    """
+    if component.name in {"Generator", "Link"}:
+        committables = network.get_committable_i(component.name)
+        extendables = network.get_extendable_i(component.name)
+        intersection = committables.intersection(extendables)
+        if not intersection.empty:
+            logger.warning(
+                "Assets can only be committable or extendable. Found "
+                f"assets in component {component.name} which are both:"
+                f"\n\n\t{', '.join(intersection)}"
+            )
+
+
+def check_generators(component: Component) -> None:
+    """Check static attrs p_now, s_nom, e_nom in generator components."""
+    if component.name in {"Generator"}:
+        bad_uc_gens = component.df.index[
+            component.df.committable
+            & (component.df.up_time_before > 0)
+            & (component.df.down_time_before > 0)
+        ]
+        if not bad_uc_gens.empty:
+            logger.warning(
+                "The following committable generators were both up and down"
+                f" before the simulation: {bad_uc_gens}."
+                " This could cause an infeasibility."
+            )
+
+
+def check_dtypes_(component: Component) -> None:
+    """
+    Check if the dtypes of the attributes in the component are as expected.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+    component : pypsa.Component
+        The component to check.
+
+    """
+    dtypes_soll = component.attrs.loc[component.attrs["static"], "dtype"].drop("name")
+    unmatched = component.df.dtypes[dtypes_soll.index] != dtypes_soll
+
+    if unmatched.any():
+        logger.warning(
+            "The following attributes of the dataframe %s "
+            "have the wrong dtype:\n%s\n"
+            "They are:\n%s\nbut should be:\n%s",
+            component.list_name,
+            unmatched.index[unmatched],
+            component.df.dtypes[dtypes_soll.index[unmatched]],
+            dtypes_soll[unmatched],
+        )
+
+    # now check varying attributes
+
+    types_soll = component.attrs.loc[component.attrs["varying"], ["typ", "dtype"]]
+
+    for attr, typ, dtype in types_soll.itertuples():
+        if component.pnl[attr].empty:
+            continue
+
+        unmatched = component.pnl[attr].dtypes != dtype
+
+        if unmatched.any():
+            logger.warning(
+                "The following columns of time-varying attribute "
+                "%s in %s_t have the wrong dtype:\n%s\n"
+                "They are:\n%s\nbut should be:\n%s",
+                attr,
+                component.list_name,
+                unmatched.index[unmatched],
+                component.pnl[attr].dtypes[unmatched],
+                typ,
+            )
+
+
+def check_investment_periods(network: Network) -> None:
+    """
+    Check if investment periods are aligned with snapshots.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+
+    """
+    constraint_periods = set(
+        network.global_constraints.investment_period.dropna().unique()
+    )
+    if isinstance(network.snapshots, pd.MultiIndex):
+        if not constraint_periods.issubset(network.snapshots.unique("period")):
+            msg = (
+                "The global constraints contain investment periods which "
+                "are not in the set of optimized snapshots."
+            )
+            raise ValueError(msg)
+    else:
+        if constraint_periods:
+            msg = (
+                "The global constraints contain investment periods but "
+                "snapshots are not multi-indexed."
+            )
+            raise ValueError(msg)
+
+
+def check_shapes(network: Network) -> None:
+    """
+    Check if shapes are aligned with related components.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+    component : pypsa.Component
+        The component to check.
+
+    """
+    shape_components = network.shapes.component.unique()
+    for c in set(shape_components) & set(network.all_components):
+        geos = network.shapes.query("component == @c")
+        not_included = geos.index[~geos.idx.isin(network.df(c).index)]
+
+        if not not_included.empty:
+            logger.warning(
+                f"The following shapes are related to component {c} and have"
+                f" idx values that are not included in the component's index:\n"
+                f"{not_included}"
+            )
+
+
+def check_nans_for_component_default_attrs(
+    network: Network, component: Component
+) -> None:
+    """
+    Check for missing values in component attributes.
+
+    Checks for all attributes if they are nan but have a default value, which is not
+     nan.
+
+    Parameters
+    ----------
+    network : pypsa.Network
+        The network to check.
+    component : pypsa.Component
+        The component to check.
+
+    """
+    # Get non-NA default attributes for the current component
+    not_na_component_attrs = network.component_attrs[component.name][
+        network.component_attrs[component.name].replace("", np.nan)["default"].notna()
+    ].index
+
+    # Remove attributes that are not in the component's static data
+    relevant_static_df = component.df[
+        list(set(component.df.columns).intersection(not_na_component_attrs))
+    ]
+
+    # Remove attributes that are not in the component's time series data (if
+    # there is any)
+    relevant_series_dfs = [
+        value
+        for key, value in component.pnl.items()
+        if key in not_na_component_attrs and not value.empty
+    ]
+
+    # Run the check for nan values on relevant data
+    for values_df in [relevant_static_df] + relevant_series_dfs:
+        if values_df.isna().to_numpy().any():
+            nan_cols = values_df.columns[values_df.isna().any()]
+            logger.warning(
+                "Encountered nan's in columns %s of component '%s'.",
+                nan_cols,
+                component.name,
+            )

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -600,7 +600,7 @@ class HandlerCircle(HandlerPatch):
         return [p]
 
 
-def add_legend_lines(ax, sizes, labels, patch_kw={}, legend_kw={}):
+def add_legend_lines(ax, sizes, labels, colors=[], patch_kw={}, legend_kw={}):
     """
     Add a legend for lines and links.
 
@@ -611,6 +611,8 @@ def add_legend_lines(ax, sizes, labels, patch_kw={}, legend_kw={}):
         Size of the line reference; for example [3, 2, 1]
     labels : list-like, str
         Label of the line reference; for example ["30 GW", "20 GW", "10 GW"]
+    colors: list-like, str
+        Color of the line reference; for example ["red, "green", "blue"]
     patch_kw : defaults to {}
         Keyword arguments passed to plt.Line2D
     legend_kw : defaults to {}
@@ -618,12 +620,19 @@ def add_legend_lines(ax, sizes, labels, patch_kw={}, legend_kw={}):
     """
     sizes = np.atleast_1d(sizes)
     labels = np.atleast_1d(labels)
+    colors = np.atleast_1d(colors)
 
     if len(sizes) != len(labels):
         msg = "Sizes and labels must have the same length."
         raise ValueError(msg)
+    elif len(colors) > 0 and len(sizes) != len(colors):
+        msg = "Sizes, labels, and colors must have the same length."
+        raise ValueError(msg)
 
-    handles = [plt.Line2D([0], [0], linewidth=s, **patch_kw) for s in sizes]
+    if len(colors) == 0:
+        handles = [plt.Line2D([0], [0], linewidth=s, **patch_kw) for s in sizes]
+    else:
+        handles = [plt.Line2D([0], [0], linewidth=s, color=c, **patch_kw) for s, c in zip(sizes, colors)]
 
     legend = ax.legend(handles, labels, **legend_kw)
 

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -632,7 +632,10 @@ def add_legend_lines(ax, sizes, labels, colors=[], patch_kw={}, legend_kw={}):
     if len(colors) == 0:
         handles = [plt.Line2D([0], [0], linewidth=s, **patch_kw) for s in sizes]
     else:
-        handles = [plt.Line2D([0], [0], linewidth=s, color=c, **patch_kw) for s, c in zip(sizes, colors)]
+        handles = [
+            plt.Line2D([0], [0], linewidth=s, color=c, **patch_kw)
+            for s, c in zip(sizes, colors)
+        ]
 
     legend = ax.legend(handles, labels, **legend_kw)
 


### PR DESCRIPTION
Closes #874 

## Changes proposed in this Pull Request
Adds `nan` checks for all attributes where a non `nan` default argument exists.
See here:
https://github.com/lkstrp/PyPSA/blob/dc9e6932281574c580c66944782bab1f668c60d8/pypsa/components.py#L1571-L1605

Also restructures `n.consistency_check()` and splits up all the checks in sub functions.


## Checklist

- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
