### PR TITLE
replace index name "name" by "carrier"

### DIFF
--- a/pypsa/statistics.py
+++ b/pypsa/statistics.py
@@ -192,7 +192,7 @@ def get_transmission_carriers(
         carriers[c] = n.df(c).carrier[idx].unique()
     return pd.MultiIndex.from_tuples(
         [(c, i) for c, idx in carriers.items() for i in idx],
-        names=["component", "name"],
+        names=["component", "carrier"],
     )
 
 


### PR DESCRIPTION

## Changes proposed in this Pull Request
change the name of `get_transmission_carrier` to ("component", "carrier") instead of ("component", "name"), because it confusing that you get the carriers but the index name is "name".

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
