### PR TITLE
Pylint fixes: fix {} and [] default arguments etc.

### DIFF
--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -593,7 +593,7 @@ class HandlerCircle(HandlerPatch):
         return [p]
 
 
-def add_legend_lines(ax, sizes, labels, colors=[], patch_kw={}, legend_kw={}):
+def add_legend_lines(ax, sizes, labels, colors=None, patch_kw=None, legend_kw=None):
     """
     Add a legend for lines and links.
 
@@ -613,7 +613,11 @@ def add_legend_lines(ax, sizes, labels, colors=[], patch_kw={}, legend_kw={}):
     """
     sizes = np.atleast_1d(sizes)
     labels = np.atleast_1d(labels)
-    colors = np.atleast_1d(colors)
+    colors = [] if colors is None else np.atleast_1d(colors)
+    if patch_kw is None:
+        patch_kw = {}
+    if legend_kw is None:
+        legend_kw = {}
 
     if len(sizes) != len(labels):
         msg = "Sizes and labels must have the same length."
@@ -635,7 +639,7 @@ def add_legend_lines(ax, sizes, labels, colors=[], patch_kw={}, legend_kw={}):
     ax.get_figure().add_artist(legend)
 
 
-def add_legend_patches(ax, colors, labels, patch_kw={}, legend_kw={}):
+def add_legend_patches(ax, colors, labels, patch_kw=None, legend_kw=None):
     """
     Add patches for color references.
 
@@ -653,6 +657,10 @@ def add_legend_patches(ax, colors, labels, patch_kw={}, legend_kw={}):
     """
     colors = np.atleast_1d(colors)
     labels = np.atleast_1d(labels)
+    if patch_kw is None:
+        patch_kw = {}
+    if legend_kw is None:
+        legend_kw = {}
 
     if len(colors) != len(labels):
         msg = "Colors and labels must have the same length."
@@ -665,7 +673,7 @@ def add_legend_patches(ax, colors, labels, patch_kw={}, legend_kw={}):
     ax.get_figure().add_artist(legend)
 
 
-def add_legend_circles(ax, sizes, labels, srid=4326, patch_kw={}, legend_kw={}):
+def add_legend_circles(ax, sizes, labels, srid=4326, patch_kw=None, legend_kw=None):
     """
     Add a legend for reference circles.
 
@@ -683,6 +691,10 @@ def add_legend_circles(ax, sizes, labels, srid=4326, patch_kw={}, legend_kw={}):
     """
     sizes = np.atleast_1d(sizes)
     labels = np.atleast_1d(labels)
+    if patch_kw is None:
+        patch_kw = {}
+    if legend_kw is None:
+        legend_kw = {}
 
     if len(sizes) != len(labels):
         msg = "Sizes and labels must have the same length."
@@ -897,7 +909,7 @@ def iplot(
     mapbox=False,
     mapbox_style="open-street-map",
     mapbox_token="",
-    mapbox_parameters={},
+    mapbox_parameters=None,
 ):
     """
     Plot the network buses and lines interactively using plotly.
@@ -980,6 +992,9 @@ def iplot(
     -------
     fig: dictionary for plotly figure
     """
+
+    if mapbox_parameters is None:
+        mapbox_parameters = {}
 
     if fig is None:
         fig = dict(data=[], layout={})

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -185,7 +185,7 @@ def get_grouping(n, c, groupby, port=None, nice_names=False) -> [pd.Series, list
     elif isinstance(groupby, str):
         by = n.df(c)[groupby]
     elif groupby is not False:
-        ValueError(
+        raise ValueError(
             f"Argument `groupby` must be a function, list, string, False or dict, got {type(groupby)}"
         )
     return dict(by=by, level=level)


### PR DESCRIPTION
This patch fixes two problems identified by Pylint:

1. A missing `raise` statement (at least, it appears to be missing).
2. Eliminate the use of [] and {} default arguments. There is a good reason for doing this:

https://pylint.pycqa.org/en/latest/user_guide/messages/warning/dangerous-default-value.html