### PR TITLE
add argument compute_infeasibilities to n.optimize()

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -32,6 +32,8 @@ Upcoming Release
 
 * Bugfix: The global constraint on the total transmission costs now includes the weight of the investment periods and persistence of investment costs of active assets in multi-horizon optimisations.
 
+* Add option `n.optimize(compute_infeasibilities=True)` to compute Irreducible Inconsistent Subset (IIS) in case an infeasibility was encountered and Gurobi is installed.
+
 PyPSA 0.28.0 (8th May 2024)
 =================================
 

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -488,9 +488,7 @@ def define_transmission_expansion_cost_limit(n, sns):
             )
 
             if not isnan(period):
-                ext_i = ext_i[n.get_active_assets(c, period)[ext_i]].rename(
-                    ext_i.name
-                )
+                ext_i = ext_i[n.get_active_assets(c, period)[ext_i]].rename(ext_i.name)
                 weights = 1
 
             elif isinstance(sns, pd.MultiIndex):

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -10,6 +10,7 @@ from functools import wraps
 import numpy as np
 import pandas as pd
 from linopy import Model, merge
+from linopy.solvers import available_solvers
 
 from pypsa.descriptors import additional_linkports, get_committable_i, nominal_attrs
 from pypsa.descriptors import get_switchable_as_dense as get_as_dense
@@ -512,6 +513,7 @@ def optimize(
     assign_all_duals=False,
     solver_name="highs",
     solver_options={},
+    compute_infeasibilities=False,
     **kwargs,
 ):
     """
@@ -548,6 +550,9 @@ def optimize(
         Name of the solver to use.
     solver_options : dict
         Keyword arguments used by the solver. Can also be passed via **kwargs.
+    compute_infeasibilities : bool, default False
+        Whether to compute and print Irreducible Inconsistent Subsystem (IIS) in case
+        of an infeasible solution. Requires Gurobi.
     **kwargs:
         Keyword argument used by `linopy.Model.solve`, such as `solver_name`,
         `problem_fn` or solver options directly passed to the solver.
@@ -584,6 +589,13 @@ def optimize(
         assign_solution(n)
         assign_duals(n, assign_all_duals)
         post_processing(n)
+
+    if (
+        condition == "infeasible"
+        and compute_infeasibilities
+        and "gurobi" in available_solvers
+    ):
+        n.model.print_infeasibilities()
 
     return status, condition
 


### PR DESCRIPTION
counter-proposal for #928

Implemented this way as currently only Gurobi supports the compute infeasibilities, and setting `compute_infeasibilities=True` automatically requests "gurobi" as solver.

I know HiGHS is planning to add IIS computation soon, in which case the IIS functions in linopy need to be expanded and one could check if the `solver_name` can do IIS:

```py
from linopy.solvers import iis_solvers
if condition == 'infeasibile' and compute_infeasibilities and solver_name in iis_solvers:
    n.model.print_infeasibilities(solver_name=solver_name)
```