### PR TITLE
pyproject: fix requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs = [
     "nbsphinx-link==1.3.0",
     "scikit-learn==1.5.1",
     "docutils==0.20.0", # Just temporarily until sphinx-docutils is updated (see https://github.com/sphinx-doc/sphinx/issues/12340)
-    "ipython===8.26.0",
+    "ipython==8.26.0",
     "ipykernel==6.29.5",
 ]
 gurobipy = ["gurobipy"]


### PR DESCRIPTION
fix typo. this did not lead to an error but a warning that it will be ignored (only the requirement)