### PR TITLE
test: use `coverage` instead of `pytest-cov` and `uv` instead of `pip`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,12 +66,17 @@ jobs:
 
     - name: Install package and dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install "$(ls dist/*.whl)[dev]"
+        python -m pip install uv
+        uv pip install --compile --system "$(ls dist/*.whl)[dev]"
+        # Use --compile to get pip's behavior. Otherwise the pandapower installation 
+        # will be broken on python<3.12
+        # See https://github.com/astral-sh/uv/issues/1928#issuecomment-1968857514
 
     - name: Test with pytest
       run: |
-        pytest --cov=./ --cov-report=xml
+        coverage run -m pytest
+        coverage xml
+        cat coverage.xml
 
     - name: Upload code coverage report
       uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Source = "https://github.com/PyPSA/PyPSA"
 [project.optional-dependencies]
 dev = [
     "pytest", 
-    "pytest-cov",
+    "coverage",
     "pypower",
     "pandapower>=2.14.9",
     "scikit-learn",


### PR DESCRIPTION
- Fixes another codecov bug where coverage was always reported as 0%.
  - Now uses `coverage` instead of `pytest-cov` (which is based on `coverage`) and changed dependencies
- Use `uv` instead of `pip` for faster requirements installation 