### PR TITLE
test: fix codecov report and improve docs test speed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install "$(ls dist/*.whl)[dev]"
 
-
     - name: Test with pytest
       run: |
         pytest --cov=./ --cov-report=xml
@@ -78,9 +77,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v4
 
-  test-notebooks-and-docs:
-    # Test package build in matrix of OS and Python versions
-    name: Test example notebooks and docs build
+
+  test-docs-build:
+    name: Test docs build # Also tests example notebooks (similar to nbmake)
     needs: [build]
     runs-on: ubuntu-latest
 
@@ -104,10 +103,6 @@ jobs:
         python -m pip install uv
         uv pip install --system nbmake requests
         uv pip install --system "$(ls dist/*.whl)[dev, cartopy, docs]"
-
-    - name: Test example notebooks
-      run: |
-        pytest --nbmake examples/notebooks
 
     - name: Test docs build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,9 +74,9 @@ jobs:
         pytest --cov=./ --cov-report=xml
 
     - name: Upload code coverage report
-      if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v4
-
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   test-docs-build:
     name: Test docs build # Also tests example notebooks (similar to nbmake)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ docs = [
     "docutils==0.20.0", # Just temporarily until nbsphinx-link is updated (see https://github.com/vidartf/nbsphinx-link/issues/22)
     "ipython==8.26.0",
     "ipykernel==6.29.5",
-        "nbmake==1.5.4",
 ]
 gurobipy = ["gurobipy"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ docs = [
 ]
 gurobipy = ["gurobipy"]
 
- # setuptools_scm settings
+# setuptools_scm settings
  
 [tool.setuptools_scm]
 version_scheme = "post-release"
@@ -83,7 +83,7 @@ include = ["pypsa"]
 
 # Pytest settings
 
-[tool.pytest.ini_options]
+[tool.pytest.ini_options]   
 filterwarnings = [
     "error::DeprecationWarning", # Raise all DeprecationWarnings as errors
     "error::FutureWarning",      # Raise all FutureWarnings as errors
@@ -95,8 +95,6 @@ filterwarnings = [
 branch = true
 source = ["pypsa"]
 omit = ["test/*"]
-comment = false
-threshold = 1
 
 # Formatter and linter settings
 


### PR DESCRIPTION
- Fix codecov report
- Adds `codecov.yml` to disable codecov comment
  - Report can still be viewed on codecov.com and in PR checks
- Removes notebook check tests (nbmake) and integrates them to docs build check