### PR TITLE
add functionality for Investments statistics

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,6 +11,8 @@ Upcoming Release
   To use the features already you have to install the ``master`` branch, e.g. 
   ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* The `statistics` functions `capex`, `installed_capex`, and `expanded_capex` now have an optional `cost_attribute` argument, which defaults to `capital_cost`. The default behavior of the functions is not changed.
+
 * The `statistics` module has now for `optimal_capacity` and `expanded_capacity`, 
   positive and negative capacity values if a `bus_carrier` is selected. Positive values 
   correspond to production capacities, negative values to consumption capacities.

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -429,6 +429,11 @@ class StatisticsAccessor:
 
         For information on the list of arguments, see the docs in
         `Network.statistics` or `pypsa.statistics.StatisticsAccessor`.
+
+        Parameters
+        ----------
+        cost_attribute : str
+            Network attribute that should be used to calculate Capital Expenditure. Defaults to `capital_cost`.
         """
         n = self._parent
 
@@ -467,6 +472,11 @@ class StatisticsAccessor:
 
         For information on the list of arguments, see the docs in
         `Network.statistics` or `pypsa.statistics.StatisticsAccessor`.
+
+        Parameters
+        ----------
+        cost_attribute : str
+            Network attribute that should be used to calculate Capital Expenditure. Defaults to `capital_cost`.
         """
         n = self._parent
 
@@ -505,6 +515,11 @@ class StatisticsAccessor:
 
         For information on the list of arguments, see the docs in
         `Network.statistics` or `pypsa.statistics.StatisticsAccessor`.
+
+        Parameters
+        ----------
+        cost_attribute : str
+            Network attribute that should be used to calculate Capital Expenditure. Defaults to `capital_cost`.
         """
         df = self.capex(
             comps=comps,

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -419,6 +419,7 @@ class StatisticsAccessor:
         at_port=False,
         bus_carrier=None,
         nice_names=True,
+        cost_attribute="capital_cost",
     ):
         """
         Calculate the capital expenditure of the network in given currency.
@@ -433,7 +434,7 @@ class StatisticsAccessor:
 
         @pass_empty_series_if_keyerror
         def func(n, c, port):
-            col = n.df(c).eval(f"{nominal_attrs[c]}_opt * capital_cost")
+            col = n.df(c).eval(f"{nominal_attrs[c]}_opt * {cost_attribute}")
             return col
 
         df = aggregate_components(
@@ -458,6 +459,7 @@ class StatisticsAccessor:
         at_port=False,
         bus_carrier=None,
         nice_names=True,
+        cost_attribute="capital_cost",
     ):
         """
         Calculate the capital expenditure of already built components of the
@@ -470,7 +472,7 @@ class StatisticsAccessor:
 
         @pass_empty_series_if_keyerror
         def func(n, c, port):
-            col = n.df(c).eval(f"{nominal_attrs[c]} * capital_cost")
+            col = n.df(c).eval(f"{nominal_attrs[c]} * {cost_attribute}")
             return col
 
         df = aggregate_components(
@@ -495,6 +497,7 @@ class StatisticsAccessor:
         at_port=False,
         bus_carrier=None,
         nice_names=True,
+        cost_attribute="capital_cost",
     ):
         """
         Calculate the capex of expanded capacities of the network components in
@@ -510,6 +513,7 @@ class StatisticsAccessor:
             at_port=at_port,
             bus_carrier=bus_carrier,
             nice_names=nice_names,
+            cost_attribute=cost_attribute,
         ).sub(
             self.installed_capex(
                 comps=comps,
@@ -518,124 +522,11 @@ class StatisticsAccessor:
                 at_port=at_port,
                 bus_carrier=bus_carrier,
                 nice_names=nice_names,
+                cost_attribute=cost_attribute,
             ),
             fill_value=0,
         )
         df.attrs["name"] = "Capital Expenditure Expanded"
