### PR TITLE
chore: remove obsolete black formatter config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,10 +88,7 @@ omit = ["test/*"]
 comment = false
 threshold = 1
 
-# Formater and linter settings
-
-[tool.black]
-line-length = 88
+# Formatter and linter settings
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

You have ruff format in place in the pre-commit config. Black is not used anywhere, so I guess this can safely be removed?

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
