### PR TITLE
Bugfix: Fixing n.plot() when single buses have no coordinates

### DIFF
--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -507,6 +507,10 @@ def compute_bbox_with_margins(margin, x, y):
     """
     Helper function to compute bounding box for the plot.
     """
+    # Drop NAs to avoid issues in calculation of bbox
+    x = x.dropna(inplace=True)
+    y = y.dropna(inplace=True)
+
     # set margins
     pos = np.asarray((x, y))
     minxy, maxxy = pos.min(axis=1), pos.max(axis=1)

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -507,13 +507,9 @@ def compute_bbox_with_margins(margin, x, y):
     """
     Helper function to compute bounding box for the plot.
     """
-    # Drop NAs to avoid issues in calculation of bbox
-    x.dropna(inplace=True)
-    y.dropna(inplace=True)
-
     # set margins
     pos = np.asarray((x, y))
-    minxy, maxxy = pos.min(axis=1), pos.max(axis=1)
+    minxy, maxxy = np.nanmin(pos, axis=1), np.nanmax(pos, axis=1)
     xy1 = minxy - margin * (maxxy - minxy)
     xy2 = maxxy + margin * (maxxy - minxy)
     return tuple(xy1), tuple(xy2)

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -508,8 +508,8 @@ def compute_bbox_with_margins(margin, x, y):
     Helper function to compute bounding box for the plot.
     """
     # Drop NAs to avoid issues in calculation of bbox
-    x = x.dropna(inplace=True)
-    y = y.dropna(inplace=True)
+    x.dropna(inplace=True)
+    y.dropna(inplace=True)
 
     # set margins
     pos = np.asarray((x, y))


### PR DESCRIPTION
Closes # (if applicable).

## Error message:
```
{
	"name": "ValueError",
	"message": "Axis limits cannot be NaN or Inf",
	"stack": "---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[12], line 1
----> 1 n1.plot()

File ~/projects/development/PyPSA/pypsa/plot.py:234, in plot(n, margin, ax, geomap, projection, bus_colors, bus_alpha, bus_sizes, bus_cmap, bus_norm, bus_split_circles, line_colors, link_colors, transformer_colors, line_alpha, link_alpha, transformer_alpha, line_widths, link_widths, transformer_widths, line_cmap, link_cmap, transformer_cmap, line_norm, link_norm, transformer_norm, flow, branch_components, layouter, title, boundaries, geometry, jitter, color_geomap)
    231         draw_map_cartopy(ax, geomap, color_geomap)
    233     if boundaries is not None:
--> 234         ax.set_extent(boundaries, crs=transform)
    235 elif ax is None:
    236     ax = plt.gca()

File ~/miniconda3/envs/pypsa-eur-dev/lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:862, in GeoAxes.set_extent(self, extents, crs)
    855 except ValueError:
    856     raise ValueError(
    857         'Failed to determine the required bounds in projection '
    858         'coordinates. Check that the values provided are within the '
    859         f'valid range (x_limits={self.projection.x_limits}, '
    860         f'y_limits={self.projection.y_limits}).')
--> 862 self.set_xlim([x1, x2])
    863 self.set_ylim([y1, y2])

File ~/miniconda3/envs/pypsa-eur-dev/lib/python3.12/site-packages/matplotlib/axes/_base.py:3739, in _AxesBase.set_xlim(self, left, right, emit, auto, xmin, xmax)
   3737         raise TypeError(\"Cannot pass both 'right' and 'xmax'\")
   3738     right = xmax
-> 3739 return self.xaxis._set_lim(left, right, emit=emit, auto=auto)

File ~/miniconda3/envs/pypsa-eur-dev/lib/python3.12/site-packages/matplotlib/axis.py:1236, in Axis._set_lim(self, v0, v1, emit, auto)
   1233 name = self._get_axis_name()
   1235 self.axes._process_unit_info([(name, (v0, v1))], convert=False)
-> 1236 v0 = self.axes._validate_converted_limits(v0, self.convert_units)
   1237 v1 = self.axes._validate_converted_limits(v1, self.convert_units)
   1239 if v0 is None or v1 is None:
   1240     # Axes init calls set_xlim(0, 1) before get_xlim() can be called,
   1241     # so only grab the limits if we really need them.

File ~/miniconda3/envs/pypsa-eur-dev/lib/python3.12/site-packages/matplotlib/axes/_base.py:3660, in _AxesBase._validate_converted_limits(self, limit, convert)
   3657     converted_limit = converted_limit.squeeze()
   3658 if (isinstance(converted_limit, Real)
   3659         and not np.isfinite(converted_limit)):
-> 3660     raise ValueError(\"Axis limits cannot be NaN or Inf\")
   3661 return converted_limit

ValueError: Axis limits cannot be NaN or Inf"
}
```

## Changes proposed in this Pull Request
- Fix `n.plot()` when single buses do not have coordinates (omit from plot). Then no plot is generated at all, error message above occurs.
- Drop NA values when calculating the bounding box.
