### PR TITLE
fix: #957 run deepcopy and fix component copy order

### DIFF
--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -1083,6 +1083,11 @@ class Network(Basic):
 
         """
 
+        # Use copy.deepcopy if no arguments are passed
+        args = [snapshots, investment_periods, ignore_standard_types, with_time]
+        if all(arg is None or arg is False for arg in args):
+            return copy.deepcopy(self)
+
         # Set default arguments
         if snapshots is None:
             snapshots = self.snapshots
@@ -1107,11 +1112,6 @@ class Network(Basic):
                 stacklevel=2,
             )
 
-        # Use copy.deepcopy if no arguments are passed
-        args = [snapshots, investment_periods, ignore_standard_types, with_time]
-        if all(arg is None or arg is False for arg in args):
-            return copy.deepcopy(self)
-
         # Setup new network
         (
             override_components,
@@ -1125,7 +1125,9 @@ class Network(Basic):
         )
 
         # Copy components
-        for component in self.iterate_components(self.all_components):
+        other_comps = sorted(self.all_components - {"Bus", "Carrier"})
+        # Needs to copy buses and carriers first, since there are dependencies on them
+        for component in self.iterate_components(["Bus", "Carrier"] + other_comps):
             # Drop the standard types to avoid them being read in twice
             if (
                 not ignore_standard_types

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -123,10 +123,10 @@ def all_networks(
 ):
     return [
         ac_dc_network,
-        # ac_dc_network_r,
-        # ac_dc_network_multiindexed,
-        # ac_dc_network_shapes,
-        # storage_hvdc_network,
+        ac_dc_network_r,
+        ac_dc_network_multiindexed,
+        ac_dc_network_shapes,
+        storage_hvdc_network,
     ]
 
 

--- a/test/test_lopf_global_constraints.py
+++ b/test/test_lopf_global_constraints.py
@@ -5,7 +5,7 @@ import pytest
 
 
 def test_operational_limit_ac_dc_meshed(ac_dc_network):
-    n = ac_dc_network
+    n = ac_dc_network.copy()
 
     limit = 30_000
 
@@ -25,7 +25,7 @@ def test_operational_limit_ac_dc_meshed(ac_dc_network):
 
 
 def test_operational_limit_storage_hvdc(storage_hvdc_network):
-    n = storage_hvdc_network
+    n = storage_hvdc_network.copy()
 
     limit = 5_000
 


### PR DESCRIPTION
Closes #957

## Changes proposed in this Pull Request
- Fix bug where deepcopy was never used
- Fix bug where no bus warnings were raised because they were added later

## Checklist

- [x] I consent to the release of this PR's code under the MIT license.
