### PR TITLE
refactor: remove unnecessary module metadata

### DIFF
--- a/pypsa/__init__.py
+++ b/pypsa/__init__.py
@@ -4,6 +4,14 @@ Python for Power Systems Analysis (PyPSA)
 Energy system modelling library.
 """
 
+__author__ = (
+    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
+)
+__copyright__ = (
+    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
+    "MIT License"
+)
+
 import re
 from importlib.metadata import version
 
@@ -30,13 +38,6 @@ release_version = re.match(r"(\d+\.\d+(\.\d+)?)", __version__).group(0)
 # Assert that version is not 0.1 (which is the default version in the setup.py)
 assert release_version != "0.1", "setuptools_scm could not find the version number"
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
 
 __all__ = [
     "clustering",

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -2,14 +2,6 @@
 Functions for computing network clusters.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import logging
 from dataclasses import dataclass
 from importlib.util import find_spec

--- a/pypsa/clustering/temporal.py
+++ b/pypsa/clustering/temporal.py
@@ -1,11 +1,3 @@
 """
 Functions for temporal clustering of networks.
 """
-
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2023-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -1,22 +1,11 @@
 """Power system components."""
 
-from weakref import ref
-
-from pypsa.clustering import ClusteringAccessor
-
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import logging
 import os
 from collections import namedtuple
 from pathlib import Path
 from typing import Union
+from weakref import ref
 
 import geopandas as gpd
 import numpy as np
@@ -26,6 +15,7 @@ import validators
 from pyproj import CRS, Transformer
 from scipy.sparse import csgraph
 
+from pypsa.clustering import ClusteringAccessor
 from pypsa.consistency import (
     check_assets,
     check_dtypes_,

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -2,14 +2,6 @@
 Functionality for contingency analysis, such as branch outages.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import logging
 from collections.abc import Iterable
 

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -2,14 +2,6 @@
 Descriptors for component attributes.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import logging
 import re
 from collections import OrderedDict

--- a/pypsa/examples.py
+++ b/pypsa/examples.py
@@ -4,14 +4,6 @@ This module contains functions for retrieving/loading example networks provided
 by the PyPSA project.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2021-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import logging
 from urllib.error import HTTPError
 from urllib.request import urlretrieve

--- a/pypsa/geo.py
+++ b/pypsa/geo.py
@@ -2,14 +2,6 @@
 Functionality to help with georeferencing and calculate distances/areas.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import logging
 
 import numpy as np

--- a/pypsa/graph.py
+++ b/pypsa/graph.py
@@ -2,13 +2,6 @@
 Graph helper functions, which are attached to network and sub_network.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
 
 # Functions which will be attached to network and sub_network
 

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -2,14 +2,6 @@
 Functions for importing and exporting data.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import json
 import logging
 import math

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -2,14 +2,6 @@
 Power flow functionality.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import logging
 import time
 from operator import itemgetter

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -2,14 +2,6 @@
 Functions for plotting networks.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-2024 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import logging
 
 import matplotlib.pyplot as plt

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -2,14 +2,6 @@
 Statistics Accessor.
 """
 
-__author__ = (
-    "PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html"
-)
-__copyright__ = (
-    "Copyright 2015-4 PyPSA Developers, see https://pypsa.readthedocs.io/en/latest/developers.html, "
-    "MIT License"
-)
-
 import logging
 from functools import wraps
 from inspect import signature


### PR DESCRIPTION
I suggest to keep the python author/copyright metadata only in the package `__init__.py`. This is cleaner and they don't differ (only slightly in years) in any module anyway.
To become REUSE compatible (do we want to?) the licence is missing anyway. We could everything to SPDX then
