### PR TITLE
refactor: introduce naming conventions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,9 @@ jobs:
         python -m pip install uv
         uv pip install --system nbmake requests
         uv pip install --system "$(ls dist/*.whl)[dev]"
+        
+        # TODO: Remove once types in linopy are resolved
+        uv pip install --system linopy==0.3.14 --reinstall
 
     - name: Run type checker (mypy)
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
         python -m pip install uv
         uv pip install --system nbmake requests
         uv pip install --system "$(ls dist/*.whl)[dev]"
-        
+
         # TODO: Remove once types in linopy are resolved
         uv pip install --system linopy==0.3.14 --reinstall
 

--- a/doc/api/networks.rst
+++ b/doc/api/networks.rst
@@ -17,7 +17,9 @@ General methods
     :toctree: _source/
 
     ~pypsa.Network.read_in_default_standard_types
+    ~pypsa.Network.static
     ~pypsa.Network.df
+    ~pypsa.Network.dynamic
     ~pypsa.Network.pnl
     ~pypsa.Network.to_crs
     ~pypsa.Network.set_snapshots

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -25,6 +25,11 @@ Upcoming Release
 * The `Network` class has a new method `component` to access component objects. Use it with e.g. `n.component("Generator")`. 
 * The `Subnetwork` class has new methods `df`, `pnl`, `component` to ease the access of component data for a subnetwork. Use it with e.g. `subnetwork.df("Generator")` and alike.  
 
+* Refactored API: :meth:`n.df <pypsa.Network.df>` and `n.pnl <pypsa.Network.pnl>` have 
+  been renamed to `n.static <pypsa.Network.static>` and 
+  `n.dynamic <pypsa.Network.dynamic>`. But `n.df` and `n.pnl` are still available and
+  can be used as aliases without any deprecation warning.
+
 v0.30.3 (24th September 2024)
 =============================
 

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -25,10 +25,10 @@ Upcoming Release
 * The `Network` class has a new method `component` to access component objects. Use it with e.g. `n.component("Generator")`. 
 * The `Subnetwork` class has new methods `df`, `pnl`, `component` to ease the access of component data for a subnetwork. Use it with e.g. `subnetwork.df("Generator")` and alike.  
 
-* Refactored API: :meth:`n.df <pypsa.Network.df>` and `n.pnl <pypsa.Network.pnl>` have 
-  been renamed to `n.static <pypsa.Network.static>` and 
-  `n.dynamic <pypsa.Network.dynamic>`. But `n.df` and `n.pnl` are still available and
-  can be used as aliases without any deprecation warning.
+* Refactored API: :meth:`n.df <pypsa.Network.df>` and :meth:`n.pnl <pypsa.Network.pnl>` 
+  have been renamed to :meth:`n.static <pypsa.Network.static>` and 
+  :meth:`n.dynamic <pypsa.Network.dynamic>`. But `n.df` and `n.pnl` are still available 
+  and can be used as aliases without any deprecation warning for now.
 
 v0.30.3 (24th September 2024)
 =============================

--- a/examples/notebooks/multi-investment-optimisation.ipynb
+++ b/examples/notebooks/multi-investment-optimisation.ipynb
@@ -323,7 +323,7 @@
     "c = \"Generator\"\n",
     "df = pd.concat(\n",
     "    {\n",
-    "        period: n.get_active_assets(c, period) * n.df(c).p_nom_opt\n",
+    "        period: n.get_active_assets(c, period) * n.static(c).p_nom_opt\n",
     "        for period in n.investment_periods\n",
     "    },\n",
     "    axis=1,\n",

