### PR TITLE
Make extendability and committability compatible, when modularity is on

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -13,6 +13,13 @@ Upcoming Release
 
 * new feature or bugfix
 
+* PyPSA now supports committability and extendability, on 
+  the same components, if modularity is used. The new feature
+  is compatible with start-up and shut-down costs, ramp-up and
+  shut-down limit. The feature is not still compatible with
+  min-up and min-down time, up and down time before.
+
+
 PyPSA 0.29.0 (31st July 2024)
 =============================
 

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -29,9 +29,14 @@ from pypsa.optimization.constraints import (
     define_modular_constraints,
     define_nodal_balance_constraints,
     define_nominal_constraints_for_extendables,
-    define_operational_constraints_for_committables,
-    define_operational_constraints_for_extendables,
-    define_operational_constraints_for_non_extendables,
+    define_committability_variables_constraints_for_non_modular,
+    define_committability_variables_constraints_for_modular_and_non_extendables,
+    define_committability_variables_constraints_for_modular_and_extendables,
+    define_operational_constraints_for_committables_non_modular_non_extendables,
+    define_operational_constraints_for_committables_and_modular,
+    define_operational_constraints_for_extendables_and_committables_but_non_modular,
+    define_operational_constraints_for_extendables_but_non_committables,
+    define_operational_constraints_for_non_extendables_and_non_committables,
     define_ramp_limit_constraints,
     define_storage_unit_constraints,
     define_store_constraints,
@@ -50,10 +55,14 @@ from pypsa.optimization.variables import (
     define_modular_variables,
     define_nominal_variables,
     define_operational_variables,
-    define_shut_down_variables,
+    #Removed function no longer used
+    #define_shut_down_variables,
     define_spillage_variables,
-    define_start_up_variables,
-    define_status_variables,
+    #Removed function no longer used
+    #define_start_up_variables,
+    #Removed function no longer used
+    #define_status_variables,
+    define_integer_committability_variables,
 )
 from pypsa.pf import _as_snapshots
 
@@ -246,9 +255,14 @@ def create_model(
 
     for c, attr in lookup.query("not nominal and not handle_separately").index:
         define_operational_variables(n, sns, c, attr)
-        define_status_variables(n, sns, c)
-        define_start_up_variables(n, sns, c)
-        define_shut_down_variables(n, sns, c)
+        #Removed functions no longer used
+        #define_status_variables(n, sns, c)
+        #define_start_up_variables(n, sns, c)
+        #define_shut_down_variables(n, sns, c)
+        #Define all variable used in committability (status, start_upm and shut_down)
+        #for all committable components  (ext/non ext and mod/non mod)
+        define_integer_committability_variables(n, sns, c)
+        
 
     define_spillage_variables(n, sns)
     define_operational_variables(n, sns, "Store", "p")
@@ -262,18 +276,42 @@ def create_model(
         define_nominal_constraints_for_extendables(n, c, attr)
         define_fixed_nominal_constraints(n, c, attr)
         define_modular_constraints(n, c, attr)
+        #Define upper limit of committable variables for committable but NON modular components (ext/non ext) --> up.lim. = 1
+        define_committability_variables_constraints_for_non_modular(n, sns, c, attr)
+        #Define upper limit of committable variables for committable, modular, but NON extendable components --> up.lim. = p_nom/p_nom_mod
+        define_committability_variables_constraints_for_modular_and_non_extendables(n, sns, c, attr)
+        #Define upper limit of committable variables for committable, modular, and extendable components --> up.lim. = n_mod (variable)
+        #ATT: : ALERTON FORM OF WRITTEN EQUATIONS
+        define_committability_variables_constraints_for_modular_and_extendables(n, sns, c, attr)
 
     for c, attr in lookup.query("not nominal and not handle_separately").index:
-        define_operational_constraints_for_non_extendables(
+        #Define operational constraints for non extendable and non committable components (mod/non mod).
+        #Function is kept as it was.
+        define_operational_constraints_for_non_extendables_and_non_committables(
             n, sns, c, attr, transmission_losses
         )
-        define_operational_constraints_for_extendables(
+        #Define operational constraints for extendable but non committable components (mod/non mod).
+        #Function is kept as it was, I only added filter for non committable.
+        define_operational_constraints_for_extendables_but_non_committables(
             n, sns, c, attr, transmission_losses
         )
-        define_operational_constraints_for_committables(n, sns, c)
+        #Define operational constraints for committable but non modular components and non extendable.
+        #Function is kept as it was, I only: 1)  added filter for non modular and non extendable; 2) changed the name of the function according to 1).
+        define_operational_constraints_for_committables_non_modular_non_extendables(n, sns, c)
+        #Define operational constraints for committable, extendable but non-modular. This function is identical
+        #to "define_operational_constraints_for_extendables_but_non_committables". The only difference is the
+        #identification of the components on which to apply the function. Extendability is preferred over
+        #committability (committability is simply ignored) to ensure compatibility with previous tests.
+        define_operational_constraints_for_extendables_and_committables_but_non_modular(
+            n, sns, c, attr, transmission_losses
+        )
+        #Define operational constraints for committable and modular components (ext/non ext).
+        #Function similar to "define_operational_constraints_for_committables_non_modular_non_extendables". The only difference is the
+        #multiplication of committable variables per p_nom_mod.
+        define_operational_constraints_for_committables_and_modular(n, sns, c)
         define_ramp_limit_constraints(n, sns, c, attr)
         define_fixed_operation_constraints(n, sns, c, attr)
-
+        
     meshed_buses = get_strongly_meshed_buses(n)
     weakly_meshed_buses = n.buses.index.difference(meshed_buses)
     if not meshed_buses.empty and not weakly_meshed_buses.empty:

--- a/pypsa/optimization/variables.py
+++ b/pypsa/optimization/variables.py
@@ -31,7 +31,7 @@ def define_operational_variables(n, sns, c, attr):
     coords = [sns, n.df(c).index.rename(c)]
     n.model.add_variables(coords=coords, name=f"{c}-{attr}", mask=active)
 
-
+#TO BE REMOVED
 def define_status_variables(n, sns, c):
     com_i = n.get_committable_i(c)
 
@@ -46,7 +46,43 @@ def define_status_variables(n, sns, c):
         coords=coords, name=f"{c}-status", mask=active, binary=is_binary, **kwargs
     )
 
+def define_integer_committability_variables(n, sns, c):
+    """
+    Initializes integer variables  related to committability for all committable components. Initialized variables are:
+    - status
+    - start-up
+    - shut down
 
+    Parameters
+    ----------
+    n : pypsa.Network
+    sns : pd.Index
+        Snapshots of the constraint.
+    c : str
+        network component of which the committability variables should be defined
+    """
+    com_i = n.get_committable_i(c)
+
+    if com_i.empty:
+        return
+
+    active = get_activity_mask(n, c, sns, com_i) if n._multi_invest else None
+    coords = (sns, com_i)
+    is_integer = not n._linearized_uc
+    
+    n.model.add_variables(
+        lower=0, coords=coords, name=f"{c}-status",  mask=active, integer=is_integer
+        )
+    
+    n.model.add_variables(
+        lower=0, coords=coords, name=f"{c}-start_up",  mask=active, integer=is_integer
+        )
+    
+    n.model.add_variables(
+        lower=0, coords=coords, name=f"{c}-shut_down",  mask=active, integer=is_integer
+        )
+
+#TO BE REMOVED
 def define_start_up_variables(n, sns, c):
     com_i = n.get_committable_i(c)
 
@@ -61,7 +97,7 @@ def define_start_up_variables(n, sns, c):
         coords=coords, name=f"{c}-start_up", mask=active, binary=is_binary, **kwargs
     )
 
-
+#TO BE REMOVED
 def define_shut_down_variables(n, sns, c):
     com_i = n.get_committable_i(c)
 

--- a/test/test_compatibility_ext_and_com.py
+++ b/test/test_compatibility_ext_and_com.py
@@ -1,0 +1,89 @@
+from numpy.testing import assert_array_almost_equal as equal
+
+import pypsa
+from pypsa.descriptors import nominal_attrs
+
+
+def test_compatibility_ext_and_comt():
+    """
+    This test is based on https://pypsa.readthedocs.io/en/latest/examples/unit-
+    commitment.html and is not very comprehensive.
+    """
+
+    n = pypsa.Network()
+
+    snapshots = range(4)
+
+    n.set_snapshots(snapshots)
+
+    n.add("Bus", "bus")
+
+    n.add(
+    "Generator",
+    "coal",
+    bus="bus",
+    committable=True,
+    ramp_limit_up = 1,
+    p_min_pu=0.3,
+    marginal_cost=20,
+    p_nom=10000,
+    start_up_cost = 2
+    )
+
+    n.add(
+        "Generator",
+        "gas",
+        bus="bus",
+        committable=True,
+        p_nom_extendable = True,
+        ramp_limit_up = 0.5,
+        marginal_cost=70,
+        capital_cost = 1,
+        stand_by_cost=10,
+        p_nom_mod = 500,
+        p_min_pu=0.1,
+        start_up_cost = 2
+    )
+
+    n.add(
+        "Generator",
+        "gas2",
+        bus="bus",
+        committable=True,
+        p_nom_extendable = True,
+        ramp_limit_up = 0.9,
+        marginal_cost=60,
+        stand_by_cost=10,
+        p_min_pu=0.1,
+        capital_cost = 1,
+        start_up_cost = 2
+    )
+
+    n.add(
+        "Generator",
+        "gas3",
+        bus="bus",
+        ramp_limit_up = 0.8,
+        marginal_cost=60,
+        stand_by_cost=10,
+        p_min_pu=0.1,
+        p_nom=1000,
+        p_nom_mod = 250,
+        start_up_cost = 2
+    )
+
+    n.add("Load", "load", bus="bus", p_set=[4000, 6000, 5000, 800])
+
+    n.optimize()
+
+    f_obj = 0
+    for c in nominal_attrs.keys():
+        f_obj += (n.df(c)[f"{nominal_attrs[c]}_opt"] * n.df(c).capital_cost).sum()
+    f_obj += (n.generators_t.p * n.generators.marginal_cost).sum().sum()
+    f_obj += (n.links_t.p0 * n.links.marginal_cost).sum().sum()
+    f_obj += (n.stores_t.p * n.stores.marginal_cost).sum().sum()
+    f_obj += (n.generators_t.status * n.generators.stand_by_cost).sum().sum()
+    f_obj += (n.generators_t.start_up * n.generators.start_up_cost).sum().sum()
+    f_obj += (n.generators_t.shut_down * n.generators.shut_down_cost).sum().sum()
+
+    equal(f_obj, n.objective + n.objective_constant)


### PR DESCRIPTION
Closes #1000 

@davide-f and I would like to propose a MILP formulation for extendability and committability, only when modularity is on, to make these two features compatible. We have also added a test for the feature we have implemented, and believe that the proposed changes are consistent with the rest of the codebase. In particular, the goal is to keep everything compatible with the previous version without introducing breaking changes.

At the moment we'd like to continue working on improving the proposed code changes, but perhaps we'll also propose a new test that's more accurate with respect to the changes introduced.

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [X] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [X] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X] I consent to the release of this PR's code under the MIT license.