-        df.attrs["unit"] = "currency"
-        return df
-
-    def investments(
-        self,
-        comps=None,
-        aggregate_groups="sum",
-        groupby=None,
-        at_port=False,
-        bus_carrier=None,
-        nice_names=True,
-    ):
-        """
-        Calculate the capital investment of the network in given currency.
-
-        If `bus_carrier` is given, only components which are connected to buses
-        with carrier `bus_carrier` are considered.
-
-        For information on the list of arguments, see the docs in
-        `Network.statistics` or `pypsa.statistics.StatisticsAccessor`.
-        """
-        n = self._parent
-
-        @pass_empty_series_if_keyerror
-        def func(n, c, port):
-            col = n.df(c).eval(f"{nominal_attrs[c]}_opt * investment")
-            return col
-
-        df = aggregate_components(
-            n,
-            func,
-            comps=comps,
-            agg=aggregate_groups,
-            groupby=groupby,
-            at_port=at_port,
-            bus_carrier=bus_carrier,
-            nice_names=nice_names,
-        )
-        df.attrs["name"] = "Capital Investment"
-        df.attrs["unit"] = "currency"
-        return df
-
-    def installed_investments(
-        self,
-        comps=None,
-        aggregate_groups="sum",
-        groupby=None,
-        at_port=False,
-        bus_carrier=None,
-        nice_names=True,
-    ):
-        """
-        Calculate the capital investment of already built components of the
-        network in given currency.
-
-        For information on the list of arguments, see the docs in
-        `Network.statistics` or `pypsa.statistics.StatisticsAccessor`.
-        """
-        n = self._parent
-
-        @pass_empty_series_if_keyerror
-        def func(n, c, port):
-            col = n.df(c).eval(f"{nominal_attrs[c]} * investment")
-            return col
-
-        df = aggregate_components(
-            n,
-            func,
-            comps=comps,
-            agg=aggregate_groups,
-            groupby=groupby,
-            at_port=at_port,
-            bus_carrier=bus_carrier,
-            nice_names=nice_names,
-        )
-        df.attrs["name"] = "Capital Investment Fixed"
-        df.attrs["unit"] = "currency"
-        return df
-
-    def expanded_investments(
-        self,
-        comps=None,
-        aggregate_groups="sum",
-        groupby=None,
-        at_port=False,
-        bus_carrier=None,
-        nice_names=True,
-    ):
-        """
-        Calculate the capital investment of expanded capacities of the network components in
-        currency.
-
-        For information on the list of arguments, see the docs in
-        `Network.statistics` or `pypsa.statistics.StatisticsAccessor`.
-        """
-        df = self.investments(
-            comps=comps,
-            aggregate_groups=aggregate_groups,
-            groupby=groupby,
-            at_port=at_port,
-            bus_carrier=bus_carrier,
-            nice_names=nice_names,
-        ).sub(
-            self.installed_investments(
-                comps=comps,
-                aggregate_groups=aggregate_groups,
-                groupby=groupby,
-                at_port=at_port,
-                bus_carrier=bus_carrier,
-                nice_names=nice_names,
-            ),
-            fill_value=0,
-        )
-        df.attrs["name"] = "Capital Investment Expanded"
         df.attrs["unit"] = "currency"
         return df
 

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -449,9 +449,7 @@ class StatisticsAccessor:
         df.attrs["name"] = "Capital Expenditure"
         df.attrs["unit"] = "currency"
         return df
-    
 
