### PR TITLE
add semi circle legend method for plotting

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,6 +11,8 @@ Upcoming Release
   To use the features already you have to install the ``master`` branch, e.g. 
   ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* Add semicircle legend to the plot module. To add semicircle to your plot axis you can do `pypsa.plot.add_legend_semicircle(ax, sizes=[1000/scaling_factor], labels=["1 GWh"])`, where sizes should have the same order of magintude as `bus_sizes`.
+
 * The `statistics` module has now for `optimal_capacity` and `expanded_capacity`, 
   positive and negative capacity values if a `bus_carrier` is selected. Positive values 
   correspond to production capacities, negative values to consumption capacities.

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,7 +11,7 @@ Upcoming Release
   To use the features already you have to install the ``master`` branch, e.g. 
   ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
-* Add semicircle legend to the plot module. To add semicircle to your plot axis you can do `pypsa.plot.add_legend_semicircle(ax, sizes=[1000/scaling_factor], labels=["1 GWh"])`, where sizes should have the same order of magintude as `bus_sizes`.
+* Add semicircle legend to the plot module. To add semicircle to your plot axis you can do `pypsa.plot.add_legend_semicircle(ax, sizes=[1000/scaling_factor], labels=["1 GWh"])`, where sizes should have the same order of magnitude as `bus_sizes`.
 
 * The `statistics` module has now for `optimal_capacity` and `expanded_capacity`, 
   positive and negative capacity values if a `bus_carrier` is selected. Positive values 

--- a/test/test_plotting.py
+++ b/test/test_plotting.py
@@ -13,7 +13,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pypsa.plot import add_legend_circles, add_legend_lines, add_legend_patches
+from pypsa.plot import (
+    add_legend_circles,
+    add_legend_lines,
+    add_legend_patches,
+    add_legend_semicircles,
+)
 from pypsa.statistics import get_transmission_branches
 
 try:
@@ -295,5 +300,17 @@ def test_plot_legend_circles_geomap(ac_dc_network):
     n.plot(ax=ax, geomap=True)
 
     add_legend_circles(ax, [1, 0.5], ["reference A", "reference B"])
+
+    plt.close()
+
+
+@pytest.mark.skipif(not cartopy_present, reason="Cartopy not installed")
+def test_plot_legend_semicircles_geomap(ac_dc_network):
+    n = ac_dc_network
+
+    fig, ax = plt.subplots(subplot_kw={"projection": ccrs.PlateCarree()})
+    n.plot(ax=ax, geomap=True)
+
+    add_legend_semicircles(ax, [1, 0.5], ["reference A", "reference B"])
 
     plt.close()


### PR DESCRIPTION
I have been using the added code many times to add a legend for semicircles in my plots, and I thought maybe other people also wan to use it. It is very similar to the function add_legend_circles. 


## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