--- a/examples/notebooks/scigrid-redispatch.ipynb
+++ b/examples/notebooks/scigrid-redispatch.ipynb
@@ -145,13 +145,13 @@
    "outputs": [],
    "source": [
     "for c in m.iterate_components(m.one_port_components):\n",
-    "    c.df.bus = c.df.bus.map(zones)\n",
+    "    c.static.bus = c.static.bus.map(zones)\n",
     "\n",
     "for c in m.iterate_components(m.branch_components):\n",
-    "    c.df.bus0 = c.df.bus0.map(zones)\n",
-    "    c.df.bus1 = c.df.bus1.map(zones)\n",
-    "    internal = c.df.bus0 == c.df.bus1\n",
-    "    m.remove(c.name, c.df.loc[internal].index)\n",
+    "    c.static.bus0 = c.static.bus0.map(zones)\n",
+    "    c.static.bus1 = c.static.bus1.map(zones)\n",
+    "    internal = c.static.bus0 == c.static.bus1\n",
+    "    m.remove(c.name, c.static.loc[internal].index)\n",
     "\n",
     "m.remove(\"Bus\", m.buses.index)\n",
     "m.add(\"Bus\", [\"North\", \"South\"]);"

--- a/examples/notebooks/stochastic-problem.ipynb
+++ b/examples/notebooks/stochastic-problem.ipynb
@@ -334,7 +334,7 @@
     "        # add nodal balance constraints\n",
     "        exprs = []\n",
     "        expr = DataArray(sign) * m[f\"{c}-{attr}-{scenario}\"]\n",
-    "        buses = n.df(c)[column].rename(\"Bus\")\n",
+    "        buses = n.static(c)[column].rename(\"Bus\")\n",
     "        expr = expr.groupby(\n",
     "            buses.to_xarray()\n",
     "        ).sum()  # for linopy >=0.2, see breaking changes log\n",
@@ -379,7 +379,7 @@
     "        objective.append((operation * (probability[scenario] * cost_modified)).sum())\n",
     "\n",
     "    ext_i = n.get_extendable_i(c)\n",
-    "    cost = n.df(c)[\"capital_cost\"][ext_i]\n",
+    "    cost = n.static(c)[\"capital_cost\"][ext_i]\n",
     "    objective.append((capacity * cost).sum())\n",
     "\n",
     "    m.objective = merge(objective)"
@@ -786,7 +786,7 @@
     "# don't forget to add the capital costs of the (fixed) generators portfolio\n",
     "c = \"Generator\"\n",
     "ext_i = portfolios[\"naive\"].index\n",
-    "cost = n.df(c)[\"capital_cost\"][ext_i]\n",
+    "cost = n.static(c)[\"capital_cost\"][ext_i]\n",
     "cost_of_portfolio = (n.generators.p_nom * cost).sum()\n",
     "n.objective += cost_of_portfolio\n",
     "n.objective"

--- a/pypsa/clustering/__init__.py
+++ b/pypsa/clustering/__init__.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import pandas as pd
 
 from pypsa.clustering import spatial, temporal
+from pypsa.utils import deprecated_common_kwargs
 
 if TYPE_CHECKING:
     from pypsa import Network
@@ -20,36 +21,35 @@ class ClusteringAccessor:
     Clustering accessor for clustering a network spatially and temporally.
     """
 
-    def __init__(self, network: "Network") -> None:
-        self._parent = network
+    @deprecated_common_kwargs
+    def __init__(self, n: "Network") -> None:
+        self.n = n
 
     @wraps(spatial.busmap_by_hac)
     def busmap_by_hac(self, *args: Any, **kwargs: Any) -> pd.Series:
-        return spatial.busmap_by_hac(self._parent, *args, **kwargs)
+        return spatial.busmap_by_hac(self.n, *args, **kwargs)
 
     @wraps(spatial.busmap_by_kmeans)
     def busmap_by_kmeans(self, *args: Any, **kwargs: Any) -> pd.Series:
-        return spatial.busmap_by_kmeans(self._parent, *args, **kwargs)
+        return spatial.busmap_by_kmeans(self.n, *args, **kwargs)
 
     @wraps(spatial.busmap_by_greedy_modularity)
     def busmap_by_greedy_modularity(self, *args: Any, **kwargs: Any) -> pd.Series:
-        return spatial.busmap_by_greedy_modularity(self._parent, *args, **kwargs)
+        return spatial.busmap_by_greedy_modularity(self.n, *args, **kwargs)
 
     @wraps(spatial.hac_clustering)
     def cluster_spatially_by_hac(self, *args: Any, **kwargs: Any) -> "Clustering":
-        return spatial.hac_clustering(self._parent, *args, **kwargs).network
+        return spatial.hac_clustering(self.n, *args, **kwargs).n
 
     @wraps(spatial.kmeans_clustering)
     def cluster_spatially_by_kmeans(self, *args: Any, **kwargs: Any) -> "Clustering":
-        return spatial.kmeans_clustering(self._parent, *args, **kwargs).network
+        return spatial.kmeans_clustering(self.n, *args, **kwargs).n
 
     @wraps(spatial.greedy_modularity_clustering)
     def cluster_spatially_by_greedy_modularity(
         self, *args: Any, **kwargs: Any
     ) -> "Clustering":
-        return spatial.greedy_modularity_clustering(
-            self._parent, *args, **kwargs
-        ).network
+        return spatial.greedy_modularity_clustering(self.n, *args, **kwargs).n
 
     def cluster_by_busmap(self, *args: Any, **kwargs: Any) -> "Clustering":
         """
@@ -60,13 +60,13 @@ class ClusteringAccessor:
 
         Returns
         -------
-        network : pypsa.Network
+        n : pypsa.Network
         """
-        return spatial.get_clustering_from_busmap(self._parent, *args, **kwargs).network
+        return spatial.get_clustering_from_busmap(self.n, *args, **kwargs).n
 
     @wraps(spatial.get_clustering_from_busmap)
     def get_clustering_from_busmap(self, *args: Any, **kwargs: Any) -> "Clustering":
-        return spatial.get_clustering_from_busmap(self._parent, *args, **kwargs)
+        return spatial.get_clustering_from_busmap(self.n, *args, **kwargs)
 
 
 __all__ = ["ClusteringAccessor", "spatial", "temporal"]

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 import networkx as nx
 import numpy as np
 import pandas as pd
+from deprecation import deprecated
 from packaging.version import Version, parse
 from pandas import Series
 
@@ -455,6 +456,15 @@ class Clustering:
     n: Any
     busmap: pd.Series
     linemap: pd.Series
+
+    @property
+    @deprecated(
+        deprecated_in="0.32",
+        removed_in="1.0",
+        details="Use `clustering.n` instead.",
+    )
+    def network(self) -> Network:
+        return self.n
 
 
 def get_clustering_from_busmap(

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -181,7 +181,7 @@ def aggregateoneport(
 
     Parameters
     ----------
-    network : Network
+    n : Network
         The network containing the generators.
     busmap : dict
         A dictionary mapping old bus IDs to new bus IDs.
@@ -447,7 +447,7 @@ def aggregatelines(
 
 @dataclass
 class Clustering:
-    network: Any
+    n: Any
     busmap: pd.Series
     linemap: pd.Series
 
@@ -613,7 +613,7 @@ def busmap_by_kmeans(
     Returns
     -------
     busmap : pandas.Series
-        Mapping of network.buses to k-means clusters (indexed by
+        Mapping of n.buses to k-means clusters (indexed by
         non-negative integers).
     """
     if find_spec("sklearn") is None:
@@ -732,7 +732,7 @@ def busmap_by_hac(
     Returns
     -------
     busmap : pandas.Series
-        Mapping of network.buses to clusters (indexed by
+        Mapping of n.buses to clusters (indexed by
         non-negative integers).
     """
 
@@ -862,7 +862,7 @@ def busmap_by_greedy_modularity(
     Returns
     -------
     busmap : pandas.Series
-        Mapping of network.buses to clusters (indexed by
+        Mapping of n.buses to clusters (indexed by
         non-negative integers).
 
     References
@@ -962,7 +962,7 @@ def busmap_by_stubs(
     Returns
     -------
     busmap : pandas.Series
-        Mapping of network.buses to k-means clusters (indexed by
+        Mapping of n.buses to k-means clusters (indexed by
         non-negative integers).
     """
     busmap = pd.Series(n.buses.index, n.buses.index)

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -490,8 +490,8 @@ def get_clustering_from_busmap(
 
     clustered = Network()
 
-    io._import_components_from_dataframe(clustered, buses, "Bus")
-    io._import_components_from_dataframe(clustered, lines, "Line")
+    io._import_components_from_df(clustered, buses, "Bus")
+    io._import_components_from_df(clustered, lines, "Line")
 
     # Carry forward global constraints to clustered n.
     clustered.global_constraints = n.global_constraints
@@ -506,7 +506,7 @@ def get_clustering_from_busmap(
             )
         for attr, df in lines_t.items():
             if not df.empty:
-                io._import_series_from_dataframe(clustered, df, "Line", attr)
+                io._import_series_from_df(clustered, df, "Line", attr)
 
     one_port_components = n.one_port_components.copy()
 
@@ -522,11 +522,11 @@ def get_clustering_from_busmap(
             with_time=with_time,
             custom_strategies=generator_strategies,
         )
-        io._import_components_from_dataframe(clustered, generators, "Generator")
+        io._import_components_from_df(clustered, generators, "Generator")
         if with_time:
             for attr, df in generators_pnl.items():
                 if not df.empty:
-                    io._import_series_from_dataframe(clustered, df, "Generator", attr)
+                    io._import_series_from_df(clustered, df, "Generator", attr)
 
     for one_port in aggregate_one_ports:
         one_port_components.remove(one_port)
@@ -537,14 +537,14 @@ def get_clustering_from_busmap(
             with_time=with_time,
             custom_strategies=one_port_strategies.get(one_port, {}),
         )
-        io._import_components_from_dataframe(clustered, new_df, one_port)
+        io._import_components_from_df(clustered, new_df, one_port)
         for attr, df in new_pnl.items():
-            io._import_series_from_dataframe(clustered, df, one_port, attr)
+            io._import_series_from_df(clustered, df, one_port, attr)
 
     # Collect remaining one ports
 
     for c in n.iterate_components(one_port_components):
-        io._import_components_from_dataframe(
+        io._import_components_from_df(
             clustered,
             c.static.assign(bus=c.static.bus.map(busmap)).dropna(subset=["bus"]),
             c.name,
@@ -554,7 +554,7 @@ def get_clustering_from_busmap(
         for c in n.iterate_components(one_port_components):
             for attr, df in c.pnl.items():
                 if not df.empty:
-                    io._import_series_from_dataframe(clustered, df, c.name, attr)
+                    io._import_series_from_df(clustered, df, c.name, attr)
 
     new_links = (
         n.links.assign(bus0=n.links.bus0.map(busmap), bus1=n.links.bus1.map(busmap))
@@ -574,14 +574,14 @@ def get_clustering_from_busmap(
     if scale_link_capital_costs:
         new_links["capital_cost"] *= (new_links.length / n.links.length).fillna(1)
 
-    io._import_components_from_dataframe(clustered, new_links, "Link")
+    io._import_components_from_df(clustered, new_links, "Link")
 
     if with_time:
         for attr, df in n.links_t.items():
             if not df.empty:
-                io._import_series_from_dataframe(clustered, df, "Link", attr)
+                io._import_series_from_df(clustered, df, "Link", attr)
 
-    io._import_components_from_dataframe(clustered, n.carriers, "Carrier")
+    io._import_components_from_df(clustered, n.carriers, "Carrier")
 
     clustered.determine_network_topology()
 

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -540,14 +540,14 @@ def get_clustering_from_busmap(
 
     for one_port in aggregate_one_ports:
         one_port_components.remove(one_port)
-        new_df, new_dynamic = aggregateoneport(
+        new_static, new_dynamic = aggregateoneport(
             n,
             busmap,
             component=one_port,
             with_time=with_time,
             custom_strategies=one_port_strategies.get(one_port, {}),
         )
-        io._import_components_from_df(clustered, new_df, one_port)
+        io._import_components_from_df(clustered, new_static, one_port)
         for attr, df in new_dynamic.items():
             io._import_series_from_df(clustered, df, one_port, attr)
 

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -1680,7 +1680,7 @@ class SubNetwork:
             buses = self.buses_i()
             return df[df.bus.isin(buses)]
         else:
-            raise ValueError(f"Component {c_name} not supported for subnetworks")
+            raise ValueError(f"Component {c_name} not supported for sub-networks")
 
     def pnl(self, c_name: str) -> Dict:
         pnl = Dict()
@@ -1765,7 +1765,7 @@ class SubNetwork:
         self, components: Collection[str] | None = None, skip_empty: bool = True
     ) -> Iterator[Component]:
         """
-        Iterate over components of the subnetwork and extract corresponding
+        Iterate over components of the sub-network and extract corresponding
         data.
 
         Parameters

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -53,8 +53,8 @@ from pypsa.descriptors import (
 )
 from pypsa.graph import adjacency_matrix, graph, incidence_matrix
 from pypsa.io import (
-    _import_components_from_dataframe,
-    _import_series_from_dataframe,
+    _import_components_from_df,
+    _import_series_from_df,
     export_to_csv_folder,
     export_to_hdf5,
     export_to_netcdf,
@@ -227,9 +227,9 @@ class Network:
     import_from_pypower_ppc = import_from_pypower_ppc
     import_from_pandapower_net = import_from_pandapower_net
     merge = merge
-    _import_components_from_dataframe = _import_components_from_dataframe
+    _import_components_from_df = _import_components_from_df
     import_components_from_dataframe = import_components_from_dataframe  # Deprecated
-    _import_series_from_dataframe = _import_series_from_dataframe
+    _import_series_from_df = _import_series_from_df
     import_series_from_dataframe = import_series_from_dataframe  # Deprecated
 
     # from pypsa.pf
@@ -369,7 +369,7 @@ class Network:
             self.component_attrs[component] = attrs
             self.components[component]["attrs"] = attrs
 
-        self._build_dataframes()
+        self._build_dfs()
 
         if not ignore_standard_types:
             self.read_in_default_standard_types()
@@ -464,7 +464,7 @@ class Network:
             return False
         return True
 
-    def _build_dataframes(self) -> None:
+    def _build_dfs(self) -> None:
         """
         Function called when network is created to build component
         pandas.DataFrames.
@@ -512,7 +512,7 @@ class Network:
                 file_name, index_col=0
             )
 
-            self._import_components_from_dataframe(
+            self._import_components_from_df(
                 self.components[std_type]["standard_types"], std_type
             )
 
@@ -1048,13 +1048,11 @@ class Network:
             static_df = pd.DataFrame(static, index=names)
         else:
             static_df = pd.DataFrame(index=names)
-        self._import_components_from_dataframe(
-            static_df, class_name, overwrite=overwrite
-        )
+        self._import_components_from_df(static_df, class_name, overwrite=overwrite)
 
         # Load time-varying attributes as components
         for k, v in series.items():
-            self._import_series_from_dataframe(v, class_name, k, overwrite=overwrite)
+            self._import_series_from_df(v, class_name, k, overwrite=overwrite)
 
         return names
 
@@ -1322,7 +1320,7 @@ class Network:
             else:
                 static = component.static
 
-            _import_components_from_dataframe(n, static, component.name)
+            _import_components_from_df(n, static, component.name)
 
         # Copy time-varying data, if given
 
@@ -1403,7 +1401,7 @@ class Network:
             override_components=override_components,
             override_component_attrs=override_component_attrs,
         )
-        n._import_components_from_dataframe(
+        n._import_components_from_df(
             pd.DataFrame(self.buses.loc[key]).assign(sub_network=""), "Bus"
         )
         buses_i = n.buses.index
@@ -1415,21 +1413,21 @@ class Network:
             - self.branch_components
         )
         for c in rest_components - {"Bus", "SubNetwork"}:
-            n._import_components_from_dataframe(pd.DataFrame(self.static(c)), c)
+            n._import_components_from_df(pd.DataFrame(self.static(c)), c)
 
         for c in self.standard_type_components:
             static = self.static(c).drop(self.components[c]["standard_types"].index)
-            n._import_components_from_dataframe(pd.DataFrame(static), c)
+            n._import_components_from_df(pd.DataFrame(static), c)
 
         for c in self.one_port_components:
             static = self.static(c).loc[lambda df: df.bus.isin(buses_i)]
-            n._import_components_from_dataframe(pd.DataFrame(static), c)
+            n._import_components_from_df(pd.DataFrame(static), c)
 
         for c in self.branch_components:
             static = self.static(c).loc[
                 lambda df: df.bus0.isin(buses_i) & df.bus1.isin(buses_i)
             ]
-            n._import_components_from_dataframe(pd.DataFrame(static), c)
+            n._import_components_from_df(pd.DataFrame(static), c)
 
         n.set_snapshots(self.snapshots[time_i])
         for c in self.all_components:

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -561,7 +561,7 @@ class Network:
     # )
     def pnl(self, component_name: str) -> Dict:
         """
-        Alias for :py:meth:`pypsa.Network.static`.
+        Alias for :py:meth:`pypsa.Network.dynamic`.
 
         Parameters
         ----------

--- a/pypsa/consistency.py
+++ b/pypsa/consistency.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
+from pypsa.utils import deprecated_common_kwargs
+
 if TYPE_CHECKING:
     from pypsa.components import Component, Network
 
@@ -22,22 +24,23 @@ def _bus_columns(df: pd.DataFrame) -> pd.Index:
     return df.columns[df.columns.str.startswith("bus")]
 
 
-def check_for_unknown_buses(network: Network, component: Component) -> None:
+@deprecated_common_kwargs
+def check_for_unknown_buses(n: Network, component: Component) -> None:
     """
     Check if buses are attached to component but are not defined in the network.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
 
     """
     for attr in _bus_columns(component.df):
-        missing = ~component.df[attr].isin(network.buses.index)
+        missing = ~component.df[attr].isin(n.buses.index)
         # if bus2, bus3... contain empty strings do not warn
-        if component.name in network.branch_components and int(attr[-1]) > 1:
+        if component.name in n.branch_components and int(attr[-1]) > 1:
             missing &= component.df[attr] != ""
         if missing.any():
             logger.warning(
@@ -47,22 +50,23 @@ def check_for_unknown_buses(network: Network, component: Component) -> None:
             )
 
 
-def check_for_disconnected_buses(network: Network) -> None:
+@deprecated_common_kwargs
+def check_for_disconnected_buses(n: Network) -> None:
     """
     Check if network has buses that are not connected to any component.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
 
     """
     connected_buses = set()
-    for component in network.iterate_components():
+    for component in n.iterate_components():
         for attr in _bus_columns(component.df):
             connected_buses.update(component.df[attr])
 
-    disconnected_buses = set(network.buses.index) - connected_buses
+    disconnected_buses = set(n.buses.index) - connected_buses
     if disconnected_buses:
         logger.warning(
             "The following buses have no attached components, which can break the "
@@ -71,13 +75,14 @@ def check_for_disconnected_buses(network: Network) -> None:
         )
 
 
-def check_for_unknown_carriers(network: Network, component: Component) -> None:
+@deprecated_common_kwargs
+def check_for_unknown_carriers(n: Network, component: Component) -> None:
     """
     Check if carriers are attached to component but are not defined in the network.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
@@ -85,7 +90,7 @@ def check_for_unknown_carriers(network: Network, component: Component) -> None:
     """
     if "carrier" in component.df.columns:
         missing = (
-            ~component.df["carrier"].isin(network.carriers.index)
+            ~component.df["carrier"].isin(n.carriers.index)
             & component.df["carrier"].notna()
             & (component.df["carrier"] != "")
         )
@@ -97,19 +102,20 @@ def check_for_unknown_carriers(network: Network, component: Component) -> None:
             )
 
 
-def check_for_zero_impedances(network: Network, component: Component) -> None:
+@deprecated_common_kwargs
+def check_for_zero_impedances(n: Network, component: Component) -> None:
     """
     Check if component has zero impedances. Only checks passive branch components.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
 
     """
-    if component.name in network.passive_branch_components:
+    if component.name in n.passive_branch_components:
         for attr in ["x", "r"]:
             bad = component.df[attr] == 0
             if bad.any():
@@ -122,6 +128,7 @@ def check_for_zero_impedances(network: Network, component: Component) -> None:
                 )
 
 
+@deprecated_common_kwargs
 def check_for_zero_s_nom(component: Component) -> None:
     """
     Check if component has zero s_nom. Only checks transformers.
@@ -144,13 +151,14 @@ def check_for_zero_s_nom(component: Component) -> None:
             )
 
 
-def check_time_series(network: Network, component: Component) -> None:
+@deprecated_common_kwargs
+def check_time_series(n: Network, component: Component) -> None:
     """
     Check if time series of component are aligned with network snapshots.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
@@ -163,8 +171,8 @@ def check_time_series(network: Network, component: Component) -> None:
         if len(diff):
             logger.warning(
                 "The following %s have time series defined "
-                "for attribute %s in network.%s_t, but are "
-                "not defined in network.%s:\n%s",
+                "for attribute %s in n.%s_t, but are "
+                "not defined in n.%s:\n%s",
                 component.list_name,
                 attr,
                 component.list_name,
@@ -172,29 +180,30 @@ def check_time_series(network: Network, component: Component) -> None:
                 diff,
             )
 
-        if not network.snapshots.equals(attr_df.index):
+        if not n.snapshots.equals(attr_df.index):
             logger.warning(
                 "The index of the time-dependent Dataframe for attribute "
-                "%s of network.%s_t is not aligned with network snapshots",
+                "%s of n.%s_t is not aligned with network snapshots",
                 attr,
                 component.list_name,
             )
 
 
-def check_static_power_attributes(network: Network, component: Component) -> None:
+@deprecated_common_kwargs
+def check_static_power_attributes(n: Network, component: Component) -> None:
     """
     Check static attrs p_now, s_nom, e_nom in any component.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
 
     """
     static_attrs = ["p_nom", "s_nom", "e_nom"]
-    if component.name in network.all_components - {"TransformerType"}:
+    if component.name in n.all_components - {"TransformerType"}:
         static_attr = component.attrs.query("static").index.intersection(static_attrs)
         if len(static_attr):
             attr = static_attr[0]
@@ -218,28 +227,29 @@ def check_static_power_attributes(network: Network, component: Component) -> Non
                     )
 
 
-def check_time_series_power_attributes(network: Network, component: Component) -> None:
+@deprecated_common_kwargs
+def check_time_series_power_attributes(n: Network, component: Component) -> None:
     """
     Check `p_max_pu` and `e_max_pu` nan and infinite values in time series.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
 
     """
     varying_attrs = ["p_max_pu", "e_max_pu"]
-    if component.name in network.all_components - {"TransformerType"}:
+    if component.name in n.all_components - {"TransformerType"}:
         varying_attr = component.attrs.query("varying").index.intersection(
             varying_attrs
         )
 
         if len(varying_attr):
             attr = varying_attr[0][0]
-            max_pu = network.get_switchable_as_dense(component.name, attr + "_max_pu")
-            min_pu = network.get_switchable_as_dense(component.name, attr + "_min_pu")
+            max_pu = n.get_switchable_as_dense(component.name, attr + "_max_pu")
+            min_pu = n.get_switchable_as_dense(component.name, attr + "_min_pu")
 
             # check for NaN values:
             if max_pu.isna().to_numpy().any():
@@ -298,21 +308,22 @@ def check_time_series_power_attributes(network: Network, component: Component) -
                 )
 
 
-def check_assets(network: Network, component: Component) -> None:
+@deprecated_common_kwargs
+def check_assets(n: Network, component: Component) -> None:
     """
     Check if assets are only committable or extendable, but not both.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
 
     """
     if component.name in {"Generator", "Link"}:
-        committables = network.get_committable_i(component.name)
-        extendables = network.get_extendable_i(component.name)
+        committables = n.get_committable_i(component.name)
+        extendables = n.get_extendable_i(component.name)
         intersection = committables.intersection(extendables)
         if not intersection.empty:
             logger.warning(
@@ -321,7 +332,7 @@ def check_assets(network: Network, component: Component) -> None:
                 f"\n\n\t{', '.join(intersection)}"
             )
 
-
+@deprecated_common_kwargs
 def check_generators(component: Component) -> None:
     """Check static attrs p_now, s_nom, e_nom in generator components."""
     if component.name in {"Generator"}:
@@ -338,13 +349,14 @@ def check_generators(component: Component) -> None:
             )
 
 
+@deprecated_common_kwargs
 def check_dtypes_(component: Component) -> None:
     """
     Check if the dtypes of the attributes in the component are as expected.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
@@ -386,22 +398,20 @@ def check_dtypes_(component: Component) -> None:
                 typ,
             )
 
-
-def check_investment_periods(network: Network) -> None:
+@deprecated_common_kwargs
+def check_investment_periods(n: Network) -> None:
     """
     Check if investment periods are aligned with snapshots.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
 
     """
-    constraint_periods = set(
-        network.global_constraints.investment_period.dropna().unique()
-    )
-    if isinstance(network.snapshots, pd.MultiIndex):
-        if not constraint_periods.issubset(network.snapshots.unique("period")):
+    constraint_periods = set(n.global_constraints.investment_period.dropna().unique())
+    if isinstance(n.snapshots, pd.MultiIndex):
+        if not constraint_periods.issubset(n.snapshots.unique("period")):
             msg = (
                 "The global constraints contain investment periods which "
                 "are not in the set of optimized snapshots."
@@ -415,23 +425,23 @@ def check_investment_periods(network: Network) -> None:
             )
             raise ValueError(msg)
 
-
-def check_shapes(network: Network) -> None:
+@deprecated_common_kwargs
+def check_shapes(n: Network) -> None:
     """
     Check if shapes are aligned with related components.
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
 
     """
-    shape_components = network.shapes.component.unique()
-    for c in set(shape_components) & set(network.all_components):
-        geos = network.shapes.query("component == @c")
-        not_included = geos.index[~geos.idx.isin(network.df(c).index)]
+    shape_components = n.shapes.component.unique()
+    for c in set(shape_components) & set(n.all_components):
+        geos = n.shapes.query("component == @c")
+        not_included = geos.index[~geos.idx.isin(n.df(c).index)]
 
         if not not_included.empty:
             logger.warning(
@@ -440,10 +450,8 @@ def check_shapes(network: Network) -> None:
                 f"{not_included}"
             )
 
-
-def check_nans_for_component_default_attrs(
-    network: Network, component: Component
-) -> None:
+@deprecated_common_kwargs
+def check_nans_for_component_default_attrs(n: Network, component: Component) -> None:
     """
     Check for missing values in component attributes.
 
@@ -452,15 +460,15 @@ def check_nans_for_component_default_attrs(
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         The network to check.
     component : pypsa.Component
         The component to check.
 
     """
     # Get non-NA and not-empty default attributes for the current component
-    default = network.component_attrs[component.name]["default"]
-    not_null_component_attrs = network.component_attrs[component.name][
+    default = n.component_attrs[component.name]["default"]
+    not_null_component_attrs = n.component_attrs[component.name][
         default.notna() & default.ne("")
     ].index
 

--- a/pypsa/consistency.py
+++ b/pypsa/consistency.py
@@ -165,7 +165,7 @@ def check_time_series(n: Network, component: Component) -> None:
 
     """
     for attr in component.attrs.index[component.attrs.varying & component.attrs.static]:
-        attr_df = component.pnl[attr]
+        attr_df = component.dynamic[attr]
 
         diff = attr_df.columns.difference(component.static.index)
         if len(diff):
@@ -386,10 +386,10 @@ def check_dtypes_(component: Component) -> None:
     types_soll = component.attrs.loc[component.attrs["varying"], ["typ", "dtype"]]
 
     for attr, typ, dtype in types_soll.itertuples():
-        if component.pnl[attr].empty:
+        if component.dynamic[attr].empty:
             continue
 
-        unmatched = component.pnl[attr].dtypes != dtype
+        unmatched = component.dynamic[attr].dtypes != dtype
 
         if unmatched.any():
             logger.warning(
@@ -399,7 +399,7 @@ def check_dtypes_(component: Component) -> None:
                 attr,
                 component.list_name,
                 unmatched.index[unmatched],
-                component.pnl[attr].dtypes[unmatched],
+                component.dynamic[attr].dtypes[unmatched],
                 typ,
             )
 
@@ -498,7 +498,7 @@ def check_nans_for_component_default_attrs(n: Network, component: Component) -> 
     # there is any)
     relevant_series_dfs = {
         key: value
-        for key, value in component.pnl.items()
+        for key, value in component.dynamic.items()
         if key in not_null_component_attrs and not value.empty
     }
 

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -115,7 +115,7 @@ def network_lpf_contingency(
         branch_outages = passive_branches.index
 
     p0_base = pd.concat(
-        {c: n.pnl(c).p0.loc[snapshot] for c in n.passive_branch_components}
+        {c: n.dynamic(c).p0.loc[snapshot] for c in n.passive_branch_components}
     )
     p0 = p0_base.to_frame("base")
 

--- a/pypsa/contingency.py
+++ b/pypsa/contingency.py
@@ -119,20 +119,20 @@ def network_lpf_contingency(
     )
     p0 = p0_base.to_frame("base")
 
-    for sn in n.sub_networks.obj:
-        sn._branches = sn.branches()
-        sn.calculate_BODF()
+    for sub_network in n.sub_networks.obj:
+        sub_network._branches = sub_network.branches()
+        sub_network.calculate_BODF()
 
     for branch in branch_outages:
         if not isinstance(branch, tuple):
             logger.warning(f"No type given for {branch}, assuming it is a line")
             branch = ("Line", branch)
 
-        sn = n.sub_networks.obj[passive_branches.sub_network[branch]]
+        sub_network = n.sub_networks.obj[passive_branches.sub_network[branch]]
 
-        branch_i = sn._branches.index.get_loc(branch)
+        branch_i = sub_network._branches.index.get_loc(branch)
         p0_new = p0_base + pd.Series(
-            sn.BODF[:, branch_i] * p0_base[branch], sn._branches.index
+            sub_network.BODF[:, branch_i] * p0_base[branch], sub_network._branches.index
         )
         p0_new.name = branch
 

--- a/pypsa/definitions/components.py
+++ b/pypsa/definitions/components.py
@@ -57,6 +57,24 @@ class Component:
             f"dynamic=Keys({list(self.dynamic.keys())}))"
         )
 
+    # @deprecated(
+    #     deprecated_in="0.32",
+    #     removed_in="1.0",
+    #     details="Use `c.static` instead.",
+    # )
+    @property
+    def df(self) -> pd.DataFrame:
+        return self.static
+
+    # @deprecated(
+    #     deprecated_in="0.32",
+    #     removed_in="1.0",
+    #     details="Use `c.dynamic` instead.",
+    # )
+    @property
+    def pnl(self) -> Dict:
+        return self.dynamic
+
     def get_active_assets(
         self,
         investment_period: int | str | Sequence | None = None,

--- a/pypsa/definitions/components.py
+++ b/pypsa/definitions/components.py
@@ -29,7 +29,7 @@ class Component:
         A dictionary of attributes and their metadata.
     static : pd.DataFrame
         A DataFrame containing data for each component instance.
-    pnl : Dict[str, pd.DataFrame]
+    dynamic : Dict[str, pd.DataFrame]
         A dictionary of time series data (panel data) for the component.
     ind : pd.Index
         An index of component identifiers.
@@ -40,7 +40,7 @@ class Component:
     attrs: pd.DataFrame
     investment_periods: pd.Index  # TODO: Needs better general approach
     static: pd.DataFrame
-    pnl: Dict
+    dynamic: Dict
     ind: None  # deprecated
 
     # raise a deprecation warning if ind attribute is not None
@@ -54,7 +54,7 @@ class Component:
         return (
             f"Component(name={self.name!r}, list_name={self.list_name!r}, "
             f"attrs=Keys({list(self.attrs.keys())}), static=DataFrame(shape={self.static.shape}), "
-            f"pnl=Keys({list(self.pnl.keys())}))"
+            f"dynamic=Keys({list(self.dynamic.keys())}))"
         )
 
     def get_active_assets(

--- a/pypsa/definitions/components.py
+++ b/pypsa/definitions/components.py
@@ -27,7 +27,7 @@ class Component:
         The plural name used for lists of components (e.g., 'generators').
     attrs : Dict[str, Any]
         A dictionary of attributes and their metadata.
-    df : pd.DataFrame
+    static : pd.DataFrame
         A DataFrame containing data for each component instance.
     pnl : Dict[str, pd.DataFrame]
         A dictionary of time series data (panel data) for the component.
@@ -39,7 +39,7 @@ class Component:
     list_name: str
     attrs: pd.DataFrame
     investment_periods: pd.Index  # TODO: Needs better general approach
-    df: pd.DataFrame
+    static: pd.DataFrame
     pnl: Dict
     ind: None  # deprecated
 
@@ -53,7 +53,7 @@ class Component:
     def __repr__(self) -> str:
         return (
             f"Component(name={self.name!r}, list_name={self.list_name!r}, "
-            f"attrs=Keys({list(self.attrs.keys())}), df=DataFrame(shape={self.df.shape}), "
+            f"attrs=Keys({list(self.attrs.keys())}), static=DataFrame(shape={self.static.shape}), "
             f"pnl=Keys({list(self.pnl.keys())}))"
         )
 
@@ -86,9 +86,9 @@ class Component:
             Boolean mask for active components
         """
         if investment_period is None:
-            return self.df.active
-        if not {"build_year", "lifetime"}.issubset(self.df):
-            return self.df.active
+            return self.static.active
+        if not {"build_year", "lifetime"}.issubset(self.static):
+            return self.static.active
 
         # Logical OR of active assets in all investment periods and
         # logical AND with active attribute
@@ -96,7 +96,7 @@ class Component:
         for period in np.atleast_1d(investment_period):
             if period not in self.investment_periods:
                 raise ValueError("Investment period not in `n.investment_periods`")
-            active[period] = self.df.eval(
+            active[period] = self.static.eval(
                 "build_year <= @period < build_year + lifetime"
             )
-        return pd.DataFrame(active).any(axis=1) & self.df.active
+        return pd.DataFrame(active).any(axis=1) & self.static.active

--- a/pypsa/definitions/components.py
+++ b/pypsa/definitions/components.py
@@ -95,9 +95,7 @@ class Component:
         active = {}
         for period in np.atleast_1d(investment_period):
             if period not in self.investment_periods:
-                raise ValueError(
-                    "Investment period not in `network.investment_periods`"
-                )
+                raise ValueError("Investment period not in `n.investment_periods`")
             active[period] = self.df.eval(
                 "build_year <= @period < build_year + lifetime"
             )

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -27,6 +27,7 @@ class OrderedGraph(nx.MultiGraph):
     adjlist_dict_factory = OrderedDict
 
 
+@deprecated_common_kwargs
 def get_switchable_as_dense(
     n: Network,
     component: str,
@@ -467,7 +468,6 @@ def update_linkports_component_attrs(
             n.static(c)[target] = n.components[c]["attrs"].loc[target, "default"]
 
 
-@deprecated_common_kwargs
 def additional_linkports(n: Network, where: Iterable[str] | None = None) -> list[str]:
     """
     Identify additional link ports (bus connections) beyond predefined ones.

--- a/pypsa/examples.py
+++ b/pypsa/examples.py
@@ -140,8 +140,8 @@ def scigrid_de(update: bool = False, from_master: bool = False) -> Network:
         {
             carrier
             for c in n.iterate_components()
-            if "carrier" in c.df
-            for carrier in c.df.carrier.unique()
+            if "carrier" in c.static
+            for carrier in c.static.carrier.unique()
         }
     )
     n.add("Carrier", carriers)

--- a/pypsa/graph.py
+++ b/pypsa/graph.py
@@ -74,8 +74,8 @@ def graph(
     # Multigraph uses the branch type and name as key
     def gen_edges() -> Iterable[tuple[str, str, tuple[str, int], dict]]:
         for c in n.iterate_components(branch_components):
-            for branch in c.df.loc[
-                slice(None) if include_inactive else c.df.query("active").index
+            for branch in c.static.loc[
+                slice(None) if include_inactive else c.static.query("active").index
             ].itertuples():
                 if weight is None:
                     data = {}
@@ -144,11 +144,11 @@ def adjacency_matrix(
     weight_vals = []
     for c in n.iterate_components(branch_components):
         active = c.get_active_assets(investment_period)
-        sel = c.df[active].index
+        sel = c.static[active].index
 
-        no_branches = len(c.df.loc[sel])
-        bus0_inds.append(busorder.get_indexer(c.df.loc[sel, "bus0"]))
-        bus1_inds.append(busorder.get_indexer(c.df.loc[sel, "bus1"]))
+        no_branches = len(c.static.loc[sel])
+        bus0_inds.append(busorder.get_indexer(c.static.loc[sel, "bus0"]))
+        bus1_inds.append(busorder.get_indexer(c.static.loc[sel, "bus1"]))
         weight_vals.append(
             np.ones(no_branches) if weights is None else weights[c.name][sel].values
         )
@@ -210,10 +210,10 @@ def incidence_matrix(
     bus0_inds = []
     bus1_inds = []
     for c in n.iterate_components(branch_components):
-        sel = c.df.query("active").index
-        no_branches += len(c.df.loc[sel])
-        bus0_inds.append(busorder.get_indexer(c.df.loc[sel, "bus0"]))
-        bus1_inds.append(busorder.get_indexer(c.df.loc[sel, "bus1"]))
+        sel = c.static.query("active").index
+        no_branches += len(c.static.loc[sel])
+        bus0_inds.append(busorder.get_indexer(c.static.loc[sel, "bus0"]))
+        bus1_inds.append(busorder.get_indexer(c.static.loc[sel, "bus1"]))
     bus0_inds = np.concatenate(bus0_inds)
     bus1_inds = np.concatenate(bus1_inds)
 

--- a/pypsa/graph.py
+++ b/pypsa/graph.py
@@ -12,13 +12,15 @@ import pandas as pd
 import scipy as sp
 
 from pypsa.descriptors import OrderedGraph
+from pypsa.utils import deprecated_common_kwargs
 
 if TYPE_CHECKING:
     from pypsa import Network, SubNetwork
 
 
+@deprecated_common_kwargs
 def graph(
-    network: Network | SubNetwork,
+    n: Network | SubNetwork,
     branch_components: Collection[str] | None = None,
     weight: str | None = None,
     inf_weight: bool | float = False,
@@ -29,7 +31,7 @@ def graph(
 
     Parameters
     ----------
-    network : Network|SubNetwork
+    n : Network|SubNetwork
 
     branch_components : [str]
         Components to use as branches. The default are
@@ -51,16 +53,16 @@ def graph(
     """
     from pypsa import components
 
-    if isinstance(network, components.Network):
+    if isinstance(n, components.Network):
         if branch_components is None:
-            branch_components = network.branch_components
+            branch_components = n.branch_components
         else:
             branch_components = set(branch_components)
-        buses_i = network.buses.index
-    elif isinstance(network, components.SubNetwork):
+        buses_i = n.buses.index
+    elif isinstance(n, components.SubNetwork):
         if branch_components is None:
-            branch_components = network.network.passive_branch_components
-        buses_i = network.buses_i()
+            branch_components = n.n.passive_branch_components
+        buses_i = n.buses_i()
     else:
         raise TypeError("graph must be called with a Network or a SubNetwork")
 
@@ -71,7 +73,7 @@ def graph(
 
     # Multigraph uses the branch type and name as key
     def gen_edges() -> Iterable[tuple[str, str, tuple[str, int], dict]]:
-        for c in network.iterate_components(branch_components):
+        for c in n.iterate_components(branch_components):
             for branch in c.df.loc[
                 slice(None) if include_inactive else c.df.query("active").index
             ].itertuples():
@@ -91,8 +93,9 @@ def graph(
     return graph
 
 
+@deprecated_common_kwargs
 def adjacency_matrix(
-    network: Network | SubNetwork,
+    n: Network | SubNetwork,
     branch_components: Collection[str] | None = None,
     investment_period: int | str | None = None,
     busorder: pd.Index | None = None,
@@ -106,7 +109,7 @@ def adjacency_matrix(
     branch_components : iterable sublist of `branch_components`
        Buses connected by any of the selected branches are adjacent
        (default: branch_components (network) or passive_branch_components (sub_network))
-    busorder : pd.Index subset of network.buses.index
+    busorder : pd.Index subset of n.buses.index
        Basis to use for the matrix representation of the adjacency matrix
        (default: buses.index (network) or buses_i() (sub_network))
     weights : pd.Series or None (default)
@@ -121,16 +124,16 @@ def adjacency_matrix(
 
     from pypsa import components
 
-    if isinstance(network, components.Network):
+    if isinstance(n, components.Network):
         if branch_components is None:
-            branch_components = network.branch_components
+            branch_components = n.branch_components
         if busorder is None:
-            busorder = network.buses.index
-    elif isinstance(network, components.SubNetwork):
+            busorder = n.buses.index
+    elif isinstance(n, components.SubNetwork):
         if branch_components is None:
-            branch_components = network.network.passive_branch_components
+            branch_components = n.n.passive_branch_components
         if busorder is None:
-            busorder = network.buses_i()
+            busorder = n.buses_i()
     else:
         raise TypeError(" must be called with a Network or a SubNetwork")
 
@@ -139,7 +142,7 @@ def adjacency_matrix(
     bus0_inds = []
     bus1_inds = []
     weight_vals = []
-    for c in network.iterate_components(branch_components):
+    for c in n.iterate_components(branch_components):
         active = c.get_active_assets(investment_period)
         sel = c.df[active].index
 
@@ -162,8 +165,9 @@ def adjacency_matrix(
     )
 
 
+@deprecated_common_kwargs
 def incidence_matrix(
-    network: Network | SubNetwork,
+    n: Network | SubNetwork,
     branch_components: Collection[str] | None = None,
     busorder: pd.Index | None = None,
 ) -> sp.sparse.csr_matrix:
@@ -175,7 +179,7 @@ def incidence_matrix(
     branch_components : iterable sublist of `branch_components`
        Buses connected by any of the selected branches are adjacent
        (default: branch_components (network) or passive_branch_components (sub_network))
-    busorder : pd.Index subset of network.buses.index
+    busorder : pd.Index subset of n.buses.index
        Basis to use for the matrix representation of the adjacency matrix
        (default: buses.index (network) or buses_i() (sub_network))
 
@@ -186,26 +190,26 @@ def incidence_matrix(
     """
     from pypsa import components
 
-    if isinstance(network, components.Network):
+    if isinstance(n, components.Network):
         if branch_components is None:
-            branch_components = network.branch_components
+            branch_components = n.branch_components
         if busorder is None:
-            busorder = network.buses.index
-    elif isinstance(network, components.SubNetwork):
+            busorder = n.buses.index
+    elif isinstance(n, components.SubNetwork):
         if branch_components is None:
-            branch_components = network.network.passive_branch_components
+            branch_components = n.n.passive_branch_components
         if busorder is None:
-            busorder = network.buses_i()
+            busorder = n.buses_i()
     else:
         raise ValueError(
-            "The 'network' parameter must be an instance of 'Network' or 'SubNetwork'."
+            "The 'n' parameter must be an instance of 'Network' or 'SubNetwork'."
         )
 
     no_buses = len(busorder)
     no_branches = 0
     bus0_inds = []
     bus1_inds = []
-    for c in network.iterate_components(branch_components):
+    for c in n.iterate_components(branch_components):
         sel = c.df.query("active").index
         no_branches += len(c.df.loc[sel])
         bus0_inds.append(busorder.get_indexer(c.df.loc[sel, "bus0"]))

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -14,6 +14,8 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.request import urlretrieve
 
+from pypsa.utils import deprecated_common_kwargs
+
 try:
     from cloudpathlib import AnyPath as Path
 except ImportError:
@@ -479,6 +481,7 @@ class ExporterNetCDF(Exporter):
                 self.ds.to_netcdf(_path)
 
 
+@deprecated_common_kwargs
 def _export_to_exporter(
     n: Network,
     exporter: Exporter,
@@ -602,6 +605,7 @@ def _export_to_exporter(
     )
 
 
+@deprecated_common_kwargs
 def import_from_csv_folder(
     n: Network,
     csv_folder_name: str | Path,
@@ -633,6 +637,7 @@ def import_from_csv_folder(
         _import_from_importer(n, importer, basename=basename, skip_time=skip_time)
 
 
+@deprecated_common_kwargs
 def export_to_csv_folder(
     n: Network,
     csv_folder_name: str,
@@ -682,6 +687,7 @@ def export_to_csv_folder(
         )
 
 
+@deprecated_common_kwargs
 def import_from_hdf5(n: Network, path: str | Path, skip_time: bool = False) -> None:
     """
     Import network data from HDF5 store at `path`.
@@ -699,6 +705,7 @@ def import_from_hdf5(n: Network, path: str | Path, skip_time: bool = False) -> N
         _import_from_importer(n, importer, basename=basename, skip_time=skip_time)
 
 
+@deprecated_common_kwargs
 def export_to_hdf5(
     n: Network,
     path: Path | str,
@@ -742,6 +749,7 @@ def export_to_hdf5(
         )
 
 
+@deprecated_common_kwargs
 def import_from_netcdf(
     n: Network, path: str | Path | xr.Dataset, skip_time: bool = False
 ) -> None:
@@ -763,6 +771,7 @@ def import_from_netcdf(
         _import_from_importer(n, importer, basename=basename, skip_time=skip_time)
 
 
+@deprecated_common_kwargs
 def export_to_netcdf(
     n: Network,
     path: str | None = None,
@@ -820,6 +829,7 @@ def export_to_netcdf(
         return exporter.ds
 
 
+@deprecated_common_kwargs
 def _import_from_importer(
     n: Network, importer: Any, basename: str, skip_time: bool = False
 ) -> None:
@@ -1243,6 +1253,7 @@ def _import_series_from_df(
     dynamic[attr].loc[n.snapshots, df.columns] = df.loc[n.snapshots, df.columns]
 
 
+@deprecated_common_kwargs
 def merge(
     n: Network,
     other: Network,
@@ -1313,6 +1324,7 @@ def merge(
     return None if inplace else new
 
 
+@deprecated_common_kwargs
 def import_from_pypower_ppc(
     n: Network, ppc: dict, overwrite_zero_s_nom: float | None = None
 ) -> None:
@@ -1522,6 +1534,7 @@ def import_from_pypower_ppc(
     n.buses.loc[n.generators.bus, "v_mag_pu_set"] = np.asarray(n.generators["v_set_pu"])
 
 
+@deprecated_common_kwargs
 def import_from_pandapower_net(
     n: Network,
     net: pandapowerNet,

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -695,9 +695,9 @@ def optimize_and_run_non_linear_powerflow(
         return dict(status=status, terminantion_condition=condition)
 
     for c in n.one_port_components:
-        n.pnl(c)["p_set"] = n.pnl(c)["p"]
+        n.dynamic(c)["p_set"] = n.dynamic(c)["p"]
     for c in {"Link"}:
-        n.pnl(c)["p_set"] = n.pnl(c)["p0"]
+        n.dynamic(c)["p_set"] = n.dynamic(c)["p0"]
 
     n.generators.control = "PV"
     for sub_network in n.sub_networks.obj:

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -196,7 +196,7 @@ def optimize_transmission_expansion_iteratively(
 
     def save_optimal_capacities(n: Network, iteration: int, status: str) -> None:
         for c, attr in pd.Series(nominal_attrs)[list(n.branch_components)].items():
-            n.df(c)[f"{attr}_opt_{iteration}"] = n.df(c)[f"{attr}_opt"]
+            n.static(c)[f"{attr}_opt_{iteration}"] = n.static(c)[f"{attr}_opt"]
         setattr(n, f"status_{iteration}", status)
         setattr(n, f"objective_{iteration}", n.objective)
         n.iteration = iteration
@@ -253,7 +253,7 @@ def optimize_transmission_expansion_iteratively(
 
     if track_iterations:
         for c, attr in pd.Series(nominal_attrs)[list(n.branch_components)].items():
-            n.df(c)[f"{attr}_opt_0"] = n.df(c)[f"{attr}"]
+            n.static(c)[f"{attr}_opt_0"] = n.static(c)[f"{attr}"]
 
     iteration = 1
     diff = msq_threshold
@@ -403,7 +403,9 @@ def optimize_security_constrained(
             continue
 
         sub_network.calculate_BODF()
-        BODF = pd.DataFrame(sub_network.BODF, index=branches_i, columns=branches_i)[outages]
+        BODF = pd.DataFrame(sub_network.BODF, index=branches_i, columns=branches_i)[
+            outages
+        ]
 
         for c_outage, c_affected in product(outages.unique(0), branches_i.unique(0)):
             c_outage_ = c_outage + "-outage"
@@ -611,9 +613,9 @@ def optimize_mga(
                 coeffs = coeffs.reindex(n.get_extendable_i(c))
                 coeffs.index.name = ""
             elif isinstance(coeffs, pd.Series):
-                coeffs = coeffs.reindex(columns=n.df(c).index)
+                coeffs = coeffs.reindex(columns=n.static(c).index)
             elif isinstance(coeffs, pd.DataFrame):
-                coeffs = coeffs.reindex(columns=n.df(c).index, index=snapshots)
+                coeffs = coeffs.reindex(columns=n.static(c).index, index=snapshots)
             objective.append(m[f"{c}-{attr}"] * coeffs * sense)
 
     m.objective = merge(objective)

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -130,7 +130,7 @@ def optimize_transmission_expansion_iteratively(
     ----------
     snapshots : list or index slice
         A list of snapshots to optimise, must be a subset of
-        network.snapshots, defaults to network.snapshots
+        n.snapshots, defaults to n.snapshots
     msq_threshold: float, default 0.05
         Maximal mean square difference between optimized line capacity of
         the current and the previous iteration. As soon as this threshold is

--- a/pypsa/optimization/common.py
+++ b/pypsa/optimization/common.py
@@ -39,12 +39,12 @@ def set_from_frame(n: Network, c: str, attr: str, df: pd.DataFrame) -> None:
     """
     Update values in time-dependent attribute from new dataframe.
     """
-    pnl = n.pnl(c)
-    if (attr not in pnl) or (pnl[attr].empty):
-        pnl[attr] = df.reindex(n.snapshots).fillna(0.0)
+    dynamic = n.dynamic(c)
+    if (attr not in dynamic) or (dynamic[attr].empty):
+        dynamic[attr] = df.reindex(n.snapshots).fillna(0.0)
     else:
-        pnl[attr].loc[df.index, df.columns] = df
-        pnl[attr] = pnl[attr].fillna(0.0)
+        dynamic[attr].loc[df.index, df.columns] = df
+        dynamic[attr] = dynamic[attr].fillna(0.0)
 
 
 def get_strongly_meshed_buses(n: Network, threshold: int = 45) -> pd.Series:

--- a/pypsa/optimization/common.py
+++ b/pypsa/optimization/common.py
@@ -62,7 +62,7 @@ def get_strongly_meshed_buses(n: Network, threshold: int = 45) -> pd.Series:
     pandas series of all meshed buses.
     """
     all_buses = pd.Series(
-        hstack([ravel(c.df.filter(like="bus")) for c in n.iterate_components()])
+        hstack([ravel(c.static.filter(like="bus")) for c in n.iterate_components()])
     )
     all_buses = all_buses[all_buses != ""]
     counts = all_buses.value_counts()

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -60,7 +60,7 @@ def define_operational_constraints_for_non_extendables(
     if fix_i.empty:
         return
 
-    nominal_fix = n.df(c)[nominal_attrs[c]].reindex(fix_i)
+    nominal_fix = n.static(c)[nominal_attrs[c]].reindex(fix_i)
     min_pu, max_pu = get_bounds_pu(n, c, sns, fix_i, attr)
     lower = min_pu.mul(nominal_fix)
     upper = max_pu.mul(nominal_fix)
@@ -158,18 +158,18 @@ def define_operational_constraints_for_committables(
     active = get_activity_mask(n, c, sns, com_i)
 
     # parameters
-    nominal = DataArray(n.df(c)[nominal_attrs[c]].reindex(com_i))
+    nominal = DataArray(n.static(c)[nominal_attrs[c]].reindex(com_i))
     min_pu, max_pu = map(DataArray, get_bounds_pu(n, c, sns, com_i, "p"))
     lower_p = min_pu * nominal
     upper_p = max_pu * nominal
-    min_up_time_set = n.df(c).min_up_time[com_i]
-    min_down_time_set = n.df(c).min_down_time[com_i]
-    ramp_up_limit = nominal * n.df(c).ramp_limit_up[com_i].fillna(1)
-    ramp_down_limit = nominal * n.df(c).ramp_limit_down[com_i].fillna(1)
-    ramp_start_up = nominal * n.df(c).ramp_limit_start_up[com_i]
-    ramp_shut_down = nominal * n.df(c).ramp_limit_shut_down[com_i]
-    up_time_before_set = n.df(c)["up_time_before"].reindex(com_i)
-    down_time_before_set = n.df(c)["down_time_before"].reindex(com_i)
+    min_up_time_set = n.static(c).min_up_time[com_i]
+    min_down_time_set = n.static(c).min_down_time[com_i]
+    ramp_up_limit = nominal * n.static(c).ramp_limit_up[com_i].fillna(1)
+    ramp_down_limit = nominal * n.static(c).ramp_limit_down[com_i].fillna(1)
+    ramp_start_up = nominal * n.static(c).ramp_limit_start_up[com_i]
+    ramp_shut_down = nominal * n.static(c).ramp_limit_shut_down[com_i]
+    up_time_before_set = n.static(c)["up_time_before"].reindex(com_i)
+    down_time_before_set = n.static(c)["down_time_before"].reindex(com_i)
     initially_up = up_time_before_set.astype(bool)
     initially_down = down_time_before_set.astype(bool)
 
@@ -260,7 +260,8 @@ def define_operational_constraints_for_committables(
 
     # linearized approximation because committable can partly start up and shut down
     cost_equal = all(
-        n.df(c).loc[com_i, "start_up_cost"] == n.df(c).loc[com_i, "shut_down_cost"]
+        n.static(c).loc[com_i, "start_up_cost"]
+        == n.static(c).loc[com_i, "shut_down_cost"]
     )
     # only valid additional constraints if start up costs equal to shut down costs
     if n._linearized_uc and not cost_equal:
@@ -334,8 +335,8 @@ def define_nominal_constraints_for_extendables(n: Network, c: str, attr: str) ->
         return
 
     capacity = n.model[f"{c}-{attr}"]
-    lower = n.df(c)[attr + "_min"].reindex(ext_i)
-    upper = n.df(c)[attr + "_max"].reindex(ext_i)
+    lower = n.static(c)[attr + "_min"].reindex(ext_i)
+    upper = n.static(c)[attr + "_max"].reindex(ext_i)
     mask = upper != inf
     n.model.add_constraints(capacity, ">=", lower, name=f"{c}-ext-{attr}-lower")
     n.model.add_constraints(
@@ -355,7 +356,7 @@ def define_ramp_limit_constraints(n: Network, sns: pd.Index, c: str, attr: str) 
     """
     m = n.model
 
-    if {"ramp_limit_up", "ramp_limit_down"}.isdisjoint(n.df(c)):
+    if {"ramp_limit_up", "ramp_limit_down"}.isdisjoint(n.static(c)):
         return
 
     ramp_limit_up = get_as_dense(n, c, "ramp_limit_up", sns)
@@ -378,7 +379,7 @@ def define_ramp_limit_constraints(n: Network, sns: pd.Index, c: str, attr: str) 
 
     if is_rolling_horizon:
         active = get_activity_mask(n, c, sns)
-        rhs_start = pd.DataFrame(0.0, index=sns, columns=n.df(c).index)
+        rhs_start = pd.DataFrame(0.0, index=sns, columns=n.static(c).index)
         rhs_start.loc[sns[0]] = p_start
 
         def p_actual(idx: pd.Index) -> DataArray:
@@ -389,7 +390,7 @@ def define_ramp_limit_constraints(n: Network, sns: pd.Index, c: str, attr: str) 
 
     else:
         active = get_activity_mask(n, c, sns[1:])
-        rhs_start = pd.DataFrame(0, index=sns[1:], columns=n.df(c).index)
+        rhs_start = pd.DataFrame(0, index=sns[1:], columns=n.static(c).index)
         rhs_start.index.name = "snapshot"
 
         def p_actual(idx: pd.Index) -> DataArray:
@@ -405,9 +406,9 @@ def define_ramp_limit_constraints(n: Network, sns: pd.Index, c: str, attr: str) 
 
     # ----------------------------- Fixed Generators ----------------------------- #
 
-    assets = n.df(c).reindex(fix_i)
+    assets = n.static(c).reindex(fix_i)
 
-    p_nom = n.df(c)[nominal_attrs[c]].reindex(fix_i)
+    p_nom = n.static(c)[nominal_attrs[c]].reindex(fix_i)
 
     # fix up
     if not ramp_limit_up[fix_i].isnull().all().all():
@@ -437,7 +438,7 @@ def define_ramp_limit_constraints(n: Network, sns: pd.Index, c: str, attr: str) 
 
     # ----------------------------- Extendable Generators ----------------------------- #
 
-    assets = n.df(c).reindex(ext_i)
+    assets = n.static(c).reindex(ext_i)
 
     # ext up
     if not ramp_limit_up[ext_i].isnull().all().all():
@@ -467,7 +468,7 @@ def define_ramp_limit_constraints(n: Network, sns: pd.Index, c: str, attr: str) 
 
     # ----------------------------- Committable Generators ----------------------------- #
 
-    assets = n.df(c).reindex(com_i)
+    assets = n.static(c).reindex(com_i)
 
     # com up
     if not assets.ramp_limit_up.isnull().all():
@@ -568,15 +569,15 @@ def define_nodal_balance_constraints(
     for arg in args:
         c, attr, column, sign = arg
 
-        if n.df(c).empty:
+        if n.static(c).empty:
             continue
 
-        if "sign" in n.df(c):
+        if "sign" in n.static(c):
             # additional sign necessary for branches in reverse direction
-            sign = sign * n.df(c).sign
+            sign = sign * n.static(c).sign
 
         expr = DataArray(sign) * m[f"{c}-{attr}"]
-        cbuses = n.df(c)[column][lambda ds: ds.isin(buses)].rename("Bus")
+        cbuses = n.static(c)[column][lambda ds: ds.isin(buses)].rename("Bus")
 
         #  drop non-existent multiport buses which are ''
         if column in ["bus" + i for i in additional_linkports(n)]:
@@ -624,7 +625,7 @@ def define_kirchhoff_voltage_constraints(n: Network, sns: pd.Index) -> None:
     m = n.model
     n.calculate_dependent_values()
 
-    comps = [c for c in n.passive_branch_components if not n.df(c).empty]
+    comps = [c for c in n.passive_branch_components if not n.static(c).empty]
 
     if not comps:
         return
@@ -679,7 +680,7 @@ def define_kirchhoff_voltage_constraints(n: Network, sns: pd.Index) -> None:
 def define_fixed_nominal_constraints(n: Network, c: str, attr: str) -> None:
     """
     Sets constraints for fixing static variables of a given component and
-    attribute to the corresponding values in `n.df(c)[attr + '_set']`.
+    attribute to the corresponding values in `n.static(c)[attr + '_set']`.
 
     Parameters
     ----------
@@ -689,11 +690,11 @@ def define_fixed_nominal_constraints(n: Network, c: str, attr: str) -> None:
     attr : str
         name of the attribute, e.g. 'p'
     """
-    if attr + "_set" not in n.df(c):
+    if attr + "_set" not in n.static(c):
         return
 
     dim = f"{c}-{attr}_set_i"
-    fix = n.df(c)[attr + "_set"].dropna().rename_axis(dim)
+    fix = n.static(c)[attr + "_set"].dropna().rename_axis(dim)
 
     if fix.empty:
         return
@@ -718,13 +719,13 @@ def define_modular_constraints(n: Network, c: str, attr: str) -> None:
         name of the variable, e.g. 'n_opt'
     """
     m = n.model
-    mod_i = n.df(c).query(f"{attr}_extendable and ({attr}_mod>0)").index
+    mod_i = n.static(c).query(f"{attr}_extendable and ({attr}_mod>0)").index
 
     if (mod_i).empty:
         return
 
     modularity = m.variables[f"{c}-n_mod"]
-    modular_capacity = n.df(c)[f"{attr}_mod"].loc[mod_i]
+    modular_capacity = n.static(c)[f"{attr}_mod"].loc[mod_i]
     capacity = m.variables[f"{c}-{attr}"].loc[mod_i]
 
     con = capacity - modularity * modular_capacity.values == 0
@@ -773,7 +774,7 @@ def define_storage_unit_constraints(n: Network, sns: pd.Index) -> None:
     m = n.model
     c = "StorageUnit"
     dim = "snapshot"
-    assets = n.df(c)
+    assets = n.static(c)
     active = DataArray(get_activity_mask(n, c, sns))
 
     if assets.empty:
@@ -862,7 +863,7 @@ def define_store_constraints(n: Network, sns: pd.Index) -> None:
     m = n.model
     c = "Store"
     dim = "snapshot"
-    assets = n.df(c)
+    assets = n.static(c)
     active = DataArray(get_activity_mask(n, c, sns))
 
     if assets.empty:
@@ -929,7 +930,7 @@ def define_store_constraints(n: Network, sns: pd.Index) -> None:
 def define_loss_constraints(
     n: Network, sns: pd.Index, c: str, transmission_losses: int
 ) -> None:
-    if n.df(c).empty or c not in n.passive_branch_components:
+    if n.static(c).empty or c not in n.passive_branch_components:
         return
 
     tangents = transmission_losses
@@ -937,8 +938,8 @@ def define_loss_constraints(
 
     s_max_pu = get_as_dense(n, c, "s_max_pu").loc[sns]
 
-    s_nom_max = n.df(c)["s_nom_max"].where(
-        n.df(c)["s_nom_extendable"], n.df(c)["s_nom"]
+    s_nom_max = n.static(c)["s_nom_max"].where(
+        n.static(c)["s_nom_extendable"], n.static(c)["s_nom"]
     )
 
     if not isfinite(s_nom_max).all():
@@ -948,7 +949,7 @@ def define_loss_constraints(
         )
         raise ValueError(msg)
 
-    r_pu_eff = n.df(c)["r_pu_eff"]
+    r_pu_eff = n.static(c)["r_pu_eff"]
 
     upper_limit = r_pu_eff * (s_max_pu * s_nom_max) ** 2
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -642,15 +642,15 @@ def define_kirchhoff_voltage_constraints(n: Network, sns: pd.Index) -> None:
         snapshots = sns if period is None else sns[sns.get_loc(period)]
 
         exprs_list = []
-        for sub in n.sub_networks.obj:
-            branches = sub.branches()
+        for sub_network in n.sub_networks.obj:
+            branches = sub_network.branches()
 
-            if not sub.C.size:
+            if not sub_network.C.size:
                 continue
 
-            carrier = n.sub_networks.carrier[sub.name]
+            carrier = n.sub_networks.carrier[sub_network.name]
             weightings = branches.x_pu_eff if carrier == "AC" else branches.r_pu_eff
-            C = 1e5 * sparse.diags(weightings.values) * sub.C
+            C = 1e5 * sparse.diags(weightings.values) * sub_network.C
             ssub = s.loc[snapshots, branches.index].values
 
             ncycles = C.shape[1]

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -53,14 +53,14 @@ def define_tech_capacity_expansion_limit(n: Network, sns: Sequence) -> None:
         for c, attr in nominal_attrs.items():
             var = f"{c}-{attr}"
             dim = f"{c}-ext"
-            df = n.df(c)
+            static = n.static(c)
 
-            if "carrier" not in df:
+            if "carrier" not in static:
                 continue
 
             ext_i = (
                 n.get_extendable_i(c)
-                .intersection(df.index[df.carrier == carrier])
+                .intersection(static.index[static.carrier == carrier])
                 .rename(dim)
             )
             if period is not None:
@@ -70,7 +70,7 @@ def define_tech_capacity_expansion_limit(n: Network, sns: Sequence) -> None:
                 continue
 
             bus = "bus0" if c in n.branch_components else "bus"
-            busmap = df.loc[ext_i, bus].rename(busdim).to_xarray()
+            busmap = static.loc[ext_i, bus].rename(busdim).to_xarray()
             expr = m[var].loc[ext_i].groupby(busmap).sum()
             lhs_per_bus_list.append(expr)
 
@@ -146,14 +146,14 @@ def define_nominal_constraints_per_bus_carrier(n: Network, sns: pd.Index) -> Non
         for c, attr in nominal_attrs.items():
             var = f"{c}-{attr}"
             dim = f"{c}-ext"
-            df = n.df(c)
+            static = n.static(c)
 
-            if c not in n.one_port_components or "carrier" not in df:
+            if c not in n.one_port_components or "carrier" not in static:
                 continue
 
             ext_i = (
                 n.get_extendable_i(c)
-                .intersection(df.index[df.carrier == carrier])
+                .intersection(static.index[static.carrier == carrier])
                 .rename(dim)
             )
             if period is not None:
@@ -162,7 +162,7 @@ def define_nominal_constraints_per_bus_carrier(n: Network, sns: pd.Index) -> Non
             if ext_i.empty:
                 continue
 
-            busmap = df.loc[ext_i, "bus"].rename(buses.name).to_xarray()
+            busmap = static.loc[ext_i, "bus"].rename(buses.name).to_xarray()
             expr = m[var].loc[ext_i].groupby(busmap).sum().reindex({buses.name: buses})
             lhs.append(expr)
 
@@ -203,13 +203,13 @@ def define_growth_limit(n: Network, sns: pd.Index) -> None:
     for c, attr in nominal_attrs.items():
         var = f"{c}-{attr}"
         dim = f"{c}-ext"
-        df = n.df(c)
+        static = n.static(c)
 
-        if "carrier" not in df:
+        if "carrier" not in static:
             continue
 
         limited_i = (
-            df.index[df.carrier.isin(carrier_i)]
+            static.index[static.carrier.isin(carrier_i)]
             .intersection(n.get_extendable_i(c))
             .rename(dim)
         )
@@ -219,7 +219,7 @@ def define_growth_limit(n: Network, sns: pd.Index) -> None:
         active = pd.concat({p: n.get_active_assets(c, p) for p in periods}, axis=1)
         active = active.loc[limited_i].rename_axis(columns="periods").T
         first_active = DataArray(active.cumsum() == 1)
-        carriers = df.loc[limited_i, "carrier"].rename("Carrier")
+        carriers = static.loc[limited_i, "carrier"].rename("Carrier")
 
         vars = m[var].sel({dim: limited_i}).where(first_active)
         expr = vars.groupby(carriers.to_xarray()).sum()
@@ -420,9 +420,9 @@ def define_transmission_volume_expansion_limit(n: Network, sns: Sequence) -> Non
             if ext_i.empty:
                 continue
 
-            ext_i = ext_i.intersection(n.df(c).query("carrier in @car").index).rename(
-                ext_i.name
-            )
+            ext_i = ext_i.intersection(
+                n.static(c).query("carrier in @car").index
+            ).rename(ext_i.name)
 
             if ext_i.empty:
                 continue
@@ -434,7 +434,7 @@ def define_transmission_volume_expansion_limit(n: Network, sns: Sequence) -> Non
                     n.get_active_assets(c, sns.unique("period"))[ext_i]
                 ].rename(ext_i.name)
 
-            length = n.df(c).length.reindex(ext_i)
+            length = n.static(c).length.reindex(ext_i)
             vars = m[f"{c}-{attr}"].loc[ext_i]
             lhs.append(m.linexpr((length, vars)).sum())
 
@@ -486,9 +486,9 @@ def define_transmission_expansion_cost_limit(n: Network, sns: pd.Index) -> None:
             if ext_i.empty:
                 continue
 
-            ext_i = ext_i.intersection(n.df(c).query("carrier in @car").index).rename(
-                ext_i.name
-            )
+            ext_i = ext_i.intersection(
+                n.static(c).query("carrier in @car").index
+            ).rename(ext_i.name)
 
             if not isnan(period):
                 ext_i = ext_i[n.get_active_assets(c, period)[ext_i]].rename(ext_i.name)
@@ -509,7 +509,7 @@ def define_transmission_expansion_cost_limit(n: Network, sns: pd.Index) -> None:
             else:
                 weights = 1
 
-            cost = n.df(c).capital_cost.reindex(ext_i) * weights
+            cost = n.static(c).capital_cost.reindex(ext_i) * weights
             vars = m[f"{c}-{attr}"].loc[ext_i]
             lhs.append(m.linexpr((cost, vars)).sum())
 

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -355,7 +355,7 @@ def assign_solution(n: Network) -> None:
                     i_eff = "" if i == "1" else i
                     eff = get_as_dense(n, "Link", f"efficiency{i_eff}", sns)
                     set_from_frame(n, c, f"p{i}", -df * eff)
-                    n.pnl(c)[f"p{i}"].loc[
+                    n.dynamic(c)[f"p{i}"].loc[
                         sns, n.links.index[n.links[f"bus{i}"] == ""]
                     ] = float(n.components["Link"]["attrs"].loc[f"p{i}", "default"])
 
@@ -374,7 +374,7 @@ def assign_solution(n: Network) -> None:
     # recalculate storageunit net dispatch
     if not n.static("StorageUnit").empty:
         c = "StorageUnit"
-        n.pnl(c)["p"] = n.pnl(c)["p_dispatch"] - n.pnl(c)["p_store"]
+        n.dynamic(c)["p"] = n.dynamic(c)["p_dispatch"] - n.dynamic(c)["p_store"]
 
     n.objective = m.objective.value
 
@@ -485,7 +485,7 @@ def post_processing(n: Network) -> None:
     n.buses_t.p = (
         pd.concat(
             [
-                n.pnl(c)[attr].mul(sign(c)).rename(columns=n.static(c)[group])
+                n.dynamic(c)[attr].mul(sign(c)).rename(columns=n.static(c)[group])
                 for c, attr, group in ca
             ],
             axis=1,
@@ -732,9 +732,9 @@ class OptimizationAccessor:
         """
         n = self.n
         for c in n.one_port_components:
-            n.pnl(c).p_set = n.pnl(c).p
+            n.dynamic(c).p_set = n.dynamic(c).p
         for c in n.controllable_branch_components:
-            n.pnl(c).p_set = n.pnl(c).p0
+            n.dynamic(c).p_set = n.dynamic(c).p0
 
     def add_load_shedding(
         self,

--- a/pypsa/optimization/variables.py
+++ b/pypsa/optimization/variables.py
@@ -31,11 +31,11 @@ def define_operational_variables(n: Network, sns: Sequence, c: str, attr: str) -
     attr : str
         name of the attribute, e.g. 'p'
     """
-    if n.df(c).empty:
+    if n.static(c).empty:
         return
 
     active = get_activity_mask(n, c, sns)
-    coords = [sns, n.df(c).index.rename(c)]
+    coords = [sns, n.static(c).index.rename(c)]
     n.model.add_variables(coords=coords, name=f"{c}-{attr}", mask=active)
 
 
@@ -118,7 +118,7 @@ def define_modular_variables(n: Network, c: str, attr: str) -> None:
     attr : str
         name of the variable to be handled attached to modular constraints, e.g. 'p_nom'
     """
-    mod_i = n.df(c).query(f"{attr}_extendable and ({attr}_mod>0)").index
+    mod_i = n.static(c).query(f"{attr}_extendable and ({attr}_mod>0)").index
     mod_i = mod_i.rename(f"{c}-ext")
 
     if (mod_i).empty:
@@ -132,7 +132,7 @@ def define_spillage_variables(n: Network, sns: Sequence) -> None:
     Defines the spillage variables for storage units.
     """
     c = "StorageUnit"
-    if n.df(c).empty:
+    if n.static(c).empty:
         return
 
     upper = get_as_dense(n, c, "inflow", sns)
@@ -147,9 +147,9 @@ def define_loss_variables(n: Network, sns: Sequence, c: str) -> None:
     """
     Initializes variables for transmission losses.
     """
-    if n.df(c).empty or c not in n.passive_branch_components:
+    if n.static(c).empty or c not in n.passive_branch_components:
         return
 
     active = get_activity_mask(n, c, sns)
-    coords = [sns, n.df(c).index.rename(c)]
+    coords = [sns, n.static(c).index.rename(c)]
     n.model.add_variables(0, coords=coords, name=f"{c}-loss", mask=active)

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -270,7 +270,7 @@ def network_pf(
         use_seed=use_seed,
         distribute_slack=distribute_slack,
         slack_weights=slack_weights,
-    )  # type: ignore
+    )
 
 
 def newton_raphson_sparse(

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -27,7 +27,7 @@ from pypsa.descriptors import (
     zsum,
 )
 from pypsa.descriptors import get_switchable_as_dense as get_as_dense
-from pypsa.utils import as_index
+from pypsa.utils import as_index, deprecated_common_kwargs
 
 if TYPE_CHECKING:
     from components import Network, SubNetwork
@@ -48,6 +48,7 @@ def imag(X: pd.Series) -> pd.Series:
     return np.imag(X.to_numpy())
 
 
+@deprecated_common_kwargs
 def _allocate_pf_outputs(n: Network, linear: bool = False) -> None:
     to_allocate = {
         "Generator": ["p"],
@@ -123,6 +124,7 @@ def _calculate_controllable_nodal_power_balance(
             )
 
 
+@deprecated_common_kwargs
 def _network_prepare_and_run_pf(
     n: Network,
     snapshots: Sequence | None,
@@ -211,6 +213,7 @@ def _network_prepare_and_run_pf(
         return None
 
 
+@deprecated_common_kwargs
 def network_pf(
     n: Network,
     snapshots: Sequence | None = None,
@@ -821,6 +824,7 @@ def sub_network_pf(
     return iters, diffs, convs
 
 
+@deprecated_common_kwargs
 def network_lpf(
     n: Network, snapshots: Sequence | None = None, skip_pre: bool = False
 ) -> None:
@@ -844,6 +848,7 @@ def network_lpf(
     _network_prepare_and_run_pf(n, sns, skip_pre, linear=True)
 
 
+@deprecated_common_kwargs
 def apply_line_types(n: Network) -> None:
     """
     Calculate line electrical parameters x, r, b, g from standard types.
@@ -886,6 +891,7 @@ def apply_line_types(n: Network) -> None:
         n.lines.loc[lines_with_types_b, attr] = lines[attr]
 
 
+@deprecated_common_kwargs
 def apply_transformer_types(n: Network) -> None:
     """
     Calculate transformer electrical parameters x, r, b, g from standard types.
@@ -961,6 +967,7 @@ def wye_to_delta(
     return (summand / z2, summand / z1, summand / z3)
 
 
+@deprecated_common_kwargs
 def apply_transformer_t_model(n: Network) -> None:
     """
     Convert given T-model parameters to PI-model parameters using wye-delta
@@ -984,6 +991,7 @@ def apply_transformer_t_model(n: Network) -> None:
     n.transformers.loc[ts_b, "b_pu"] = imag(2 / za)
 
 
+@deprecated_common_kwargs
 def calculate_dependent_values(n: Network) -> None:
     """
     Calculate per unit impedances and append voltages to lines and shunt
@@ -1534,6 +1542,7 @@ def sub_network_lpf(
         )  # fmt: skip
 
 
+@deprecated_common_kwargs
 def network_batch_lpf(n: Network, snapshots: Sequence | None = None) -> None:
     """
     Batched linear power flow with numpy.dot for several snapshots.

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -236,13 +236,13 @@ def network_pf(
         If ``False`` only the slack generator takes up the slack.
     slack_weights : dict|str, default 'p_set'
         Distribution scheme describing how to determine the fraction of the total slack power
-        (of each sub network individually) a bus of the subnetwork takes up.
+        (of each sub network individually) a bus of the sub-network takes up.
         Default is to distribute proportional to generator dispatch ('p_set').
         Another option is to distribute proportional to (optimised) nominal capacity ('p_nom' or 'p_nom_opt').
         Custom weights can be specified via a dictionary that has a key for each
-        subnetwork index (``n.sub_networks.index``) and a
+        sub-network index (``n.sub_networks.index``) and a
         pandas.Series/dict with buses or generators of the
-        corresponding subnetwork as index/keys.
+        corresponding sub-network as index/keys.
         When specifying custom weights with buses as index/keys the slack power of a bus is distributed
         among its generators in proportion to their nominal capacity (``p_nom``) if given, otherwise evenly.
 
@@ -336,7 +336,7 @@ def sub_network_pf_singlebus(
         If ``False`` only the slack generator takes up the slack.
     slack_weights : pandas.Series|str, default 'p_set'
         Distribution scheme describing how to determine the fraction of the total slack power
-        a bus of the subnetwork takes up. Default is to distribute proportional to generator dispatch
+        a bus of the sub-network takes up. Default is to distribute proportional to generator dispatch
         ('p_set'). Another option is to distribute proportional to (optimised) nominal capacity ('p_nom' or 'p_nom_opt').
         Custom weights can be provided via a pandas.Series/dict
         that has the generators of the single bus as index/keys.
@@ -445,10 +445,10 @@ def sub_network_pf(
         If ``False`` only the slack generator takes up the slack.
     slack_weights : pandas.Series|str, default 'p_set'
         Distribution scheme describing how to determine the fraction of the total slack power
-        a bus of the subnetwork takes up. Default is to distribute proportional to generator dispatch
+        a bus of the sub-network takes up. Default is to distribute proportional to generator dispatch
         ('p_set'). Another option is to distribute proportional to (optimised) nominal capacity ('p_nom' or 'p_nom_opt').
         Custom weights can be provided via a pandas.Series/dict
-        that has the buses or the generators of the subnetwork as index/keys.
+        that has the buses or the generators of the sub-network as index/keys.
         When using custom weights with buses as index/keys the slack power of a bus is distributed
         among its generators in proportion to their nominal capacity (``p_nom``) if given, otherwise evenly.
 
@@ -493,7 +493,7 @@ def sub_network_pf(
         find_bus_controls(sub_network)
         _allocate_pf_outputs(n, linear=False)
 
-    # get indices for the components on this subnetwork
+    # get indices for the components on this sub-network
     branches_i = sub_network.branches_i(active_only=True)
     buses_o = sub_network.buses_o
     sn_buses = sub_network.buses().index
@@ -509,7 +509,7 @@ def sub_network_pf(
         else:
             raise ValueError(
                 "Custom slack weights pd.Series/dict must only have the",
-                "generators or buses of the subnetwork as index/keys.",
+                "generators or buses of the sub-network as index/keys.",
             )
 
     if not skip_pre and len(branches_i) > 0:
@@ -1452,7 +1452,7 @@ def sub_network_lpf(
         find_bus_controls(sub_network)
         _allocate_pf_outputs(n, linear=True)
 
-    # get indices for the components on this subnetwork
+    # get indices for the components on this sub-network
     buses_o = sub_network.buses_o
     branches_i = sub_network.branches_i(active_only=True)
 

--- a/pypsa/pf.py
+++ b/pypsa/pf.py
@@ -48,7 +48,7 @@ def imag(X: pd.Series) -> pd.Series:
     return np.imag(X.to_numpy())
 
 
-def _allocate_pf_outputs(network: Network, linear: bool = False) -> None:
+def _allocate_pf_outputs(n: Network, linear: bool = False) -> None:
     to_allocate = {
         "Generator": ["p"],
         "Load": ["p"],
@@ -58,7 +58,7 @@ def _allocate_pf_outputs(network: Network, linear: bool = False) -> None:
         "Bus": ["p", "v_ang", "v_mag_pu"],
         "Line": ["p0", "p1"],
         "Transformer": ["p0", "p1"],
-        "Link": ["p" + col[3:] for col in network.links.columns if col[:3] == "bus"],
+        "Link": ["p" + col[3:] for col in n.links.columns if col[:3] == "bus"],
     }
 
     if not linear:
@@ -68,7 +68,7 @@ def _allocate_pf_outputs(network: Network, linear: bool = False) -> None:
             if "p0" in attrs and component != "Link":
                 attrs.extend(["q0", "q1"])
 
-    allocate_series_dataframes(network, to_allocate)
+    allocate_series_dataframes(n, to_allocate)
 
 
 def _calculate_controllable_nodal_power_balance(
@@ -77,21 +77,23 @@ def _calculate_controllable_nodal_power_balance(
     snapshots: Sequence,
     buses_o: Sequence,
 ) -> None:
-    for n in ("q", "p"):
+    for power in ("q", "p"):
         # allow all one ports to dispatch as set
         for c in sub_network.iterate_components(
             network.controllable_one_port_components
         ):
             c_n_set = get_as_dense(
-                network, c.name, n + "_set", snapshots, c.df.query("active").index
+                network, c.name, power + "_set", snapshots, c.df.query("active").index
             )
-            network.pnl(c.name)[n].loc[snapshots, c.df.query("active").index] = c_n_set
+            network.pnl(c.name)[power].loc[snapshots, c.df.query("active").index] = (
+                c_n_set
+            )
 
         # set the power injection at each node from controllable components
-        network.buses_t[n].loc[snapshots, buses_o] = sum(
+        network.buses_t[power].loc[snapshots, buses_o] = sum(
             (
                 (
-                    c.pnl[n].loc[snapshots, c.df.query("active").index]
+                    c.pnl[power].loc[snapshots, c.df.query("active").index]
                     * c.df.loc[c.df.query("active").index, "sign"]
                 )
                 .T.groupby(c.df.loc[c.df.query("active").index, "bus"])
@@ -103,9 +105,9 @@ def _calculate_controllable_nodal_power_balance(
             )
         )
 
-        if n == "p":
-            network.buses_t[n].loc[snapshots, buses_o] += sum(
-                -c.pnl[n + str(i)]
+        if power == "p":
+            network.buses_t[power].loc[snapshots, buses_o] += sum(
+                -c.pnl[power + str(i)]
                 .loc[snapshots]
                 .T.groupby(c.df[f"bus{str(i)}"])
                 .sum()
@@ -118,7 +120,7 @@ def _calculate_controllable_nodal_power_balance(
 
 
 def _network_prepare_and_run_pf(
-    network: Network,
+    n: Network,
     snapshots: Sequence | None,
     skip_pre: bool,
     linear: bool = False,
@@ -134,28 +136,28 @@ def _network_prepare_and_run_pf(
         sub_network_prepare_fun: Callable = calculate_Y  # type: ignore
 
     if not skip_pre:
-        network.determine_network_topology()
-        calculate_dependent_values(network)
-        _allocate_pf_outputs(network, linear)
+        n.determine_network_topology()
+        calculate_dependent_values(n)
+        _allocate_pf_outputs(n, linear)
 
-    sns = as_index(network, snapshots, "snapshots", "snapshot")
+    sns = as_index(n, snapshots, "snapshots", "snapshot")
 
     # deal with links
-    if not network.links.empty:
-        p_set = get_as_dense(network, "Link", "p_set", sns)
-        network.links_t.p0.loc[sns] = p_set.loc[sns]
-        for i in ["1"] + additional_linkports(network):
+    if not n.links.empty:
+        p_set = get_as_dense(n, "Link", "p_set", sns)
+        n.links_t.p0.loc[sns] = p_set.loc[sns]
+        for i in ["1"] + additional_linkports(n):
             eff_name = "efficiency" if i == "1" else f"efficiency{i}"
-            efficiency = get_as_dense(network, "Link", eff_name, sns)
-            links = network.links.index[network.links[f"bus{i}"] != ""]
-            network.links_t[f"p{i}"].loc[sns, links] = (
-                -network.links_t.p0.loc[sns, links] * efficiency.loc[sns, links]
+            efficiency = get_as_dense(n, "Link", eff_name, sns)
+            links = n.links.index[n.links[f"bus{i}"] != ""]
+            n.links_t[f"p{i}"].loc[sns, links] = (
+                -n.links_t.p0.loc[sns, links] * efficiency.loc[sns, links]
             )
 
-    itdf = pd.DataFrame(index=sns, columns=network.sub_networks.index, dtype=int)
-    difdf = pd.DataFrame(index=sns, columns=network.sub_networks.index)
-    cnvdf = pd.DataFrame(index=sns, columns=network.sub_networks.index, dtype=bool)
-    for sub_network in network.sub_networks.obj:
+    itdf = pd.DataFrame(index=sns, columns=n.sub_networks.index, dtype=int)
+    difdf = pd.DataFrame(index=sns, columns=n.sub_networks.index)
+    cnvdf = pd.DataFrame(index=sns, columns=n.sub_networks.index, dtype=bool)
+    for sub_network in n.sub_networks.obj:
         if not skip_pre:
             find_bus_controls(sub_network)
 
@@ -206,7 +208,7 @@ def _network_prepare_and_run_pf(
 
 
 def network_pf(
-    network: Network,
+    n: Network,
     snapshots: Sequence | None = None,
     skip_pre: bool = False,
     x_tol: float = 1e-6,
@@ -220,8 +222,8 @@ def network_pf(
     Parameters
     ----------
     snapshots : list-like|single snapshot
-        A subset or an elements of network.snapshots on which to run
-        the power flow, defaults to network.snapshots
+        A subset or an elements of n.snapshots on which to run
+        the power flow, defaults to n.snapshots
     skip_pre : bool, default False
         Skip the preliminary steps of computing topology, calculating dependent values and finding bus controls.
     x_tol: float
@@ -238,7 +240,7 @@ def network_pf(
         Default is to distribute proportional to generator dispatch ('p_set').
         Another option is to distribute proportional to (optimised) nominal capacity ('p_nom' or 'p_nom_opt').
         Custom weights can be specified via a dictionary that has a key for each
-        subnetwork index (``network.sub_networks.index``) and a
+        subnetwork index (``n.sub_networks.index``) and a
         pandas.Series/dict with buses or generators of the
         corresponding subnetwork as index/keys.
         When specifying custom weights with buses as index/keys the slack power of a bus is distributed
@@ -253,7 +255,7 @@ def network_pf(
     """
 
     return _network_prepare_and_run_pf(
-        network,
+        n,
         snapshots,
         skip_pre,
         linear=False,
@@ -324,8 +326,8 @@ def sub_network_pf_singlebus(
     Parameters
     ----------
     snapshots : list-like|single snapshot
-        A subset or an elements of network.snapshots on which to run
-        the power flow, defaults to network.snapshots
+        A subset or an elements of n.snapshots on which to run
+        the power flow, defaults to n.snapshots
     skip_pre: bool, default False
         Skip the preliminary steps of computing topology, calculating dependent values and finding bus controls.
     distribute_slack : bool, default False
@@ -340,45 +342,40 @@ def sub_network_pf_singlebus(
         that has the generators of the single bus as index/keys.
     """
 
-    sns = as_index(sub_network.network, snapshots, "snapshots", "snapshot")
-    network = sub_network.network
+    sns = as_index(sub_network.n, snapshots, "snapshots", "snapshot")
+    n = sub_network.n
     logger.info(
         f"Balancing power on single-bus sub-network {sub_network} for snapshots {snapshots}"
     )
 
     if not skip_pre:
         find_bus_controls(sub_network)
-        _allocate_pf_outputs(network, linear=False)
+        _allocate_pf_outputs(n, linear=False)
 
     if isinstance(slack_weights, dict):
         slack_weights = pd.Series(slack_weights)
 
     buses_o = sub_network.buses_o
 
-    _calculate_controllable_nodal_power_balance(sub_network, network, sns, buses_o)
+    _calculate_controllable_nodal_power_balance(sub_network, n, sns, buses_o)
 
-    v_mag_pu_set = get_as_dense(network, "Bus", "v_mag_pu_set", sns)
-    network.buses_t.v_mag_pu.loc[sns, sub_network.slack_bus] = v_mag_pu_set.loc[
+    v_mag_pu_set = get_as_dense(n, "Bus", "v_mag_pu_set", sns)
+    n.buses_t.v_mag_pu.loc[sns, sub_network.slack_bus] = v_mag_pu_set.loc[
         :, sub_network.slack_bus
     ]
-    network.buses_t.v_ang.loc[sns, sub_network.slack_bus] = 0.0
+    n.buses_t.v_ang.loc[sns, sub_network.slack_bus] = 0.0
 
     if distribute_slack:
         for bus, group in sub_network.generators().groupby("bus"):
             if slack_weights in ["p_nom", "p_nom_opt"]:
-                if all(network.generators[slack_weights] == 0):
+                if all(n.generators[slack_weights] == 0):
                     msg = f"Invalid slack weights! Generator attribute {slack_weights} is always zero."
                     raise ValueError(msg)
                 bus_generator_shares = (
-                    network.generators[slack_weights]
-                    .loc[group.index]
-                    .pipe(normed)
-                    .fillna(0)
+                    n.generators[slack_weights].loc[group.index].pipe(normed).fillna(0)
                 )
             elif slack_weights == "p_set":
-                generators_t_p_choice = get_as_dense(
-                    network, "Generator", slack_weights, sns
-                )
+                generators_t_p_choice = get_as_dense(n, "Generator", slack_weights, sns)
                 if generators_t_p_choice.isna().all().all():
                     msg = (
                         f"Invalid slack weights! Generator attribute {slack_weights}"
@@ -399,22 +396,22 @@ def sub_network_pf_singlebus(
                 )
             else:
                 bus_generator_shares = slack_weights.pipe(normed).fillna(0)
-            network.generators_t.p.loc[sns, group.index] += (
+            n.generators_t.p.loc[sns, group.index] += (
                 bus_generator_shares.multiply(
-                    -network.buses_t.p.loc[sns, bus], axis=0
+                    -n.buses_t.p.loc[sns, bus], axis=0
                 )
             )  # fmt: skip
     else:
-        network.generators_t.p.loc[sns, sub_network.slack_generator] -= (
-            network.buses_t.p.loc[sns, sub_network.slack_bus]
+        n.generators_t.p.loc[sns, sub_network.slack_generator] -= (
+            n.buses_t.p.loc[sns, sub_network.slack_bus]
         )  # fmt: skip
 
-    network.generators_t.q.loc[sns, sub_network.slack_generator] -= (
-        network.buses_t.q.loc[sns, sub_network.slack_bus]
+    n.generators_t.q.loc[sns, sub_network.slack_generator] -= (
+        n.buses_t.q.loc[sns, sub_network.slack_bus]
     )  # fmt: skip
 
-    network.buses_t.p.loc[sns, sub_network.slack_bus] = 0.0
-    network.buses_t.q.loc[sns, sub_network.slack_bus] = 0.0
+    n.buses_t.p.loc[sns, sub_network.slack_bus] = 0.0
+    n.buses_t.q.loc[sns, sub_network.slack_bus] = 0.0
 
     return 0, 0.0, True  # dummy substitute for newton raphson output
 
@@ -434,8 +431,8 @@ def sub_network_pf(
     Parameters
     ----------
     snapshots : list-like|single snapshot
-        A subset or an elements of network.snapshots on which to run
-        the power flow, defaults to network.snapshots
+        A subset or an elements of n.snapshots on which to run
+        the power flow, defaults to n.snapshots
     skip_pre: bool, default False
         Skip the preliminary steps of computing topology, calculating dependent values and finding bus controls.
     x_tol: float
@@ -479,22 +476,22 @@ def sub_network_pf(
             )
             raise ValueError(msg)
 
-    sns = as_index(sub_network.network, snapshots, "snapshots", "snapshot")
+    sns = as_index(sub_network.n, snapshots, "snapshots", "snapshot")
     logger.info(
         "Performing non-linear load-flow on {} sub-network {} for snapshots {}".format(
-            sub_network.network.sub_networks.at[sub_network.name, "carrier"],
+            sub_network.n.sub_networks.at[sub_network.name, "carrier"],
             sub_network,
             sns,
         )
     )
 
     # _sub_network_prepare_pf(sub_network, snapshots, skip_pre, calculate_Y)
-    network = sub_network.network
+    n = sub_network.n
 
     if not skip_pre:
-        calculate_dependent_values(network)
+        calculate_dependent_values(n)
         find_bus_controls(sub_network)
-        _allocate_pf_outputs(network, linear=False)
+        _allocate_pf_outputs(n, linear=False)
 
     # get indices for the components on this subnetwork
     branches_i = sub_network.branches_i(active_only=True)
@@ -518,7 +515,7 @@ def sub_network_pf(
     if not skip_pre and len(branches_i) > 0:
         calculate_Y(sub_network, skip_pre=True)
 
-    _calculate_controllable_nodal_power_balance(sub_network, network, sns, buses_o)
+    _calculate_controllable_nodal_power_balance(sub_network, n, sns, buses_o)
 
     def f(
         guess: np.ndarray,
@@ -526,15 +523,13 @@ def sub_network_pf(
         slack_weights: np.ndarray | None = None,
     ) -> np.ndarray:
         last_pq = -1 if distribute_slack else None
-        network.buses_t.v_ang.loc[now, sub_network.pvpqs] = guess[
-            : len(sub_network.pvpqs)
-        ]
-        network.buses_t.v_mag_pu.loc[now, sub_network.pqs] = guess[
+        n.buses_t.v_ang.loc[now, sub_network.pvpqs] = guess[: len(sub_network.pvpqs)]
+        n.buses_t.v_mag_pu.loc[now, sub_network.pqs] = guess[
             len(sub_network.pvpqs) : last_pq
         ]
 
-        v_mag_pu = network.buses_t.v_mag_pu.loc[now, buses_o]
-        v_ang = network.buses_t.v_ang.loc[now, buses_o]
+        v_mag_pu = n.buses_t.v_mag_pu.loc[now, buses_o]
+        v_ang = n.buses_t.v_ang.loc[now, buses_o]
         V = v_mag_pu * np.exp(1j * v_ang)
 
         if distribute_slack:
@@ -556,15 +551,13 @@ def sub_network_pf(
         slack_weights: np.ndarray | None = None,
     ) -> csr_matrix:
         last_pq = -1 if distribute_slack else None
-        network.buses_t.v_ang.loc[now, sub_network.pvpqs] = guess[
-            : len(sub_network.pvpqs)
-        ]
-        network.buses_t.v_mag_pu.loc[now, sub_network.pqs] = guess[
+        n.buses_t.v_ang.loc[now, sub_network.pvpqs] = guess[: len(sub_network.pvpqs)]
+        n.buses_t.v_mag_pu.loc[now, sub_network.pqs] = guess[
             len(sub_network.pvpqs) : last_pq
         ]
 
-        v_mag_pu = network.buses_t.v_mag_pu.loc[now, buses_o]
-        v_ang = network.buses_t.v_ang.loc[now, buses_o]
+        v_mag_pu = n.buses_t.v_mag_pu.loc[now, buses_o]
+        v_ang = n.buses_t.v_ang.loc[now, buses_o]
 
         V = v_mag_pu * np.exp(1j * v_ang)
 
@@ -602,30 +595,24 @@ def sub_network_pf(
         return J
 
     # Set what we know: slack V and v_mag_pu for PV buses
-    v_mag_pu_set = get_as_dense(network, "Bus", "v_mag_pu_set", sns)
-    network.buses_t.v_mag_pu.loc[sns, sub_network.pvs] = v_mag_pu_set.loc[
-        :, sub_network.pvs
-    ]
-    network.buses_t.v_mag_pu.loc[sns, sub_network.slack_bus] = v_mag_pu_set.loc[
+    v_mag_pu_set = get_as_dense(n, "Bus", "v_mag_pu_set", sns)
+    n.buses_t.v_mag_pu.loc[sns, sub_network.pvs] = v_mag_pu_set.loc[:, sub_network.pvs]
+    n.buses_t.v_mag_pu.loc[sns, sub_network.slack_bus] = v_mag_pu_set.loc[
         :, sub_network.slack_bus
     ]
-    network.buses_t.v_ang.loc[sns, sub_network.slack_bus] = 0.0
+    n.buses_t.v_ang.loc[sns, sub_network.slack_bus] = 0.0
 
     if not use_seed:
-        network.buses_t.v_mag_pu.loc[sns, sub_network.pqs] = 1.0
-        network.buses_t.v_ang.loc[sns, sub_network.pvpqs] = 0.0
+        n.buses_t.v_mag_pu.loc[sns, sub_network.pqs] = 1.0
+        n.buses_t.v_ang.loc[sns, sub_network.pvpqs] = 0.0
 
     slack_args = {"distribute_slack": distribute_slack}
     slack_variable_b = 1 if distribute_slack else 0
 
     if distribute_slack:
         if isinstance(slack_weights, str) and slack_weights == "p_set":
-            generators_t_p_choice = get_as_dense(
-                network, "Generator", slack_weights, sns
-            )
-            bus_generation = generators_t_p_choice.rename(
-                columns=network.generators.bus
-            )
+            generators_t_p_choice = get_as_dense(n, "Generator", slack_weights, sns)
+            bus_generation = generators_t_p_choice.rename(columns=n.generators.bus)
             slack_weights_calc = (
                 pd.DataFrame(
                     bus_generation.T.groupby(bus_generation.columns).sum().T,
@@ -636,7 +623,7 @@ def sub_network_pf(
             )
 
         elif isinstance(slack_weights, str) and slack_weights in ["p_nom", "p_nom_opt"]:
-            if all(network.generators[slack_weights] == 0):
+            if all(n.generators[slack_weights] == 0):
                 msg = (
                     f"Invalid slack weights! Generator attribute {slack_weights} is "
                     f"always zero."
@@ -644,7 +631,7 @@ def sub_network_pf(
                 raise ValueError(msg)
 
             slack_weights_calc = (
-                network.generators.groupby("bus")[slack_weights]
+                n.generators.groupby("bus")[slack_weights]
                 .sum()
                 .reindex(buses_o)
                 .pipe(normed)
@@ -654,7 +641,7 @@ def sub_network_pf(
         elif generator_slack_weights_b:
             # convert generator-based slack weights to bus-based slack weights
             slack_weights_calc = (
-                slack_weights.rename(network.generators.bus)
+                slack_weights.rename(n.generators.bus)
                 .groupby(slack_weights.index.name)
                 .sum()
                 .reindex(buses_o)
@@ -677,14 +664,14 @@ def sub_network_pf(
     diffs = pd.Series(index=sns, dtype=float)
     convs = pd.Series(False, index=sns)
     for i, now in enumerate(sns):
-        p = network.buses_t.p.loc[now, buses_o]
-        q = network.buses_t.q.loc[now, buses_o]
+        p = n.buses_t.p.loc[now, buses_o]
+        q = n.buses_t.q.loc[now, buses_o]
         ss[i] = s = p + 1j * q
 
         # Make a guess for what we don't know: V_ang for PV and PQs and v_mag_pu for PQ buses
         guess = r_[
-            network.buses_t.v_ang.loc[now, sub_network.pvpqs],
-            network.buses_t.v_mag_pu.loc[now, sub_network.pqs],
+            n.buses_t.v_ang.loc[now, sub_network.pvpqs],
+            n.buses_t.v_mag_pu.loc[now, sub_network.pqs],
         ]
 
         if distribute_slack:
@@ -715,15 +702,13 @@ def sub_network_pf(
         last_pq = -1
     else:
         last_pq = None
-    network.buses_t.v_ang.loc[sns, sub_network.pvpqs] = roots[
-        :, : len(sub_network.pvpqs)
-    ]
-    network.buses_t.v_mag_pu.loc[sns, sub_network.pqs] = roots[
+    n.buses_t.v_ang.loc[sns, sub_network.pvpqs] = roots[:, : len(sub_network.pvpqs)]
+    n.buses_t.v_mag_pu.loc[sns, sub_network.pqs] = roots[
         :, len(sub_network.pvpqs) : last_pq
     ]
 
-    v_mag_pu = network.buses_t.v_mag_pu.loc[sns, buses_o].values
-    v_ang = network.buses_t.v_ang.loc[sns, buses_o].values
+    v_mag_pu = n.buses_t.v_mag_pu.loc[sns, buses_o].values
+    v_ang = n.buses_t.v_ang.loc[sns, buses_o].values
 
     V = v_mag_pu * np.exp(1j * v_ang)
 
@@ -731,7 +716,7 @@ def sub_network_pf(
     buses_indexer = buses_o.get_indexer
     branch_bus0 = []
     branch_bus1 = []
-    for c in sub_network.iterate_components(network.passive_branch_components):
+    for c in sub_network.iterate_components(n.passive_branch_components):
         branch_bus0 += list(c.df.query("active").bus0)
         branch_bus1 += list(c.df.query("active").bus1)
     v0 = V[:, buses_indexer(branch_bus0)]
@@ -745,24 +730,24 @@ def sub_network_pf(
 
     s0 = pd.DataFrame(v0 * np.conj(i0), columns=branches_i, index=sns)
     s1 = pd.DataFrame(v1 * np.conj(i1), columns=branches_i, index=sns)
-    for c in sub_network.iterate_components(network.passive_branch_components):
+    for c in sub_network.iterate_components(n.passive_branch_components):
         s0t = s0.loc[:, c.name]
         s1t = s1.loc[:, c.name]
-        network.pnl(c.name).p0.loc[sns, s0t.columns] = s0t.values.real
-        network.pnl(c.name).q0.loc[sns, s0t.columns] = s0t.values.imag
-        network.pnl(c.name).p1.loc[sns, s1t.columns] = s1t.values.real
-        network.pnl(c.name).q1.loc[sns, s1t.columns] = s1t.values.imag
+        n.pnl(c.name).p0.loc[sns, s0t.columns] = s0t.values.real
+        n.pnl(c.name).q0.loc[sns, s0t.columns] = s0t.values.imag
+        n.pnl(c.name).p1.loc[sns, s1t.columns] = s1t.values.real
+        n.pnl(c.name).q1.loc[sns, s1t.columns] = s1t.values.imag
 
     s_calc = np.empty((len(sns), len(buses_o)), dtype=complex)
     for i in np.arange(len(sns)):
         s_calc[i] = V[i] * np.conj(sub_network.Y * V[i])
     slack_index = buses_o.get_loc(sub_network.slack_bus)
     if distribute_slack:
-        network.buses_t.p.loc[sns, sn_buses] = s_calc.real[:, buses_indexer(sn_buses)]
+        n.buses_t.p.loc[sns, sn_buses] = s_calc.real[:, buses_indexer(sn_buses)]
     else:
-        network.buses_t.p.loc[sns, sub_network.slack_bus] = s_calc[:, slack_index].real
-    network.buses_t.q.loc[sns, sub_network.slack_bus] = s_calc[:, slack_index].imag
-    network.buses_t.q.loc[sns, sub_network.pvs] = s_calc[
+        n.buses_t.p.loc[sns, sub_network.slack_bus] = s_calc[:, slack_index].real
+    n.buses_t.q.loc[sns, sub_network.slack_bus] = s_calc[:, slack_index].imag
+    n.buses_t.q.loc[sns, sub_network.pvs] = s_calc[
         :, buses_indexer(sub_network.pvs)
     ].imag
 
@@ -771,31 +756,29 @@ def sub_network_pf(
     if len(shunt_impedances_i):
         # add voltages
         shunt_impedances_v_mag_pu = v_mag_pu[
-            :, buses_indexer(network.shunt_impedances.loc[shunt_impedances_i, "bus"])
+            :, buses_indexer(n.shunt_impedances.loc[shunt_impedances_i, "bus"])
         ]
-        network.shunt_impedances_t.p.loc[sns, shunt_impedances_i] = (
+        n.shunt_impedances_t.p.loc[sns, shunt_impedances_i] = (
             shunt_impedances_v_mag_pu**2
-        ) * network.shunt_impedances.loc[shunt_impedances_i, "g_pu"].values
-        network.shunt_impedances_t.q.loc[sns, shunt_impedances_i] = (
+        ) * n.shunt_impedances.loc[shunt_impedances_i, "g_pu"].values
+        n.shunt_impedances_t.q.loc[sns, shunt_impedances_i] = (
             shunt_impedances_v_mag_pu**2
-        ) * network.shunt_impedances.loc[shunt_impedances_i, "b_pu"].values
+        ) * n.shunt_impedances.loc[shunt_impedances_i, "b_pu"].values
 
     # let slack generator take up the slack
     if distribute_slack:
         distributed_slack_power = (
-            network.buses_t.p.loc[sns, sn_buses] - ss[:, buses_indexer(sn_buses)].real
+            n.buses_t.p.loc[sns, sn_buses] - ss[:, buses_indexer(sn_buses)].real
         )
         for bus, group in sub_network.generators().groupby("bus"):
             if isinstance(slack_weights, str) and slack_weights == "p_set":
-                generators_t_p_choice = get_as_dense(
-                    network, "Generator", slack_weights, sns
-                )
+                generators_t_p_choice = get_as_dense(n, "Generator", slack_weights, sns)
                 bus_generator_shares = (
                     generators_t_p_choice.loc[sns, group.index]
                     .apply(normed, axis=1)
                     .fillna(0)
                 )
-                network.generators_t.p.loc[sns, group.index] += (
+                n.generators_t.p.loc[sns, group.index] += (
                     bus_generator_shares.multiply(
                         distributed_slack_power.loc[sns, bus], axis=0
                     )
@@ -806,30 +789,28 @@ def sub_network_pf(
                         slack_weights.loc[group.index].pipe(normed).fillna(0)  # type: ignore
                     )
                 else:
-                    bus_generators_p_nom = network.generators.p_nom.loc[group.index]
+                    bus_generators_p_nom = n.generators.p_nom.loc[group.index]
                     # distribute evenly if no p_nom given
                     if all(bus_generators_p_nom) == 0:
                         bus_generators_p_nom = 1
                     bus_generator_shares = bus_generators_p_nom.pipe(normed).fillna(0)
-                network.generators_t.p.loc[sns, group.index] += (
+                n.generators_t.p.loc[sns, group.index] += (
                     distributed_slack_power.loc[
                         sns, bus
                     ].apply(lambda row: row * bus_generator_shares)
                 )  # fmt: skip
     else:
-        network.generators_t.p.loc[sns, sub_network.slack_generator] += (
-            network.buses_t.p.loc[sns, sub_network.slack_bus] - ss[:, slack_index].real
+        n.generators_t.p.loc[sns, sub_network.slack_generator] += (
+            n.buses_t.p.loc[sns, sub_network.slack_bus] - ss[:, slack_index].real
         )
 
     # set the Q of the slack and PV generators
-    network.generators_t.q.loc[sns, sub_network.slack_generator] += (
-        network.buses_t.q.loc[sns, sub_network.slack_bus] - ss[:, slack_index].imag
+    n.generators_t.q.loc[sns, sub_network.slack_generator] += (
+        n.buses_t.q.loc[sns, sub_network.slack_bus] - ss[:, slack_index].imag
     )
 
-    network.generators_t.q.loc[
-        sns, network.buses.loc[sub_network.pvs, "generator"]
-    ] += np.asarray(
-        network.buses_t.q.loc[sns, sub_network.pvs]
+    n.generators_t.q.loc[sns, n.buses.loc[sub_network.pvs, "generator"]] += np.asarray(
+        n.buses_t.q.loc[sns, sub_network.pvs]
         - ss[:, buses_indexer(sub_network.pvs)].imag
     )
 
@@ -837,7 +818,7 @@ def sub_network_pf(
 
 
 def network_lpf(
-    network: Network, snapshots: Sequence | None = None, skip_pre: bool = False
+    n: Network, snapshots: Sequence | None = None, skip_pre: bool = False
 ) -> None:
     """
     Linear power flow for generic network.
@@ -845,8 +826,8 @@ def network_lpf(
     Parameters
     ----------
     snapshots : list-like|single snapshot
-        A subset or an elements of network.snapshots on which to run
-        the power flow, defaults to network.snapshots
+        A subset or an elements of n.snapshots on which to run
+        the power flow, defaults to n.snapshots
     skip_pre : bool, default False
         Skip the preliminary steps of computing topology, calculating
         dependent values and finding bus controls.
@@ -855,32 +836,32 @@ def network_lpf(
     -------
     None
     """
-    sns = as_index(network, snapshots, "snapshots", "snapshot")
-    _network_prepare_and_run_pf(network, sns, skip_pre, linear=True)
+    sns = as_index(n, snapshots, "snapshots", "snapshot")
+    _network_prepare_and_run_pf(n, sns, skip_pre, linear=True)
 
 
-def apply_line_types(network: Network) -> None:
+def apply_line_types(n: Network) -> None:
     """
     Calculate line electrical parameters x, r, b, g from standard types.
     """
-    lines_with_types_b = network.lines.type != ""
+    lines_with_types_b = n.lines.type != ""
     if lines_with_types_b.zsum() == 0:
         return
 
     missing_types = pd.Index(
-        network.lines.loc[lines_with_types_b, "type"].unique()
-    ).difference(network.line_types.index)
+        n.lines.loc[lines_with_types_b, "type"].unique()
+    ).difference(n.line_types.index)
     if not missing_types.empty:
         msg = (
             f'The type(s) {", ".join(missing_types)} do(es) not exist in '
-            f"network.line_types"
+            f"n.line_types"
         )
         raise ValueError(msg)
 
     # Get a copy of the lines data
-    lines = network.lines.loc[
-        lines_with_types_b, ["type", "length", "num_parallel"]
-    ].join(network.line_types, on="type")
+    lines = n.lines.loc[lines_with_types_b, ["type", "length", "num_parallel"]].join(
+        n.line_types, on="type"
+    )
 
     for attr in ["r", "x"]:
         lines[attr] = (
@@ -898,32 +879,32 @@ def apply_line_types(network: Network) -> None:
 
     # now set calculated values on live lines
     for attr in ["r", "x", "b"]:
-        network.lines.loc[lines_with_types_b, attr] = lines[attr]
+        n.lines.loc[lines_with_types_b, attr] = lines[attr]
 
 
-def apply_transformer_types(network: Network) -> None:
+def apply_transformer_types(n: Network) -> None:
     """
     Calculate transformer electrical parameters x, r, b, g from standard types.
     """
-    trafos_with_types_b = network.transformers.type != ""
+    trafos_with_types_b = n.transformers.type != ""
     if trafos_with_types_b.zsum() == 0:
         return
 
     missing_types = pd.Index(
-        network.transformers.loc[trafos_with_types_b, "type"].unique()
-    ).difference(network.transformer_types.index)
+        n.transformers.loc[trafos_with_types_b, "type"].unique()
+    ).difference(n.transformer_types.index)
     if not missing_types.empty:
         msg = (
             f'The type(s) {", ".join(missing_types)} do(es) not exist in '
-            f"network.transformer_types"
+            f"n.transformer_types"
         )
         raise ValueError(msg)
 
     # Get a copy of the transformers data
     # (joining pulls in "phase_shift", "s_nom", "tap_side" from TransformerType)
-    t = network.transformers.loc[
+    t = n.transformers.loc[
         trafos_with_types_b, ["type", "tap_position", "num_parallel"]
-    ].join(network.transformer_types, on="type")
+    ].join(n.transformer_types, on="type")
 
     t["r"] = t["vscr"] / 100.0
     t["x"] = np.sqrt((t["vsc"] / 100.0) ** 2 - t["r"] ** 2)
@@ -948,7 +929,7 @@ def apply_transformer_types(network: Network) -> None:
 
     # now set calculated values on live transformers
     for attr in ["r", "x", "g", "b", "phase_shift", "s_nom", "tap_side", "tap_ratio"]:
-        network.transformers.loc[trafos_with_types_b, attr] = t[attr]
+        n.transformers.loc[trafos_with_types_b, attr] = t[attr]
 
     # TODO: status, rate_A
 
@@ -976,15 +957,15 @@ def wye_to_delta(
     return (summand / z2, summand / z1, summand / z3)
 
 
-def apply_transformer_t_model(network: Network) -> None:
+def apply_transformer_t_model(n: Network) -> None:
     """
     Convert given T-model parameters to PI-model parameters using wye-delta
     transformation.
     """
-    z_series = network.transformers.r_pu + 1j * network.transformers.x_pu
-    y_shunt = network.transformers.g_pu + 1j * network.transformers.b_pu
+    z_series = n.transformers.r_pu + 1j * n.transformers.x_pu
+    y_shunt = n.transformers.g_pu + 1j * n.transformers.b_pu
 
-    ts_b = (network.transformers.model == "t") & (y_shunt != 0.0)
+    ts_b = (n.transformers.model == "t") & (y_shunt != 0.0)
 
     if ts_b.zsum() == 0:
         return
@@ -993,65 +974,49 @@ def apply_transformer_t_model(network: Network) -> None:
         z_series.loc[ts_b] / 2, z_series.loc[ts_b] / 2, 1 / y_shunt.loc[ts_b]
     )
 
-    network.transformers.loc[ts_b, "r_pu"] = real(zc)
-    network.transformers.loc[ts_b, "x_pu"] = imag(zc)
-    network.transformers.loc[ts_b, "g_pu"] = real(2 / za)
-    network.transformers.loc[ts_b, "b_pu"] = imag(2 / za)
+    n.transformers.loc[ts_b, "r_pu"] = real(zc)
+    n.transformers.loc[ts_b, "x_pu"] = imag(zc)
+    n.transformers.loc[ts_b, "g_pu"] = real(2 / za)
+    n.transformers.loc[ts_b, "b_pu"] = imag(2 / za)
 
 
-def calculate_dependent_values(network: Network) -> None:
+def calculate_dependent_values(n: Network) -> None:
     """
     Calculate per unit impedances and append voltages to lines and shunt
     impedances.
     """
-    apply_line_types(network)
-    apply_transformer_types(network)
+    apply_line_types(n)
+    apply_transformer_types(n)
 
-    network.lines["v_nom"] = network.lines.bus0.map(network.buses.v_nom)
-    network.lines.loc[network.lines.carrier == "", "carrier"] = network.lines.bus0.map(
-        network.buses.carrier
-    )
+    n.lines["v_nom"] = n.lines.bus0.map(n.buses.v_nom)
+    n.lines.loc[n.lines.carrier == "", "carrier"] = n.lines.bus0.map(n.buses.carrier)
 
-    network.lines["x_pu"] = network.lines.x / (network.lines.v_nom**2)
-    network.lines["r_pu"] = network.lines.r / (network.lines.v_nom**2)
-    network.lines["b_pu"] = network.lines.b * network.lines.v_nom**2
-    network.lines["g_pu"] = network.lines.g * network.lines.v_nom**2
-    network.lines["x_pu_eff"] = network.lines["x_pu"]
-    network.lines["r_pu_eff"] = network.lines["r_pu"]
+    n.lines["x_pu"] = n.lines.x / (n.lines.v_nom**2)
+    n.lines["r_pu"] = n.lines.r / (n.lines.v_nom**2)
+    n.lines["b_pu"] = n.lines.b * n.lines.v_nom**2
+    n.lines["g_pu"] = n.lines.g * n.lines.v_nom**2
+    n.lines["x_pu_eff"] = n.lines["x_pu"]
+    n.lines["r_pu_eff"] = n.lines["r_pu"]
 
     # convert transformer impedances from base power s_nom to base = 1 MVA
-    network.transformers["x_pu"] = network.transformers.x / network.transformers.s_nom
-    network.transformers["r_pu"] = network.transformers.r / network.transformers.s_nom
-    network.transformers["b_pu"] = network.transformers.b * network.transformers.s_nom
-    network.transformers["g_pu"] = network.transformers.g * network.transformers.s_nom
-    network.transformers["x_pu_eff"] = (
-        network.transformers["x_pu"] * network.transformers["tap_ratio"]
-    )
-    network.transformers["r_pu_eff"] = (
-        network.transformers["r_pu"] * network.transformers["tap_ratio"]
-    )
+    n.transformers["x_pu"] = n.transformers.x / n.transformers.s_nom
+    n.transformers["r_pu"] = n.transformers.r / n.transformers.s_nom
+    n.transformers["b_pu"] = n.transformers.b * n.transformers.s_nom
+    n.transformers["g_pu"] = n.transformers.g * n.transformers.s_nom
+    n.transformers["x_pu_eff"] = n.transformers["x_pu"] * n.transformers["tap_ratio"]
+    n.transformers["r_pu_eff"] = n.transformers["r_pu"] * n.transformers["tap_ratio"]
 
-    apply_transformer_t_model(network)
+    apply_transformer_t_model(n)
 
-    network.shunt_impedances["v_nom"] = network.shunt_impedances["bus"].map(
-        network.buses.v_nom
-    )
-    network.shunt_impedances["b_pu"] = (
-        network.shunt_impedances.b * network.shunt_impedances.v_nom**2
-    )
-    network.shunt_impedances["g_pu"] = (
-        network.shunt_impedances.g * network.shunt_impedances.v_nom**2
-    )
+    n.shunt_impedances["v_nom"] = n.shunt_impedances["bus"].map(n.buses.v_nom)
+    n.shunt_impedances["b_pu"] = n.shunt_impedances.b * n.shunt_impedances.v_nom**2
+    n.shunt_impedances["g_pu"] = n.shunt_impedances.g * n.shunt_impedances.v_nom**2
 
-    network.links.loc[network.links.carrier == "", "carrier"] = network.links.bus0.map(
-        network.buses.carrier
-    )
+    n.links.loc[n.links.carrier == "", "carrier"] = n.links.bus0.map(n.buses.carrier)
 
-    network.stores.loc[network.stores.carrier == "", "carrier"] = (
-        network.stores.bus.map(network.buses.carrier)
-    )
+    n.stores.loc[n.stores.carrier == "", "carrier"] = n.stores.bus.map(n.buses.carrier)
 
-    update_linkports_component_attrs(network)
+    update_linkports_component_attrs(n)
 
 
 def find_slack_bus(sub_network: SubNetwork) -> None:
@@ -1070,9 +1035,9 @@ def find_slack_bus(sub_network: SubNetwork) -> None:
 
         if len(slacks) == 0:
             sub_network.slack_generator = gens.index[0]
-            sub_network.network.generators.loc[
-                sub_network.slack_generator, "control"
-            ] = "Slack"
+            sub_network.n.generators.loc[sub_network.slack_generator, "control"] = (
+                "Slack"
+            )
             logger.debug(
                 f"No slack generator found in sub-network {sub_network.name}, using {sub_network.slack_generator} as the slack generator"
             )
@@ -1081,7 +1046,7 @@ def find_slack_bus(sub_network: SubNetwork) -> None:
             sub_network.slack_generator = slacks[0]
         else:
             sub_network.slack_generator = slacks[0]
-            sub_network.network.generators.loc[slacks[1:], "control"] = "PV"
+            sub_network.n.generators.loc[slacks[1:], "control"] = "PV"
             logger.debug(
                 f"More than one slack generator found in sub-network {sub_network.name}, using {sub_network.slack_generator} as the slack generator"
             )
@@ -1089,9 +1054,7 @@ def find_slack_bus(sub_network: SubNetwork) -> None:
         sub_network.slack_bus = gens.bus[sub_network.slack_generator]
 
     # also put it into the dataframe
-    sub_network.network.sub_networks.at[sub_network.name, "slack_bus"] = (
-        sub_network.slack_bus
-    )
+    sub_network.n.sub_networks.at[sub_network.name, "slack_bus"] = sub_network.slack_bus
 
     logger.debug(
         f"Slack bus for sub-network {sub_network.name} is {sub_network.slack_bus}"
@@ -1105,7 +1068,7 @@ def find_bus_controls(sub_network: SubNetwork) -> None:
     This function also fixes sub_network.buses_o, a DataFrame ordered by
     control type.
     """
-    network = sub_network.network
+    n = sub_network.n
 
     find_slack_bus(sub_network)
 
@@ -1113,19 +1076,19 @@ def find_bus_controls(sub_network: SubNetwork) -> None:
     buses_i = sub_network.buses_i()
 
     # default bus control is PQ
-    network.buses.loc[buses_i, "control"] = "PQ"
+    n.buses.loc[buses_i, "control"] = "PQ"
 
     # find all buses with one or more gens with PV
     pvs = gens[gens.control == "PV"].index.to_series()
     if len(pvs) > 0:
         pvs = pvs.groupby(gens.bus).first()
-        network.buses.loc[pvs.index, "control"] = "PV"
-        network.buses.loc[pvs.index, "generator"] = pvs
+        n.buses.loc[pvs.index, "control"] = "PV"
+        n.buses.loc[pvs.index, "generator"] = pvs
 
-    network.buses.loc[sub_network.slack_bus, "control"] = "Slack"
-    network.buses.loc[sub_network.slack_bus, "generator"] = sub_network.slack_generator
+    n.buses.loc[sub_network.slack_bus, "control"] = "Slack"
+    n.buses.loc[sub_network.slack_bus, "generator"] = sub_network.slack_generator
 
-    buses_control = network.buses.loc[buses_i, "control"]
+    buses_control = n.buses.loc[buses_i, "control"]
     sub_network.pvs = buses_control.index[buses_control == "PV"]
     sub_network.pqs = buses_control.index[buses_control == "PQ"]
 
@@ -1139,13 +1102,13 @@ def calculate_B_H(sub_network: SubNetwork, skip_pre: bool = False) -> None:
     """
     Calculate B and H matrices for AC or DC sub-networks.
     """
-    network = sub_network.network
+    n = sub_network.n
 
     if not skip_pre:
-        calculate_dependent_values(network)
+        calculate_dependent_values(n)
         find_bus_controls(sub_network)
 
-    if network.sub_networks.at[sub_network.name, "carrier"] == "DC":
+    if n.sub_networks.at[sub_network.name, "carrier"] == "DC":
         attribute = "r_pu_eff"
     else:
         attribute = "x_pu_eff"
@@ -1155,7 +1118,7 @@ def calculate_B_H(sub_network: SubNetwork, skip_pre: bool = False) -> None:
     z = np.concatenate(
         [
             (c.df.loc[c.df.query("active").index, attribute]).values
-            for c in sub_network.iterate_components(network.passive_branch_components)
+            for c in sub_network.iterate_components(n.passive_branch_components)
         ]
     )
     # susceptances
@@ -1184,7 +1147,7 @@ def calculate_B_H(sub_network: SubNetwork, skip_pre: bool = False) -> None:
                 if c.name == "Transformer"
                 else np.zeros((len(c.df.query("active").index),))
             )
-            for c in sub_network.iterate_components(network.passive_branch_components)
+            for c in sub_network.iterate_components(n.passive_branch_components)
         ]
     )
     sub_network.p_branch_shift = np.multiply(-b, phase_shift, where=b != np.inf)
@@ -1237,9 +1200,9 @@ def calculate_Y(
     Calculate bus admittance matrices for AC sub-networks.
     """
     if not skip_pre:
-        calculate_dependent_values(sub_network.network)
+        calculate_dependent_values(sub_network.n)
 
-    if sub_network.network.sub_networks.at[sub_network.name, "carrier"] != "AC":
+    if sub_network.n.sub_networks.at[sub_network.name, "carrier"] != "AC":
         logger.warning("Non-AC networks not supported for Y!")
         return
 
@@ -1249,7 +1212,7 @@ def calculate_Y(
     if active_branches_only:
         branches = branches[branches.active]
 
-    network = sub_network.network
+    n = sub_network.n
 
     # following leans heavily on pypower.makeYbus
     # Copyright Richard Lincoln, Ray Zimmerman, BSD-style licence
@@ -1284,12 +1247,12 @@ def calculate_Y(
 
     # bus shunt impedances
     b_sh = (
-        network.shunt_impedances.b_pu.groupby(network.shunt_impedances.bus)
+        n.shunt_impedances.b_pu.groupby(n.shunt_impedances.bus)
         .sum()
         .reindex(buses_o, fill_value=0.0)
     )
     g_sh = (
-        network.shunt_impedances.g_pu.groupby(network.shunt_impedances.bus)
+        n.shunt_impedances.g_pu.groupby(n.shunt_impedances.bus)
         .sum()
         .reindex(buses_o, fill_value=0.0)
     )
@@ -1330,7 +1293,7 @@ def aggregate_multi_graph(sub_network: SubNetwork) -> None:
     Aggregate branches between same buses and replace with a single branch with
     aggregated properties (e.g. s_nom is summed, length is averaged).
     """
-    network = sub_network.network
+    n = sub_network.n
 
     count = 0
     seen = []
@@ -1340,7 +1303,7 @@ def aggregate_multi_graph(sub_network: SubNetwork) -> None:
             continue
         line_objs = list(graph.adj[u][v].keys())
         if len(line_objs) > 1:
-            lines = network.lines.loc[[line[1] for line in line_objs]]
+            lines = n.lines.loc[[line[1] for line in line_objs]]
             attr_inv = ["x", "r"]
             attr_sum = ["s_nom", "b", "g", "s_nom_max", "s_nom_min"]
             attr_mean = ["capital_cost", "length", "terrain_factor"]
@@ -1356,7 +1319,7 @@ def aggregate_multi_graph(sub_network: SubNetwork) -> None:
 
             # remove all but first line
             for line in line_objs[1:]:
-                network.remove("Line", line[1])
+                n.remove("Line", line[1])
 
             rep = line_objs[0]
 
@@ -1464,8 +1427,8 @@ def sub_network_lpf(
     Parameters
     ----------
     snapshots : list-like|single snapshot
-        A subset or an elements of network.snapshots on which to run
-        the power flow, defaults to network.snapshots
+        A subset or an elements of n.snapshots on which to run
+        the power flow, defaults to n.snapshots
     skip_pre : bool, default False
         Skip the preliminary steps of computing topology, calculating
         dependent values and finding bus controls.
@@ -1474,20 +1437,20 @@ def sub_network_lpf(
     -------
     None
     """
-    sns = as_index(sub_network.network, snapshots, "snapshots", "snapshot")
+    sns = as_index(sub_network.n, snapshots, "snapshots", "snapshot")
     logger.info(
         "Performing linear load-flow on %s sub-network %s for snapshot(s) %s",
-        sub_network.network.sub_networks.at[sub_network.name, "carrier"],
+        sub_network.n.sub_networks.at[sub_network.name, "carrier"],
         sub_network,
         snapshots,
     )
 
-    network = sub_network.network
+    n = sub_network.n
 
     if not skip_pre:
-        calculate_dependent_values(network)
+        calculate_dependent_values(n)
         find_bus_controls(sub_network)
-        _allocate_pf_outputs(network, linear=True)
+        _allocate_pf_outputs(n, linear=True)
 
     # get indices for the components on this subnetwork
     buses_o = sub_network.buses_o
@@ -1495,19 +1458,17 @@ def sub_network_lpf(
 
     # allow all shunt impedances to dispatch as set
     shunt_impedances_i = sub_network.shunt_impedances_i()
-    network.shunt_impedances_t.p.loc[sns, shunt_impedances_i] = (
-        network.shunt_impedances.g_pu.loc[shunt_impedances_i].values
-    )
+    n.shunt_impedances_t.p.loc[sns, shunt_impedances_i] = n.shunt_impedances.g_pu.loc[
+        shunt_impedances_i
+    ].values
 
     # allow all one ports to dispatch as set
-    for c in sub_network.iterate_components(network.controllable_one_port_components):
-        c_p_set = get_as_dense(
-            network, c.name, "p_set", sns, c.df.query("active").index
-        )
-        network.pnl(c.name).p.loc[sns, c.df.query("active").index] = c_p_set
+    for c in sub_network.iterate_components(n.controllable_one_port_components):
+        c_p_set = get_as_dense(n, c.name, "p_set", sns, c.df.query("active").index)
+        n.pnl(c.name).p.loc[sns, c.df.query("active").index] = c_p_set
 
     # set the power injection at each node
-    network.buses_t.p.loc[sns, buses_o] = sum(
+    n.buses_t.p.loc[sns, buses_o] = sum(
         [
             (
                 (
@@ -1518,7 +1479,7 @@ def sub_network_lpf(
                 .sum()
                 .T.reindex(columns=buses_o, fill_value=0.0)
             )
-            for c in sub_network.iterate_components(network.one_port_components)
+            for c in sub_network.iterate_components(n.one_port_components)
         ]
         + [
             -c.pnl[f"p{str(i)}"]
@@ -1526,7 +1487,7 @@ def sub_network_lpf(
             .T.groupby(c.df[f"bus{str(i)}"])
             .sum()
             .T.reindex(columns=buses_o, fill_value=0)
-            for c in network.iterate_components(network.controllable_branch_components)
+            for c in n.iterate_components(n.controllable_branch_components)
             for i in [int(col[3:]) for col in c.df.columns if col[:3] == "bus"]
         ]
     )
@@ -1536,40 +1497,40 @@ def sub_network_lpf(
 
     v_diff = np.zeros((len(sns), len(buses_o)))
     if len(branches_i) > 0:
-        p = network.buses_t["p"].loc[sns, buses_o].values - sub_network.p_bus_shift
+        p = n.buses_t["p"].loc[sns, buses_o].values - sub_network.p_bus_shift
         v_diff[:, 1:] = spsolve(sub_network.B[1:, 1:], p[:, 1:].T).T
         flows = (
             pd.DataFrame(v_diff * sub_network.H.T, columns=branches_i, index=sns)
             + sub_network.p_branch_shift
         )
 
-        for c in sub_network.iterate_components(network.passive_branch_components):
+        for c in sub_network.iterate_components(n.passive_branch_components):
             f = flows.loc[:, c.name]
-            network.pnl(c.name).p0.loc[sns, f.columns] = f
-            network.pnl(c.name).p1.loc[sns, f.columns] = -f
+            n.pnl(c.name).p0.loc[sns, f.columns] = f
+            n.pnl(c.name).p1.loc[sns, f.columns] = -f
 
-    if network.sub_networks.at[sub_network.name, "carrier"] == "DC":
-        network.buses_t.v_mag_pu.loc[sns, buses_o] = 1 + v_diff
-        network.buses_t.v_ang.loc[sns, buses_o] = 0.0
+    if n.sub_networks.at[sub_network.name, "carrier"] == "DC":
+        n.buses_t.v_mag_pu.loc[sns, buses_o] = 1 + v_diff
+        n.buses_t.v_ang.loc[sns, buses_o] = 0.0
     else:
-        network.buses_t.v_ang.loc[sns, buses_o] = v_diff
-        network.buses_t.v_mag_pu.loc[sns, buses_o] = 1.0
+        n.buses_t.v_ang.loc[sns, buses_o] = v_diff
+        n.buses_t.v_mag_pu.loc[sns, buses_o] = 1.0
 
     # set slack bus power to pick up remained
     slack_adjustment = (
-        -network.buses_t.p.loc[sns, buses_o[1:]].sum(axis=1).fillna(0.0)
-        - network.buses_t.p.loc[sns, buses_o[0]]
+        -n.buses_t.p.loc[sns, buses_o[1:]].sum(axis=1).fillna(0.0)
+        - n.buses_t.p.loc[sns, buses_o[0]]
     )
-    network.buses_t.p.loc[sns, buses_o[0]] += slack_adjustment
+    n.buses_t.p.loc[sns, buses_o[0]] += slack_adjustment
 
     # let slack generator take up the slack
     if sub_network.slack_generator is not None:
-        network.generators_t.p.loc[sns, sub_network.slack_generator] += (
+        n.generators_t.p.loc[sns, sub_network.slack_generator] += (
             slack_adjustment
         )  # fmt: skip
 
 
-def network_batch_lpf(network: Network, snapshots: Sequence | None = None) -> None:
+def network_batch_lpf(n: Network, snapshots: Sequence | None = None) -> None:
     """
     Batched linear power flow with numpy.dot for several snapshots.
     """

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -895,8 +895,8 @@ def autogenerate_coordinates(n, assign=False, layouter=None):
 
     Examples
     --------
-    >>> autogenerate_coordinates(network)
-    >>> autogenerate_coordinates(network, assign=True, layouter=nx.circle_layout)
+    >>> autogenerate_coordinates(n)
+    >>> autogenerate_coordinates(n, assign=True, layouter=nx.circle_layout)
 
     """
     G = n.graph()

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -379,7 +379,7 @@ def plot(
     arrow_collections = []
 
     if flow is not None:
-        rough_scale = sum(len(n.df(c)) for c in branch_components) + 100
+        rough_scale = sum(len(n.static(c)) for c in branch_components) + 100
         flow = _flow_ds_from_arg(flow, n, branch_components) / rough_scale
 
     for c in n.iterate_components(branch_components):
@@ -394,7 +394,7 @@ def plot(
         if any([isinstance(v, pd.Series) for _, v in d.items()]):
             df = pd.DataFrame(d)
         else:
-            df = pd.DataFrame(d, index=c.df.index)
+            df = pd.DataFrame(d, index=c.static.index)
 
         if df.empty:
             continue
@@ -414,15 +414,15 @@ def plot(
         if not geometry:
             segments = np.asarray(
                 (
-                    (c.df.bus0[df.index].map(x), c.df.bus0[df.index].map(y)),
-                    (c.df.bus1[df.index].map(x), c.df.bus1[df.index].map(y)),
+                    (c.static.bus0[df.index].map(x), c.static.bus0[df.index].map(y)),
+                    (c.static.bus1[df.index].map(x), c.static.bus1[df.index].map(y)),
                 )
             ).transpose(2, 0, 1)
         else:
             from shapely.geometry import LineString
             from shapely.wkt import loads
 
-            linestrings = c.df.geometry[lambda ds: ds != ""].map(loads)
+            linestrings = c.static.geometry[lambda ds: ds != ""].map(loads)
             if not all(isinstance(ls, LineString) for ls in linestrings):
                 msg = "The WKT-encoded geometry in the 'geometry' column must be "
                 "composed of LineStrings"
@@ -432,10 +432,10 @@ def plot(
         if b_flow is not None:
             coords = pd.DataFrame(
                 {
-                    "x1": c.df.bus0.map(x),
-                    "y1": c.df.bus0.map(y),
-                    "x2": c.df.bus1.map(x),
-                    "y2": c.df.bus1.map(y),
+                    "x1": c.static.bus0.map(x),
+                    "y1": c.static.bus0.map(y),
+                    "x2": c.static.bus1.map(x),
+                    "y2": c.static.bus1.map(y),
                 }
             )
             b_flow = b_flow.mul(b_widths.abs(), fill_value=0)
@@ -475,7 +475,7 @@ def plot(
 
 
 def as_branch_series(ser, arg, c, n):
-    ser = pd.Series(ser, index=n.df(c).index)
+    ser = pd.Series(ser, index=n.static(c).index)
     if ser.isnull().any():
         msg = f"{c}_{arg}s does not specify all "
         f"entries. Missing values for {c}: {list(ser[ser.isnull()].index)}"
@@ -1142,14 +1142,14 @@ def iplot(
         b_text = branch_text[c.name]
 
         if b_text is None:
-            b_text = c.name + " " + c.df.index
+            b_text = c.name + " " + c.static.index
 
-        x0 = c.df.bus0.map(x)
-        x1 = c.df.bus1.map(x)
-        y0 = c.df.bus0.map(y)
-        y1 = c.df.bus1.map(y)
+        x0 = c.static.bus0.map(x)
+        x1 = c.static.bus1.map(x)
+        y0 = c.static.bus0.map(y)
+        y1 = c.static.bus1.map(y)
 
-        for b in c.df.index:
+        for b in c.static.index:
             shapes.append(
                 dict(
                     type="line",

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -795,15 +795,15 @@ def _flow_ds_from_arg(flow, n, branch_components):
     if flow in n.snapshots:
         return pd.concat(
             {
-                c: n.pnl(c).p0.loc[flow]
+                c: n.dynamic(c).p0.loc[flow]
                 for c in branch_components
-                if not n.pnl(c).p0.empty
+                if not n.dynamic(c).p0.empty
             },
             sort=True,
         )
     if isinstance(flow, str) or callable(flow):
         return pd.concat(
-            [n.pnl(c).p0 for c in branch_components],
+            [n.dynamic(c).p0 for c in branch_components],
             axis=1,
             keys=branch_components,
             sort=True,

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -24,9 +24,9 @@ def get_carrier(n: Network, c: str, nice_names: bool = True) -> pd.Series:
     """
     Get the nice carrier names for a component.
     """
-    df = n.df(c)
-    fall_back = pd.Series("", index=df.index)
-    carrier_series = df.get("carrier", fall_back).rename("carrier")
+    static = n.static(c)
+    fall_back = pd.Series("", index=static.index)
+    carrier_series = static.get("carrier", fall_back).rename("carrier")
     if nice_names:
         carrier_series = carrier_series.replace(
             n.carriers.nice_name[lambda ds: ds != ""]
@@ -42,7 +42,7 @@ def get_bus_carrier(
     """
     bus = f"bus{port}"
     buses_carrier = get_carrier(n, "Bus", nice_names=nice_names)
-    return n.df(c)[bus].map(buses_carrier).rename("bus_carrier")
+    return n.static(c)[bus].map(buses_carrier).rename("bus_carrier")
 
 
 def get_bus_and_carrier(
@@ -52,7 +52,7 @@ def get_bus_and_carrier(
     Get the buses and nice carrier names for a component.
     """
     bus = f"bus{port}"
-    return [n.df(c)[bus].rename("bus"), get_carrier(n, c, nice_names=nice_names)]
+    return [n.static(c)[bus].rename("bus"), get_carrier(n, c, nice_names=nice_names)]
 
 
 def get_bus_unit_and_carrier(
@@ -63,8 +63,8 @@ def get_bus_unit_and_carrier(
     """
     bus = f"bus{port}"
     return [
-        n.df(c)[bus].rename("bus"),
-        n.df(c)[bus].map(n.buses.unit).rename("unit"),
+        n.static(c)[bus].rename("bus"),
+        n.static(c)[bus].map(n.buses.unit).rename("unit"),
         get_carrier(n, c, nice_names=nice_names),
     ]
 
@@ -76,7 +76,7 @@ def get_name_bus_and_carrier(
     Get the name, buses and nice carrier names for a component.
     """
     return [
-        n.df(c).index.to_series().rename("name"),
+        n.static(c).index.to_series().rename("name"),
         *get_bus_and_carrier(n, c, port, nice_names=nice_names),
     ]
 
@@ -147,9 +147,9 @@ def port_efficiency(n: Network, c: str, port: str = "") -> float:
     elif port == "0":
         efficiency = -1
     elif port == "1":
-        efficiency = n.df(c).get("efficiency", 1)
+        efficiency = n.static(c).get("efficiency", 1)
     else:
-        efficiency = n.df(c).get(f"efficiency{port}", 1)
+        efficiency = n.static(c).get(f"efficiency{port}", 1)
     return efficiency
 
 
@@ -162,7 +162,9 @@ def get_transmission_branches(
     """
     index = {}
     for c in n.branch_components:
-        bus_map = n.df(c).filter(like="bus").apply(lambda ds: ds.map(n.buses.carrier))
+        bus_map = (
+            n.static(c).filter(like="bus").apply(lambda ds: ds.map(n.buses.carrier))
+        )
         if isinstance(bus_carrier, str):
             bus_carrier = [bus_carrier]
         elif bus_carrier is None:
@@ -189,7 +191,7 @@ def get_transmission_carriers(
     carriers = {}
     for c in branches.unique(0):
         idx = branches[branches.get_loc(c)].get_level_values(1)
-        carriers[c] = n.df(c).carrier[idx].unique()
+        carriers[c] = n.static(c).carrier[idx].unique()
     return pd.MultiIndex.from_tuples(
         [(c, i) for c, idx in carriers.items() for i in idx],
         names=["component", "carrier"],
@@ -211,9 +213,9 @@ def get_grouping(
         else:
             by = groupby(n, c, nice_names=nice_names)
     elif isinstance(groupby, list):
-        by = [n.df(c)[key] for key in groupby]
+        by = [n.static(c)[key] for key in groupby]
     elif isinstance(groupby, str):
-        by = n.df(c)[groupby]
+        by = n.static(c)[groupby]
     elif groupby is not False:
         raise ValueError(
             f"Argument `groupby` must be a function, list, string, False or dict, got {type(groupby)}"
@@ -276,7 +278,7 @@ def filter_bus_carrier(
     if bus_carrier is None:
         return df
 
-    ports = n.df(c).loc[df.index, f"bus{port}"]
+    ports = n.static(c).loc[df.index, f"bus{port}"]
     port_carriers = ports.map(n.buses.carrier)
     if isinstance(bus_carrier, str):
         if bus_carrier in n.buses.carrier.unique():
@@ -410,10 +412,10 @@ class StatisticsAccessor:
         if nice_names is None:
             nice_names = self.parameters.nice_names
         for c in comps:
-            if n.df(c).empty:
+            if n.static(c).empty:
                 continue
 
-            ports = [col[3:] for col in n.df(c) if col.startswith("bus")]
+            ports = [col[3:] for col in n.static(c) if col.startswith("bus")]
             if not at_port:
                 ports = [ports[0]]
 
@@ -548,7 +550,7 @@ class StatisticsAccessor:
 
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
-            col = n.df(c).eval(f"{nominal_attrs[c]}_opt * {cost_attribute}")
+            col = n.static(c).eval(f"{nominal_attrs[c]}_opt * {cost_attribute}")
             return col
 
         df = self._aggregate_components(
@@ -589,7 +591,7 @@ class StatisticsAccessor:
 
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
-            col = n.df(c).eval(f"{nominal_attrs[c]} * {cost_attribute}")
+            col = n.static(c).eval(f"{nominal_attrs[c]} * {cost_attribute}")
             return col
 
         df = self._aggregate_components(
@@ -685,9 +687,9 @@ class StatisticsAccessor:
             efficiency = port_efficiency(n, c, port=port)
             if not at_port:
                 efficiency = abs(efficiency)
-            col = n.df(c)[f"{nominal_attrs[c]}_opt"] * efficiency
+            col = n.static(c)[f"{nominal_attrs[c]}_opt"] * efficiency
             if storage and (c == "StorageUnit"):
-                col = col * n.df(c).max_hours
+                col = col * n.static(c).max_hours
             return col
 
         df = self._aggregate_components(
@@ -737,9 +739,9 @@ class StatisticsAccessor:
             efficiency = port_efficiency(n, c, port=port)
             if not at_port:
                 efficiency = abs(efficiency)
-            col = n.df(c)[f"{nominal_attrs[c]}"] * efficiency
+            col = n.static(c)[f"{nominal_attrs[c]}"] * efficiency
             if storage and (c == "StorageUnit"):
-                col = col * n.df(c).max_hours
+                col = col * n.static(c).max_hours
             return col
 
         df = self._aggregate_components(
@@ -1011,7 +1013,7 @@ class StatisticsAccessor:
 
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
-            sign = -1.0 if c in n.branch_components else n.df(c).get("sign", 1.0)
+            sign = -1.0 if c in n.branch_components else n.static(c).get("sign", 1.0)
             weights = get_weightings(n, c)
             p = sign * n.pnl(c)[f"p{port}"]
             if kind == "supply":
@@ -1071,7 +1073,7 @@ class StatisticsAccessor:
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
             p = (
-                n.get_switchable_as_dense(c, "p_max_pu") * n.df(c).p_nom_opt
+                n.get_switchable_as_dense(c, "p_max_pu") * n.static(c).p_nom_opt
                 - n.pnl(c).p
             ).clip(lower=0)
             weights = get_weightings(n, c)
@@ -1175,9 +1177,9 @@ class StatisticsAccessor:
 
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
-            sign = -1.0 if c in n.branch_components else n.df(c).get("sign", 1.0)
+            sign = -1.0 if c in n.branch_components else n.static(c).get("sign", 1.0)
             df = sign * n.pnl(c)[f"p{port}"]
-            buses = n.df(c)[f"bus{port}"][df.columns]
+            buses = n.static(c)[f"bus{port}"][df.columns]
             prices = n.buses_t.marginal_price.reindex(
                 columns=buses, fill_value=0
             ).values

--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -371,8 +371,8 @@ class StatisticsAccessor:
     Accessor to calculate different statistical values.
     """
 
-    def __init__(self, network: Network) -> None:
-        self._parent = network
+    def __init__(self, n: Network) -> None:
+        self.n = n
         self.groupers = Groupers()  # Create an instance of the Groupers class
         self.parameters = Parameters()  # Create an instance of the Parameters class
 
@@ -380,7 +380,7 @@ class StatisticsAccessor:
         """
         Setting the parameters for the statistics accessor.
 
-        To see the list of parameters, one can simply call `network.statistics.parameters`.
+        To see the list of parameters, one can simply call `n.statistics.parameters`.
         """
         self.parameters.set_parameters(**kwargs)
 
@@ -399,7 +399,7 @@ class StatisticsAccessor:
         """
         df: pd.DataFrame
         d = {}
-        n = self._parent
+        n = self.n
 
         if is_one_component := isinstance(comps, str):
             comps = [comps]
@@ -944,7 +944,7 @@ class StatisticsAccessor:
             Note that for {'mean', 'sum'} the time series are aggregated to MWh
             using snapshot weightings. With False the time series is given in MW. Defaults to 'sum'.
         """
-        n = self._parent
+        n = self.n
 
         if comps is None:
             comps = n.branch_components
@@ -998,7 +998,7 @@ class StatisticsAccessor:
             Note that for {'mean', 'sum'} the time series are aggregated to MWh
             using snapshot weightings. With False the time series is given in MW. Defaults to 'sum'.
         """
-        n = self._parent
+        n = self.n
 
         if (
             n.buses.carrier.unique().size > 1

--- a/pypsa/utils.py
+++ b/pypsa/utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import functools
+import warnings
+from typing import TYPE_CHECKING, Any, Callable
 
 import pandas as pd
 from pandas.api.types import is_list_like
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
 
 
 def as_index(
-    network: Network,
+    n: Network,
     values: Any,
     network_attribute: str,
     index_name: str | None,
@@ -23,7 +25,7 @@ def as_index(
 
     Parameters
     ----------
-    network : pypsa.Network
+    n : pypsa.Network
         Network object from which to extract the default values.
     values : Any
         List-like or scalar object or None.
@@ -40,7 +42,7 @@ def as_index(
     """
 
     if values is None:
-        values_ = getattr(network, network_attribute)
+        values_ = getattr(n, network_attribute)
     elif isinstance(values, (pd.Index, pd.MultiIndex)):
         values_ = values
     elif not is_list_like(values):
@@ -49,7 +51,94 @@ def as_index(
         values_ = pd.Index(values)
     values_.name = index_name
 
-    assert values_.isin(getattr(network, network_attribute)).all()
+    assert values_.isin(getattr(n, network_attribute)).all()
     assert isinstance(values_, pd.Index)
 
     return values_
+
+
+def deprecated_kwargs(**aliases: str) -> Callable:
+    """
+    Decorator for deprecated function and method arguments.
+    Based on solution from [here](https://stackoverflow.com/questions/49802412).
+
+    Parameters
+    ----------
+    aliases : dict
+        A mapping of old argument names to new argument names.
+
+    Returns
+    -------
+    Callable
+        A decorator that renames the old arguments to the new arguments.
+
+    Examples
+    --------
+    >>> @deprecated_alias(object_id="id_object")
+    ... def __init__(self, id_object):
+    """
+
+    def deco(f: Callable) -> Callable:
+        @functools.wraps(f)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            rename_kwargs(f.__name__, kwargs, aliases)
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return deco
+
+
+def rename_kwargs(
+    func_name: str, kwargs: dict[str, Any], aliases: dict[str, str]
+) -> None:
+    """
+    Helper function for deprecating function arguments.
+
+    Based on solution from [here](https://stackoverflow.com/questions/49802412).
+
+    Parameters
+    ----------
+    func_name : str
+        The name of the function.
+    kwargs : dict
+        The keyword arguments of the function.
+    aliases : dict
+        A mapping of old argument names to new argument names.
+
+    """
+
+    for alias, new in aliases.items():
+        if alias in kwargs:
+            if new in kwargs:
+                raise TypeError(
+                    f"{func_name} received both {alias} and {new} as arguments!"
+                    f" {alias} is deprecated, use {new} instead."
+                )
+            warnings.warn(
+                message=(
+                    f"`{alias}` is deprecated as an argument to `{func_name}`; use"
+                    f" `{new}` instead."
+                ),
+                category=DeprecationWarning,
+                stacklevel=3,
+            )
+            kwargs[new] = kwargs.pop(alias)
+
+
+def deprecated_common_kwargs(f: Callable) -> Callable:
+    """
+    Decorator that predefines the 'a' keyword to be renamed to 'b'.
+    This allows its usage as `@deprecated_ab` without parentheses.
+
+    Parameters
+    ----------
+    f : Callable
+        The function we are decorating.
+
+    Returns
+    -------
+    Callable
+        A decorated function that renames 'a' to 'b'.
+    """
+    return deprecated_kwargs(network="n")(f)

--- a/test/test_bugs.py
+++ b/test/test_bugs.py
@@ -24,7 +24,7 @@ def test_890():
     nc = n.cluster.cluster_by_busmap(busmap)
 
     C = n.cluster.get_clustering_from_busmap(busmap)
-    nc = C.network
+    nc = C.n
 
     almost_equal(n.investment_periods, nc.investment_periods)
     almost_equal(n.investment_period_weightings, nc.investment_period_weightings)

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -8,8 +8,8 @@ from pypsa.components import Component
 @pytest.fixture
 def sample_network():
     # Create a sample network object
-    network = Network()
-    return network
+    n = Network()
+    return n
 
 
 @pytest.fixture

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -16,7 +16,7 @@ def sample_network():
 def sample_component(sample_network):
     # Create a sample component object
     data = {"active": [True, False, True], "other_attr": [1, 2, 3]}
-    df = pd.DataFrame(data, index=["asset1", "asset2", "asset3"])
+    static = pd.DataFrame(data, index=["asset1", "asset2", "asset3"])
     pnl = {"time_series": pd.DataFrame({"value": [0.1, 0.2, 0.3]})}
     attrs = pd.DataFrame({"attr1": ["metadata1"], "attr2": ["metadata2"]})
 
@@ -25,7 +25,7 @@ def sample_component(sample_network):
         list_name="generators",
         investment_periods=sample_network.investment_periods,
         attrs=attrs,
-        df=df,
+        static=static,
         pnl=pnl,
         ind=None,
     )
@@ -37,7 +37,7 @@ def test_component_initialization(sample_component):
     assert component.name == "Generator"
     assert component.list_name == "generators"
     assert "attr1" in component.attrs
-    assert component.df.shape == (3, 2)
+    assert component.static.shape == (3, 2)
     assert "time_series" in component.pnl
 
 
@@ -46,12 +46,12 @@ def test_component_repr(sample_component):
     repr_str = repr(component)
     assert "Component(name='Generator'" in repr_str
     assert "list_name='generators'" in repr_str
-    assert "df=DataFrame(shape=(3, 2))" in repr_str
+    assert "static=DataFrame(shape=(3, 2))" in repr_str
 
 
 def test_active_assets(sample_component):
     component = sample_component
-    active_assets = component.df.query("active").index
+    active_assets = component.static.query("active").index
     assert len(active_assets) == 2
     assert "asset1" in active_assets
     assert "asset3" in active_assets

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -17,7 +17,7 @@ def sample_component(sample_network):
     # Create a sample component object
     data = {"active": [True, False, True], "other_attr": [1, 2, 3]}
     static = pd.DataFrame(data, index=["asset1", "asset2", "asset3"])
-    pnl = {"time_series": pd.DataFrame({"value": [0.1, 0.2, 0.3]})}
+    dynamic = {"time_series": pd.DataFrame({"value": [0.1, 0.2, 0.3]})}
     attrs = pd.DataFrame({"attr1": ["metadata1"], "attr2": ["metadata2"]})
 
     component = Component(
@@ -26,7 +26,7 @@ def sample_component(sample_network):
         investment_periods=sample_network.investment_periods,
         attrs=attrs,
         static=static,
-        pnl=pnl,
+        dynamic=dynamic,
         ind=None,
     )
     return component
@@ -38,7 +38,7 @@ def test_component_initialization(sample_component):
     assert component.list_name == "generators"
     assert "attr1" in component.attrs
     assert component.static.shape == (3, 2)
-    assert "time_series" in component.pnl
+    assert "time_series" in component.dynamic
 
 
 def test_component_repr(sample_component):

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -30,20 +30,20 @@ def swap_df_index(df, axis=0):
 @pytest.fixture
 def n_5bus():
     # Set up empty network with 5 buses.
-    network = pypsa.Network()
-    network.add("Bus", [f"bus_{i} " for i in range(5)])
-    return network
+    n = pypsa.Network()
+    n.add("Bus", [f"bus_{i} " for i in range(5)])
+    return n
 
 
 @pytest.fixture
 def n_5bus_7sn():
     # Set up empty network with 5 buses and 7 snapshots.
-    network = pypsa.Network()
+    n = pypsa.Network()
     n_buses = 5
     n_snapshots = 7
-    network.add("Bus", [f"bus_{i} " for i in range(n_buses)])
-    network.set_snapshots(range(n_snapshots))
-    return network
+    n.add("Bus", [f"bus_{i} " for i in range(n_buses)])
+    n.set_snapshots(range(n_snapshots))
+    return n
 
 
 def test_remove(ac_dc_network):
@@ -55,14 +55,14 @@ def test_remove(ac_dc_network):
     THEN    the generator dataframe and the time-dependent generator
     dataframe should not contain the removed elements.
     """
-    network = ac_dc_network
+    n = ac_dc_network
 
     generators = {"Manchester Wind", "Frankfurt Wind"}
 
-    network.remove("Generator", generators)
+    n.remove("Generator", generators)
 
-    assert not generators.issubset(network.generators.index)
-    assert not generators.issubset(network.generators_t.p_max_pu.columns)
+    assert not generators.issubset(n.generators.index)
+    assert not generators.issubset(n.generators_t.p_max_pu.columns)
 
 
 def test_remove_misspelled_component(ac_dc_network):
@@ -74,10 +74,10 @@ def test_remove_misspelled_component(ac_dc_network):
     THEN    the function should not change anything in the Line
     component dataframe and an error should be logged.
     """
-    network = ac_dc_network
+    n = ac_dc_network
 
     with pytest.raises(ValueError):
-        network.remove("Liness", ["0", "1"])
+        n.remove("Liness", ["0", "1"])
 
 
 def test_add_misspelled_component(n_5bus):
@@ -363,10 +363,10 @@ def test_copy_default_behavior(all_networks):
     THEN    the copied network should have the same generators, loads
     and timestamps.
     """
-    for network in all_networks:
-        network_copy = network.copy()
-        assert network == network_copy
-        assert network is not network_copy
+    for n in all_networks:
+        network_copy = n.copy()
+        assert n == network_copy
+        assert n is not network_copy
 
 
 @pytest.mark.skipif(
@@ -381,13 +381,13 @@ def test_copy_snapshots(all_networks):
 
     THEN    the copied network should only have the current time index.
     """
-    for network in all_networks:
-        copied_network = network.copy(snapshots=[])
-        assert copied_network.snapshots.size == 1
+    for n in all_networks:
+        copied_n = n.copy(snapshots=[])
+        assert copied_n.snapshots.size == 1
 
-        copied_network = network.copy(snapshots=network.snapshots[:5])
-        network.set_snapshots(network.snapshots[:5])
-        assert copied_network == network
+        copied_n = n.copy(snapshots=n.snapshots[:5])
+        n.set_snapshots(n.snapshots[:5])
+        assert copied_n == n
 
 
 def test_single_add_network_static(ac_dc_network, n_5bus):

--- a/test/test_consistency_check.py
+++ b/test/test_consistency_check.py
@@ -14,7 +14,7 @@ import pypsa
 
 
 @pytest.fixture
-def consistent_network():
+def consistent_n():
     n = pypsa.Network()
     n.add("Bus", "one")
     n.add("Bus", "two")
@@ -25,32 +25,30 @@ def consistent_network():
 
 
 @pytest.mark.skipif(os.name == "nt", reason="dtype confusing on Windows")
-def test_consistency(consistent_network, caplog):
-    consistent_network.consistency_check()
+def test_consistency(consistent_n, caplog):
+    consistent_n.consistency_check()
     assert not caplog.records
 
 
-def test_missing_bus(consistent_network, caplog):
-    consistent_network.add("Bus", "three")
-    consistent_network.consistency_check()
+def test_missing_bus(consistent_n, caplog):
+    consistent_n.add("Bus", "three")
+    consistent_n.consistency_check()
     assert caplog.records[-1].levelname == "WARNING"
 
 
-def test_infeasible_capacity_limits(consistent_network, caplog):
-    consistent_network.generators.loc[
-        "gen_one", ["p_nom_extendable", "committable"]
-    ] = (
+def test_infeasible_capacity_limits(consistent_n, caplog):
+    consistent_n.generators.loc["gen_one", ["p_nom_extendable", "committable"]] = (
         True,
         True,
     )
-    consistent_network.consistency_check()
+    consistent_n.consistency_check()
     assert caplog.records[-1].levelname == "WARNING"
 
 
-def test_nans_in_capacity_limits(consistent_network, caplog):
-    consistent_network.generators.loc["gen_one", "p_nom_extendable"] = True
-    consistent_network.generators.loc["gen_one", "p_nom_max"] = np.nan
-    consistent_network.consistency_check()
+def test_nans_in_capacity_limits(consistent_n, caplog):
+    consistent_n.generators.loc["gen_one", "p_nom_extendable"] = True
+    consistent_n.generators.loc["gen_one", "p_nom_max"] = np.nan
+    consistent_n.consistency_check()
     assert caplog.records[-1].levelname == "WARNING"
 
 
@@ -68,7 +66,7 @@ def test_shapes_with_missing_idx(ac_dc_network_shapes, caplog):
     assert caplog.records[-1].message.startswith("The following shapes")
 
 
-def test_unknown_carriers(consistent_network, caplog):
-    consistent_network.add("Generator", "wind", bus="hub", carrier="wind")
-    consistent_network.consistency_check()
+def test_unknown_carriers(consistent_n, caplog):
+    consistent_n.add("Generator", "wind", bus="hub", carrier="wind")
+    consistent_n.consistency_check()
     assert caplog.records[-1].levelname == "WARNING"

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -185,19 +185,17 @@ def test_import_from_pandapower_network(
 ):
     nets = [pandapower_custom_network, pandapower_cigre_network]
     for net in nets:
-        network = pypsa.Network()
-        network.import_from_pandapower_net(
+        n = pypsa.Network()
+        n.import_from_pandapower_net(
             net,
             use_pandapower_index=use_pandapower_index,
             extra_line_data=extra_line_data,
         )
-        assert len(network.buses) == len(net.bus)
-        assert len(network.generators) == (
-            len(net.gen) + len(net.sgen) + len(net.ext_grid)
-        )
-        assert len(network.loads) == len(net.load)
-        assert len(network.transformers) == len(net.trafo)
-        assert len(network.shunt_impedances) == len(net.shunt)
+        assert len(n.buses) == len(net.bus)
+        assert len(n.generators) == (len(net.gen) + len(net.sgen) + len(net.ext_grid))
+        assert len(n.loads) == len(net.load)
+        assert len(n.transformers) == len(net.trafo)
+        assert len(n.shunt_impedances) == len(net.shunt)
 
 
 def test_netcdf_from_url():

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -75,7 +75,7 @@ def describe_nodal_balance_constraint(n):
     network_injection = (
         pd.concat(
             [
-                n.pnl(c)[f"p{inout}"].rename(columns=n.df(c)[f"bus{inout}"])
+                n.pnl(c)[f"p{inout}"].rename(columns=n.static(c)[f"bus{inout}"])
                 for inout in (0, 1)
                 for c in ("Line", "Transformer")
             ],
@@ -105,7 +105,7 @@ def describe_upper_dispatch_constraints(n):
         description[c + key] = pd.Series(
             {
                 "min": (
-                    n.df(c)[attr + "_opt"] * get_as_dense(n, c, attr[0] + "_max_pu")
+                    n.static(c)[attr + "_opt"] * get_as_dense(n, c, attr[0] + "_max_pu")
                     - n.pnl(c)[dispatch_attr]
                 )
                 .min()
@@ -124,7 +124,8 @@ def describe_lower_dispatch_constraints(n):
             description[c] = pd.Series(
                 {
                     "min": (
-                        n.df(c)[attr + "_opt"] * get_as_dense(n, c, attr[0] + "_max_pu")
+                        n.static(c)[attr + "_opt"]
+                        * get_as_dense(n, c, attr[0] + "_max_pu")
                         + n.pnl(c)[dispatch_attr]
                     )
                     .min()
@@ -136,7 +137,7 @@ def describe_lower_dispatch_constraints(n):
             description[c + key] = pd.Series(
                 {
                     "min": (
-                        -n.df(c)[attr + "_opt"]
+                        -n.static(c)[attr + "_opt"]
                         * get_as_dense(n, c, attr[0] + "_min_pu")
                         + n.pnl(c)[dispatch_attr]
                     )

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -201,7 +201,7 @@ funcs = (
 
 
 @pytest.fixture
-def solved_network(ac_dc_network):
+def solved_n(ac_dc_network):
     n = ac_dc_network
     n.optimize()
     n.lines["carrier"] = n.lines.bus0.map(n.buses.carrier)
@@ -209,8 +209,8 @@ def solved_network(ac_dc_network):
 
 
 @pytest.mark.parametrize("func", *funcs)
-def test_tolerance(solved_network, func):
-    n = solved_network
+def test_tolerance(solved_n, func):
+    n = solved_n
     description = func(n).fillna(0)
     for col in description:
         assert abs(description[col]["min"]) < TOLERANCE

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -370,7 +370,7 @@ def test_global_constraint_primary_energy_storage(n_sus):
     status, cond = n_sus.optimize(**kwargs)
 
     active = get_activity_mask(n_sus, c)
-    soc_end = n_sus.pnl(c).state_of_charge.where(active).ffill().iloc[-1]
+    soc_end = n_sus.dynamic(c).state_of_charge.where(active).ffill().iloc[-1]
     soc_diff = n_sus.static(c).state_of_charge_initial - soc_end
     emissions = n_sus.static(c).carrier.map(n_sus.carriers.co2_emissions)
     assert round(soc_diff @ emissions, 0) == 3000
@@ -390,7 +390,7 @@ def test_global_constraint_primary_energy_store(n_sts):
     status, cond = n_sts.optimize(**kwargs)
 
     active = get_activity_mask(n_sts, c)
-    soc_end = n_sts.pnl(c).e.where(active).ffill().iloc[-1]
+    soc_end = n_sts.dynamic(c).e.where(active).ffill().iloc[-1]
     soc_diff = n_sts.static(c).e_initial - soc_end
     emissions = n_sts.static(c).carrier.map(n_sts.carriers.co2_emissions)
     assert round(soc_diff @ emissions, 0) == 3000

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -360,10 +360,10 @@ def test_simple_network_store_cyclic_per_period(n_sts):
 def test_global_constraint_primary_energy_storage(n_sus):
     c = "StorageUnit"
     n_sus.add("Carrier", "emitting_carrier", co2_emissions=100)
-    n_sus.df(c)["state_of_charge_initial"] = 200
-    n_sus.df(c)["cyclic_state_of_charge"] = False
-    n_sus.df(c)["state_of_charge_initial_per_period"] = False
-    n_sus.df(c)["carrier"] = "emitting_carrier"
+    n_sus.static(c)["state_of_charge_initial"] = 200
+    n_sus.static(c)["cyclic_state_of_charge"] = False
+    n_sus.static(c)["state_of_charge_initial_per_period"] = False
+    n_sus.static(c)["carrier"] = "emitting_carrier"
 
     n_sus.add("GlobalConstraint", name="co2limit", type="primary_energy", constant=3000)
 
@@ -371,17 +371,17 @@ def test_global_constraint_primary_energy_storage(n_sus):
 
     active = get_activity_mask(n_sus, c)
     soc_end = n_sus.pnl(c).state_of_charge.where(active).ffill().iloc[-1]
-    soc_diff = n_sus.df(c).state_of_charge_initial - soc_end
-    emissions = n_sus.df(c).carrier.map(n_sus.carriers.co2_emissions)
+    soc_diff = n_sus.static(c).state_of_charge_initial - soc_end
+    emissions = n_sus.static(c).carrier.map(n_sus.carriers.co2_emissions)
     assert round(soc_diff @ emissions, 0) == 3000
 
 
 def test_global_constraint_primary_energy_store(n_sts):
     c = "Store"
     n_sts.add("Carrier", "emitting_carrier", co2_emissions=100)
-    n_sts.df(c)["e_initial"] = 200
-    n_sts.df(c)["e_cyclic"] = False
-    n_sts.df(c)["e_initial_per_period"] = False
+    n_sts.static(c)["e_initial"] = 200
+    n_sts.static(c)["e_cyclic"] = False
+    n_sts.static(c)["e_initial_per_period"] = False
 
     n_sts.buses.loc["1 battery", "carrier"] = "emitting_carrier"
 
@@ -391,8 +391,8 @@ def test_global_constraint_primary_energy_store(n_sts):
 
     active = get_activity_mask(n_sts, c)
     soc_end = n_sts.pnl(c).e.where(active).ffill().iloc[-1]
-    soc_diff = n_sts.df(c).e_initial - soc_end
-    emissions = n_sts.df(c).carrier.map(n_sts.carriers.co2_emissions)
+    soc_diff = n_sts.static(c).e_initial - soc_end
+    emissions = n_sts.static(c).carrier.map(n_sts.carriers.co2_emissions)
     assert round(soc_diff @ emissions, 0) == 3000
 
 

--- a/test/test_lopf_multilink.py
+++ b/test/test_lopf_multilink.py
@@ -4,7 +4,7 @@ import pypsa
 
 
 @pytest.fixture
-def network():
+def n():
     n = pypsa.Network()
     n.set_snapshots(range(10))
 
@@ -155,11 +155,11 @@ def network():
     return n
 
 
-def test_attribution_assignment(network):
-    assert "bus2" in network.components["Link"]["attrs"].index
-    assert network.components["Link"]["attrs"].loc["bus2", "default"] == ""
+def test_attribution_assignment(n):
+    assert "bus2" in n.components["Link"]["attrs"].index
+    assert n.components["Link"]["attrs"].loc["bus2", "default"] == ""
 
 
-def test_optimize(network):
-    status, condition = network.optimize()
+def test_optimize(n):
+    status, condition = n.optimize()
     assert status == "ok"

--- a/test/test_lopf_storage.py
+++ b/test/test_lopf_storage.py
@@ -22,7 +22,7 @@ def target_gen_p():
 
 
 @pytest.fixture
-def network():
+def n():
     csv_folder = os.path.join(
         os.path.dirname(__file__),
         "..",
@@ -33,9 +33,9 @@ def network():
     return pypsa.Network(csv_folder)
 
 
-def test_optimize(network, target_gen_p):
-    network.optimize()
-    equal(network.generators_t.p.reindex_like(target_gen_p), target_gen_p, decimal=2)
+def test_optimize(n, target_gen_p):
+    n.optimize()
+    equal(n.generators_t.p.reindex_like(target_gen_p), target_gen_p, decimal=2)
 
 
 def test_storage_energy_marginal_cost():
@@ -68,18 +68,18 @@ def test_spill_cost():
     p_set = [100, 100, 100, 100, 100]
 
     for has_spill_cost in [False, True]:
-        network = pypsa.Network(snapshots=range(len(p_set) * sets_of_snapshots))
+        n = pypsa.Network(snapshots=range(len(p_set) * sets_of_snapshots))
 
-        network.add("Bus", "bus")
+        n.add("Bus", "bus")
 
         # Add high capacity generator to help
-        network.add(
+        n.add(
             "Generator", "help", bus="bus", p_nom=1000, control="PQ", marginal_cost=100
         )
 
         # Add hydro unit
         if has_spill_cost:
-            network.add(
+            n.add(
                 "StorageUnit",
                 "hydro",
                 bus="bus",
@@ -89,7 +89,7 @@ def test_spill_cost():
                 spill_cost=1,
             )
         else:
-            network.add(
+            n.add(
                 "StorageUnit",
                 "hydro",
                 bus="bus",
@@ -99,19 +99,19 @@ def test_spill_cost():
             )
 
         # Add Load
-        network.add("Load", "load", bus="bus", p_set=p_set * sets_of_snapshots)
+        n.add("Load", "load", bus="bus", p_set=p_set * sets_of_snapshots)
 
         overlap = 2
         for i in range(sets_of_snapshots):
             if i == 1:
-                network.storage_units.state_of_charge_initial = (
-                    network.storage_units_t.state_of_charge.loc[network.snapshots[4]]
+                n.storage_units.state_of_charge_initial = (
+                    n.storage_units_t.state_of_charge.loc[n.snapshots[4]]
                 )
-            network.optimize(
-                network.snapshots[i * len(p_set) : (i + 1) * len(p_set) + overlap],
+            n.optimize(
+                n.snapshots[i * len(p_set) : (i + 1) * len(p_set) + overlap],
             )
 
-        spill = network.storage_units_t["spill"].loc[:, "hydro"]
+        spill = n.storage_units_t["spill"].loc[:, "hydro"]
         total_spill = spill.sum()
 
         if has_spill_cost:

--- a/test/test_lpf_against_pypower.py
+++ b/test/test_lpf_against_pypower.py
@@ -80,9 +80,9 @@ def test_pypower_case():
     # compare branch flows
     for item in ["lines", "transformers"]:
         df = getattr(n, item)
-        pnl = getattr(n, item + "_t")
+        dynamic = getattr(n, item + "_t")
 
         for si in ["p0", "p1"]:
-            si_pypsa = getattr(pnl, si).loc["now"].values
+            si_pypsa = getattr(dynamic, si).loc["now"].values
             si_pypower = results_df["branch"][si][df.original_index].values
             equal(si_pypsa, si_pypower)

--- a/test/test_lpf_against_pypower.py
+++ b/test/test_lpf_against_pypower.py
@@ -67,20 +67,20 @@ def test_pypower_case():
     results_df["gen"] = pd.DataFrame(data=results["gen"], columns=columns)
 
     # now compute in PyPSA
-    network = pypsa.Network()
-    network.import_from_pypower_ppc(ppc)
-    network.lpf()
+    n = pypsa.Network()
+    n.import_from_pypower_ppc(ppc)
+    n.lpf()
 
     # compare generator dispatch
-    p_pypsa = network.generators_t.p.loc["now"].values
+    p_pypsa = n.generators_t.p.loc["now"].values
     p_pypower = results_df["gen"]["p"].values
 
     equal(p_pypsa, p_pypower)
 
     # compare branch flows
     for item in ["lines", "transformers"]:
-        df = getattr(network, item)
-        pnl = getattr(network, item + "_t")
+        df = getattr(n, item)
+        pnl = getattr(n, item + "_t")
 
         for si in ["p0", "p1"]:
             si_pypsa = getattr(pnl, si).loc["now"].values

--- a/test/test_pf_activity_mask.py
+++ b/test/test_pf_activity_mask.py
@@ -30,5 +30,5 @@ def test_subnetwork_full_pf(sub_network_full):
 
 def test_subnetwork_filtered_pf(sub_network_filtered):
     sub_network_pf(sub_network_filtered, sub_network_filtered.snapshots[:3])
-    n = sub_network_filtered.network
+    n = sub_network_filtered.n
     assert n.lines_t.p0.loc[:, ~n.lines.active].eq(0).all().all()

--- a/test/test_pf_against_pypower.py
+++ b/test/test_pf_against_pypower.py
@@ -80,7 +80,7 @@ def test_pypower_case():
     for c in n.iterate_components(n.passive_branch_components):
         for si in ["p0", "p1", "q0", "q1"]:
             si_pypsa = getattr(c.pnl, si).loc["now"].values
-            si_pypower = results_df["branch"][si][c.df.original_index].values
+            si_pypower = results_df["branch"][si][c.static.original_index].values
             equal(si_pypsa, si_pypower)
 
     # compare generator dispatch

--- a/test/test_pf_against_pypower.py
+++ b/test/test_pf_against_pypower.py
@@ -79,7 +79,7 @@ def test_pypower_case():
     # compare branch flows
     for c in n.iterate_components(n.passive_branch_components):
         for si in ["p0", "p1", "q0", "q1"]:
-            si_pypsa = getattr(c.pnl, si).loc["now"].values
+            si_pypsa = getattr(c.dynamic, si).loc["now"].values
             si_pypower = results_df["branch"][si][c.static.original_index].values
             equal(si_pypsa, si_pypower)
 

--- a/test/test_pf_against_pypower.py
+++ b/test/test_pf_against_pypower.py
@@ -67,17 +67,17 @@ def test_pypower_case():
 
     # now compute in PyPSA
 
-    network = pypsa.Network()
-    network.import_from_pypower_ppc(ppc)
+    n = pypsa.Network()
+    n.import_from_pypower_ppc(ppc)
 
     # PYPOWER uses PI model for transformers, whereas PyPSA defaults to
     # T since version 0.8.0
-    network.transformers.model = "pi"
+    n.transformers.model = "pi"
 
-    network.pf()
+    n.pf()
 
     # compare branch flows
-    for c in network.iterate_components(network.passive_branch_components):
+    for c in n.iterate_components(n.passive_branch_components):
         for si in ["p0", "p1", "q0", "q1"]:
             si_pypsa = getattr(c.pnl, si).loc["now"].values
             si_pypower = results_df["branch"][si][c.df.original_index].values
@@ -85,17 +85,17 @@ def test_pypower_case():
 
     # compare generator dispatch
     for s in ["p", "q"]:
-        s_pypsa = getattr(network.generators_t, s).loc["now"].values
+        s_pypsa = getattr(n.generators_t, s).loc["now"].values
         s_pypower = results_df["gen"][s].values
         equal(s_pypsa, s_pypower)
 
     # compare voltages
-    v_mag_pypsa = network.buses_t.v_mag_pu.loc["now"]
+    v_mag_pypsa = n.buses_t.v_mag_pu.loc["now"]
     v_mag_pypower = results_df["bus"]["v_mag_pu"]
 
     equal(v_mag_pypsa, v_mag_pypower)
 
-    v_ang_pypsa = network.buses_t.v_ang.loc["now"]
+    v_ang_pypsa = n.buses_t.v_ang.loc["now"]
     pypower_slack_angle = results_df["bus"]["v_ang"][
         results_df["bus"]["type"] == 3
     ].values[0]

--- a/test/test_pf_distributed_slack.py
+++ b/test/test_pf_distributed_slack.py
@@ -6,47 +6,47 @@ def normed(s):
 
 
 def test_pf_distributed_slack(scipy_network):
-    network = scipy_network
-    network.set_snapshots(network.snapshots[:2])
+    n = scipy_network
+    n.set_snapshots(n.snapshots[:2])
 
     # There are some infeasibilities without line extensions
-    network.lines.s_max_pu = 0.7
-    network.lines.loc[["316", "527", "602"], "s_nom"] = 1715
-    network.storage_units.state_of_charge_initial = 0.0
+    n.lines.s_max_pu = 0.7
+    n.lines.loc[["316", "527", "602"], "s_nom"] = 1715
+    n.storage_units.state_of_charge_initial = 0.0
 
-    network.optimize(network.snapshots)
+    n.optimize(n.snapshots)
 
     # For the PF, set the P to the optimised P
-    network.generators_t.p_set = network.generators_t.p
-    network.storage_units_t.p_set = network.storage_units_t.p
+    n.generators_t.p_set = n.generators_t.p
+    n.storage_units_t.p_set = n.storage_units_t.p
 
     # set all buses to PV, since we don't know what Q set points are
-    network.generators.control = "PV"
+    n.generators.control = "PV"
 
     # Need some PQ buses so that Jacobian doesn't break
-    f = network.generators[network.generators.bus == "492"]
-    network.generators.loc[f.index, "control"] = "PQ"
+    f = n.generators[n.generators.bus == "492"]
+    n.generators.loc[f.index, "control"] = "PQ"
     # by dispatch
-    network.pf(distribute_slack=True, slack_weights="p_set")
+    n.pf(distribute_slack=True, slack_weights="p_set")
 
     equal(
-        network.generators_t.p_set.apply(normed, axis=1),
-        (network.generators_t.p - network.generators_t.p_set).apply(normed, axis=1),
+        n.generators_t.p_set.apply(normed, axis=1),
+        (n.generators_t.p - n.generators_t.p_set).apply(normed, axis=1),
     )
 
     # by capacity
-    network.pf(distribute_slack=True, slack_weights="p_nom")
+    n.pf(distribute_slack=True, slack_weights="p_nom")
 
-    slack_shares_by_capacity = (
-        network.generators_t.p - network.generators_t.p_set
-    ).apply(normed, axis=1)
+    slack_shares_by_capacity = (n.generators_t.p - n.generators_t.p_set).apply(
+        normed, axis=1
+    )
 
     for index, row in slack_shares_by_capacity.iterrows():
-        equal(network.generators.p_nom.pipe(normed).fillna(0.0), row)
+        equal(n.generators.p_nom.pipe(normed).fillna(0.0), row)
 
     # by custom weights (mirror 'capacity' via custom slack weights by bus)
     custom_weights = {}
-    for sub_network in network.sub_networks.obj:
+    for sub_network in n.sub_networks.obj:
         buses_o = sub_network.buses_o
         generators = sub_network.generators()
         custom_weights[sub_network.name] = (
@@ -57,20 +57,20 @@ def test_pf_distributed_slack(scipy_network):
             .fillna(0.0)
         )
 
-    network.pf(distribute_slack=True, slack_weights=custom_weights)
+    n.pf(distribute_slack=True, slack_weights=custom_weights)
 
     equal(
         slack_shares_by_capacity,
-        (network.generators_t.p - network.generators_t.p_set).apply(normed, axis=1),
+        (n.generators_t.p - n.generators_t.p_set).apply(normed, axis=1),
     )
 
     custom_weights = {
         sub_network.name: sub_network.generators().p_nom
-        for sub_network in network.sub_networks.obj
+        for sub_network in n.sub_networks.obj
     }
-    network.pf(distribute_slack=True, slack_weights=custom_weights)
+    n.pf(distribute_slack=True, slack_weights=custom_weights)
 
     equal(
         slack_shares_by_capacity,
-        (network.generators_t.p - network.generators_t.p_set).apply(normed, axis=1),
+        (n.generators_t.p - n.generators_t.p_set).apply(normed, axis=1),
     )

--- a/test/test_spatial_clustering.py
+++ b/test/test_spatial_clustering.py
@@ -145,7 +145,7 @@ def test_default_clustering_k_means(scipy_network):
     weighting = pd.Series(1, n.buses.index)
     busmap = busmap_by_kmeans(n, bus_weightings=weighting, n_clusters=50)
     C = get_clustering_from_busmap(n, busmap)
-    nc = C.network
+    nc = C.n
     assert len(nc.buses) == 50
 
 
@@ -154,7 +154,7 @@ def test_default_clustering_hac(scipy_network):
     prepare_network_for_aggregation(n)
     busmap = busmap_by_hac(n, n_clusters=50)
     C = get_clustering_from_busmap(n, busmap)
-    nc = C.network
+    nc = C.n
     assert len(nc.buses) == 50
 
 
@@ -184,6 +184,6 @@ def test_custom_line_groupers(scipy_network):
     busmap = busmap_by_kmeans(n, bus_weightings=weighting, n_clusters=20)
     C = get_clustering_from_busmap(n, busmap, custom_line_groupers=["build_year"])
     linemap = C.linemap
-    nc = C.network
+    nc = C.n
     assert len(nc.buses) == 20
     assert (n.lines.groupby(linemap).build_year.nunique() == 1).all()

--- a/test/test_spatial_clustering.py
+++ b/test/test_spatial_clustering.py
@@ -21,7 +21,7 @@ from pypsa.clustering.spatial import (
 def test_aggregate_generators(ac_dc_network):
     n = ac_dc_network
     busmap = pd.Series("all", n.buses.index)
-    df, pnl = aggregateoneport(n, busmap, "Generator")
+    df, dynamic = aggregateoneport(n, busmap, "Generator")
 
     assert (
         df.loc["all gas", "p_nom"] == n.generators.query("carrier == 'gas'").p_nom.sum()
@@ -33,7 +33,7 @@ def test_aggregate_generators(ac_dc_network):
 
     capacity_norm = normed_or_uniform(n.generators.query("carrier == 'wind'").p_nom)
     assert np.allclose(
-        pnl["p_max_pu"]["all wind"],
+        dynamic["p_max_pu"]["all wind"],
         (n.generators_t.p_max_pu * capacity_norm).sum(axis=1),
     )
     assert np.allclose(
@@ -49,7 +49,7 @@ def test_aggregate_generators_custom_strategies(ac_dc_network):
     busmap = pd.Series("all", n.buses.index)
 
     strategies = {"p_max_pu": "max", "p_nom_max": "weighted_min"}
-    df, pnl = aggregateoneport(n, busmap, "Generator", custom_strategies=strategies)
+    df, dynamic = aggregateoneport(n, busmap, "Generator", custom_strategies=strategies)
 
     assert (
         df.loc["all gas", "p_nom"] == n.generators.query("carrier == 'gas'").p_nom.sum()
@@ -62,7 +62,9 @@ def test_aggregate_generators_custom_strategies(ac_dc_network):
         df["p_nom_max"]["all wind"]
         == n.generators.loc["Frankfurt Wind", "p_nom_max"] * 3
     )
-    assert np.allclose(pnl["p_max_pu"]["all wind"], n.generators_t.p_max_pu.max(axis=1))
+    assert np.allclose(
+        dynamic["p_max_pu"]["all wind"], n.generators_t.p_max_pu.max(axis=1)
+    )
 
 
 def test_aggregate_generators_consent_error(ac_dc_network):
@@ -78,7 +80,7 @@ def test_aggregate_generators_consent_error(ac_dc_network):
     busmap = pd.Series("all", n.buses.index)
 
     with pytest.raises(AssertionError):
-        df, pnl = aggregateoneport(n, busmap, "Generator")
+        df, dynamic = aggregateoneport(n, busmap, "Generator")
 
 
 def test_aggregate_storage_units(ac_dc_network):
@@ -106,7 +108,7 @@ def test_aggregate_storage_units(ac_dc_network):
     )
 
     busmap = pd.Series("all", n.buses.index)
-    df, pnl = aggregateoneport(n, busmap, "StorageUnit")
+    df, dynamic = aggregateoneport(n, busmap, "StorageUnit")
     capacity_norm = normed_or_uniform(n.storage_units.p_nom)
 
     assert df.loc["all", "p_nom"] == n.storage_units.p_nom.sum()
@@ -129,7 +131,7 @@ def test_aggregate_storage_units_consent_error(ac_dc_network):
 
     busmap = pd.Series("all", n.buses.index)
     with pytest.raises(AssertionError):
-        df, pnl = aggregateoneport(n, busmap, "StorageUnit")
+        df, dynamic = aggregateoneport(n, busmap, "StorageUnit")
 
 
 def prepare_network_for_aggregation(n):

--- a/test/test_subnetwork.py
+++ b/test/test_subnetwork.py
@@ -57,32 +57,32 @@ def test_investment_period_weightings(scipy_subnetwork: SubNetwork) -> None:
 
 
 def test_df(scipy_subnetwork: SubNetwork) -> None:
-    buses = scipy_subnetwork.df("Bus")
+    buses = scipy_subnetwork.static("Bus")
     assert not buses.empty
     assert buses.index.isin(scipy_subnetwork.n.buses.index).all()
 
     component_names = ["Line", "Transformer", "Generator", "Load"]
     for c_name in component_names:
-        df = scipy_subnetwork.df(c_name)
+        df = scipy_subnetwork.static(c_name)
         assert not df.empty
-        assert df.index.isin(scipy_subnetwork.n.df(c_name).index).all()
+        assert df.index.isin(scipy_subnetwork.n.static(c_name).index).all()
 
     with pytest.raises(ValueError):
-        scipy_subnetwork.df("Link")
+        scipy_subnetwork.static("Link")
 
     with pytest.raises(ValueError):
-        scipy_subnetwork.df("GlobalConstraint")
+        scipy_subnetwork.static("GlobalConstraint")
 
 
 def test_incidence_matrix(ac_dc_subnetwork: SubNetwork) -> None:
-    lines = ac_dc_subnetwork.df("Line")
-    buses = ac_dc_subnetwork.df("Bus")
+    lines = ac_dc_subnetwork.static("Line")
+    buses = ac_dc_subnetwork.static("Bus")
     A = ac_dc_subnetwork.incidence_matrix()
     assert A.shape == (len(buses), len(lines))
 
 
 def test_incidence_matrix_inactive(ac_dc_subnetwork_inactive: SubNetwork) -> None:
-    lines = ac_dc_subnetwork_inactive.df("Line")
-    buses = ac_dc_subnetwork_inactive.df("Bus")
+    lines = ac_dc_subnetwork_inactive.static("Line")
+    buses = ac_dc_subnetwork_inactive.static("Bus")
     A = ac_dc_subnetwork_inactive.incidence_matrix()
     assert A.shape == (len(buses), len(lines[lines["active"]]))

--- a/test/test_subnetwork.py
+++ b/test/test_subnetwork.py
@@ -27,7 +27,7 @@ def ac_dc_subnetwork_inactive(ac_dc_network: Network) -> SubNetwork:
 
 
 def test_network(scipy_subnetwork: SubNetwork) -> None:
-    assert isinstance(scipy_subnetwork.network, pypsa.Network)
+    assert isinstance(scipy_subnetwork.n, pypsa.Network)
 
 
 def test_name(scipy_subnetwork: SubNetwork) -> None:
@@ -35,37 +35,37 @@ def test_name(scipy_subnetwork: SubNetwork) -> None:
 
 
 def test_snapshots(scipy_subnetwork: SubNetwork) -> None:
-    assert scipy_subnetwork.snapshots.equals(scipy_subnetwork.network.snapshots)
+    assert scipy_subnetwork.snapshots.equals(scipy_subnetwork.n.snapshots)
 
 
 def test_snapshot_weightings(scipy_subnetwork: SubNetwork) -> None:
     assert scipy_subnetwork.snapshot_weightings.equals(
-        scipy_subnetwork.network.snapshot_weightings
+        scipy_subnetwork.n.snapshot_weightings
     )
 
 
 def test_investment_periods(scipy_subnetwork: SubNetwork) -> None:
     assert scipy_subnetwork.investment_periods.equals(
-        scipy_subnetwork.network.investment_periods
+        scipy_subnetwork.n.investment_periods
     )
 
 
 def test_investment_period_weightings(scipy_subnetwork: SubNetwork) -> None:
     assert scipy_subnetwork.investment_period_weightings.equals(
-        scipy_subnetwork.network.investment_period_weightings
+        scipy_subnetwork.n.investment_period_weightings
     )
 
 
 def test_df(scipy_subnetwork: SubNetwork) -> None:
     buses = scipy_subnetwork.df("Bus")
     assert not buses.empty
-    assert buses.index.isin(scipy_subnetwork.network.buses.index).all()
+    assert buses.index.isin(scipy_subnetwork.n.buses.index).all()
 
     component_names = ["Line", "Transformer", "Generator", "Load"]
     for c_name in component_names:
         df = scipy_subnetwork.df(c_name)
         assert not df.empty
-        assert df.index.isin(scipy_subnetwork.network.df(c_name).index).all()
+        assert df.index.isin(scipy_subnetwork.n.df(c_name).index).all()
 
     with pytest.raises(ValueError):
         scipy_subnetwork.df("Link")


### PR DESCRIPTION
Start to introduce common naming convention. This one changes all `network` (and related, like `_parent`) to `n`. 

Since most of it is network object internal anyway, the API changes are pretty minor. But if the decorator is used, it's also backwards compatible with a `DeprecationWarning`.

If you agree and this is what you have in mind for a common naming conventions, next up is:
- [x] `network` -> `n`
- [x] `sub_n`, `sn`, `sub` -> `sub_network`
- [x] `subnetwork` (docs) -> `sub-network`
- [ ] `snapshots` -> `sns` & `snapshots` in api
- [ ] `Component` (class) -> `c`
- [ ] component name (str), `cls_name`, `class_name` -> `c_name`
- [ ] component list name (str), `list_name` -> `c_list_name`
- [ ] variables representing attributes like `p`, `q`, `p_nom` -> `attr`
- [x] `dataframe` -> `df`
- [x] `df` -> `static`
- [x] `pnl`, `varying`, `series` etc -> `dynamic` 

Feel free to add more