-    
     def installed_capex(
         self,
         comps=None,
@@ -527,7 +525,6 @@ class StatisticsAccessor:
         df.attrs["unit"] = "currency"
         return df
 
-
     def investments(
         self,
         comps=None,
@@ -566,7 +563,7 @@ class StatisticsAccessor:
         df.attrs["name"] = "Capital Investment"
         df.attrs["unit"] = "currency"
         return df
-    
+
     def installed_investments(
         self,
         comps=None,
@@ -640,7 +637,7 @@ class StatisticsAccessor:
         )
         df.attrs["name"] = "Capital Investment Expanded"
         df.attrs["unit"] = "currency"
-        return df 
+        return df
 
     def optimal_capacity(
         self,

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -449,7 +449,9 @@ class StatisticsAccessor:
         df.attrs["name"] = "Capital Expenditure"
         df.attrs["unit"] = "currency"
         return df
+    
 
+    
     def installed_capex(
         self,
         comps=None,
@@ -524,6 +526,121 @@ class StatisticsAccessor:
         df.attrs["name"] = "Capital Expenditure Expanded"
         df.attrs["unit"] = "currency"
         return df
+
+
+    def investments(
+        self,
+        comps=None,
+        aggregate_groups="sum",
+        groupby=None,
+        at_port=False,
+        bus_carrier=None,
+        nice_names=True,
+    ):
+        """
+        Calculate the capital investment of the network in given currency.
+
+        If `bus_carrier` is given, only components which are connected to buses
+        with carrier `bus_carrier` are considered.
+
+        For information on the list of arguments, see the docs in
+        `Network.statistics` or `pypsa.statistics.StatisticsAccessor`.
+        """
+        n = self._parent
+
+        @pass_empty_series_if_keyerror
+        def func(n, c, port):
+            col = n.df(c).eval(f"{nominal_attrs[c]}_opt * investment")
+            return col
+
+        df = aggregate_components(
+            n,
+            func,
+            comps=comps,
+            agg=aggregate_groups,
+            groupby=groupby,
+            at_port=at_port,
+            bus_carrier=bus_carrier,
+            nice_names=nice_names,
+        )
+        df.attrs["name"] = "Capital Investment"
+        df.attrs["unit"] = "currency"
+        return df
+    
+    def installed_investments(
+        self,
+        comps=None,
+        aggregate_groups="sum",
+        groupby=None,
+        at_port=False,
+        bus_carrier=None,
+        nice_names=True,
+    ):
+        """
+        Calculate the capital investment of already built components of the
+        network in given currency.
+
+        For information on the list of arguments, see the docs in
+        `Network.statistics` or `pypsa.statistics.StatisticsAccessor`.
+        """
+        n = self._parent
+
+        @pass_empty_series_if_keyerror
+        def func(n, c, port):
+            col = n.df(c).eval(f"{nominal_attrs[c]} * investment")
+            return col
+
+        df = aggregate_components(
+            n,
+            func,
+            comps=comps,
+            agg=aggregate_groups,
+            groupby=groupby,
+            at_port=at_port,
+            bus_carrier=bus_carrier,
+            nice_names=nice_names,
+        )
+        df.attrs["name"] = "Capital Investment Fixed"
+        df.attrs["unit"] = "currency"
+        return df
+
+    def expanded_investments(
+        self,
+        comps=None,
+        aggregate_groups="sum",
+        groupby=None,
+        at_port=False,
+        bus_carrier=None,
+        nice_names=True,
+    ):
+        """
+        Calculate the capital investment of expanded capacities of the network components in
+        currency.
+
+        For information on the list of arguments, see the docs in
+        `Network.statistics` or `pypsa.statistics.StatisticsAccessor`.
+        """
+        df = self.investments(
+            comps=comps,
+            aggregate_groups=aggregate_groups,
+            groupby=groupby,
+            at_port=at_port,
+            bus_carrier=bus_carrier,
+            nice_names=nice_names,
+        ).sub(
+            self.installed_investments(
+                comps=comps,
+                aggregate_groups=aggregate_groups,
+                groupby=groupby,
+                at_port=at_port,
+                bus_carrier=bus_carrier,
+                nice_names=nice_names,
+            ),
+            fill_value=0,
+        )
+        df.attrs["name"] = "Capital Investment Expanded"
+        df.attrs["unit"] = "currency"
+        return df 
 
     def optimal_capacity(
         self,


### PR DESCRIPTION
Work in progress. Introduces a new statistics method for computing total upfront investments. Only needed for some changes in PyPSA-Eur, not sure if it should go to PyPSA but might be useful. In Pypsa-Eur: https://github.com/PyPSA/pypsa-eur/pull/1156


## Changes proposed in this Pull Request

The methods for n.statistics compute aggregate the investments, if the correpsonding column is present in the model

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
