### PR TITLE
test: catch DeprecationWarnings and FutureWarnings in `pytest`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ filterwarnings = [
     "error::DeprecationWarning", # Raise all DeprecationWarnings as errors
     "error::FutureWarning",      # Raise all FutureWarnings as errors
     # Ignore https://github.com/pydata/xarray/issues/6505 (occurs via linopy)
+    # When https://github.com/PyPSA/linopy/issues/303 is fixed, this can be removed
     "ignore:Deleting a single level of a MultiIndex is deprecated:DeprecationWarning",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ include = ["pypsa"]
 [tool.pytest.ini_options]
 filterwarnings = [
     "error::DeprecationWarning", # Raise all DeprecationWarnings as errors
+    "error::FutureWarning",      # Raise all FutureWarnings as errors
     # Ignore https://github.com/pydata/xarray/issues/6505 (occurs via linopy)
     "ignore:Deleting a single level of a MultiIndex is deprecated:DeprecationWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,15 @@ gurobipy = ["gurobipy"]
 [tool.setuptools.packages.find]
 include = ["pypsa"]
 
+# Pytest settings
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error::DeprecationWarning", # Raise all DeprecationWarnings as errors
+    # Ignore https://github.com/pydata/xarray/issues/6505 (occurs via linopy)
+    "ignore:Deleting a single level of a MultiIndex is deprecated:DeprecationWarning",
+]
+
 # Formater and linter settings
 
 [tool.black]

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -777,6 +777,9 @@ class Network(Basic):
         obj_df = pd.DataFrame(
             data=[static_attrs.default], index=[name], columns=static_attrs.index
         )
+
+        # Remove all NaN columns before concatenating
+        obj_df = obj_df.dropna(axis=1, how="all")
         new_df = pd.concat([cls_df, obj_df], sort=False)
 
         new_df.index.name = class_name

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -1517,8 +1517,8 @@ def import_from_pandapower_net(
         network.remove("Bus", i)
 
     for c in network.iterate_components({"Load", "Generator", "ShuntImpedance"}):
-        c.df.bus.replace(to_replace, inplace=True)
+        c.df.replace({"bus": to_replace}, inplace=True)
 
     for c in network.iterate_components({"Line", "Transformer"}):
-        c.df.bus0.replace(to_replace, inplace=True)
-        c.df.bus1.replace(to_replace, inplace=True)
+        c.df.replace({"bus0": to_replace}, inplace=True)
+        c.df.replace({"bus1": to_replace}, inplace=True)

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -387,7 +387,7 @@ class StatisticsAccessor:
             self.installed_capacity,
             self.supply,
             self.withdrawal,
-            self.dispatch,
+            self.energy_balance,
             self.transmission,
             self.capacity_factor,
             self.curtailment,

--- a/test/test_lopf_global_constraints.py
+++ b/test/test_lopf_global_constraints.py
@@ -21,7 +21,7 @@ def test_operational_limit_ac_dc_meshed(ac_dc_network):
     )
 
     n.optimize()
-    assert n.statistics.dispatch().loc[:, "gas"].sum().round(3) == limit
+    assert n.statistics.energy_balance().loc[:, "gas"].sum().round(3) == limit
 
 
 def test_operational_limit_storage_hvdc(storage_hvdc_network):

--- a/test/test_lopf_unit_commitment.py
+++ b/test/test_lopf_unit_commitment.py
@@ -480,7 +480,7 @@ def test_dynamic_ramp_rates():
 
     static_ramp_up = 0.8
     static_ramp_down = 1
-    p_max_pu = pd.Series(1, index=n.snapshots)
+    p_max_pu = pd.Series(1, index=n.snapshots).astype(float)
     p_max_pu.loc[n.snapshots[0:6]] = 0.5  # 50% capacity outage for 6 periods
 
     n.add(


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Adds `pytest` settings so test fail for any missed DeprecationWarning or FutureWarning somewhere. This should clean up the Warning logs quite a bit
- Also resolves all existing Warnings
  - Except https://github.com/PyPSA/linopy/issues/303, which is ignored