### PR TITLE
ci: disable codecov comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ branch = true
 source = ["pypsa"]
 omit = ["test/*"]
 comment = false
+threshold = 1
 
 # Formater and linter settings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ filterwarnings = [
 branch = true
 source = ["pypsa"]
 omit = ["test/*"]
+comment = false
 
 # Formater and linter settings
 


### PR DESCRIPTION
After moving the settings to `pyproject.toml` in #952, the comments do appear again. I don't think this is needed, since we also have the badge and the ci check. We need to reach improve the coverage anyways (#231)