### PR TITLE
Adding fractional_last_unit_size for the post discretization

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,6 +11,10 @@ Release Notes
 ..   To use the features already you have to install the ``master`` branch, e.g. 
 ..   ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* Bugfix in the post discretization for ``Links`` with a maximum capacity.
+  Furthermore, giving the option to build out only multiples of the specified unit_size
+  or allowing to use the full maximum capacity.
+
 v0.30.2 (11th September 2024)
 =============================
 

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -32,6 +32,61 @@ def discretized_capacity(
     fractional_last_unit_size: bool,
     min_units: int = 0,
 ) -> float:
+    """
+    Discretize a optimal capacity to a capacity that is either a multiple of a unit size
+    or the maximum capacity, depending on the variable `fractional_last_unit_size`.
+
+    This function checks if the optimal capacity is within the threshold of the unit size.
+    If so, it returns the next multiple of the unit size - if not it returns the last multiple
+    of the unit size.
+    In the special case that the maximum capacity is not a multiple of the unit size, the variable
+    `fractional_last_unit_size` determines if the returned capacity is the maximum capacity (True)
+    or the last multiple of the unit size (False).
+
+    Parameters
+    ----------
+    nom_opt : float
+        The optimal capacity as returned by the optimization.
+    nom_max : float
+        The maximum capacity as defined in the network.
+    unit_size : float
+        The unit size for the capacity as defined in the config[solving][post_discretization].
+    threshold : float
+        The threshold relative to the unit size for discretizing the capacity as defined in the config[solving][post_discretization].
+    fractional_last_unit_size : bool
+        Whether only multiples of the unit size or the maximum capacity is allowed as defined in the config[solving][post_discretization].
+    min_units : int, default 0
+        The minimum number of units that should be installed.
+
+    Returns
+    -------
+    float
+        The discretized capacity.
+
+    Examples
+    --------
+    >>> discretized_capacity(
+    nom_opt = 7,
+    nom_max = 25,
+    unit_size = 5,
+    threshold = 0.1,
+    fractional_last_unit_size = False)
+    10
+    >>> discretized_capacity(
+    nom_opt = 7,
+    nom_max = 8,
+    unit_size = 5,
+    threshold = 0.1,
+    fractional_last_unit_size = False)
+    5
+    >>> discretized_capacity(
+    nom_opt = 7,
+    nom_max = 8,
+    unit_size = 5,
+    threshold = 0.1,
+    fractional_last_unit_size = True)
+    8
+    """
     units = nom_opt // unit_size + (nom_opt % unit_size >= threshold * unit_size)
     block_capacity = max(min_units, units) * unit_size
     if nom_max % unit_size == 0:
@@ -101,6 +156,8 @@ def optimize_transmission_expansion_iteratively(
         The threshold relative to the unit size for discretizing line components.
     link_threshold: dict-like, default 0.3 per carrier
         The threshold relative to the unit size for discretizing link components.
+    fractional_last_unit_size: bool, default False
+        Whether only multiples of the unit size or in case of a maximum capacity fractions of unit size is allowed.
     **kwargs
         Keyword arguments of the `n.optimize` function which runs at each iteration
     """
@@ -153,7 +210,7 @@ def optimize_transmission_expansion_iteratively(
         link_unit_size: dict | None,
         line_threshold: float | None,
         link_threshold: dict | None,
-        fractional_last_unit_size: bool | False,
+        fractional_last_unit_size: bool = False,
     ) -> None:
         """
         Discretizes the branch components of a network based on the specified

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -35,6 +35,7 @@ def optimize_transmission_expansion_iteratively(
     link_unit_size: dict | None = None,
     line_threshold: float | None = None,
     link_threshold: dict | None = None,
+    fractional_last_unit_size: bool = False,
     **kwargs: Any,
 ) -> tuple[str, str]:
     """
@@ -122,12 +123,27 @@ def optimize_transmission_expansion_iteratively(
 
     def discretized_capacity(
         nom_opt: float,
+        nom_max: float,
         unit_size: float,
         threshold: float,
+        fractional_last_unit_size: bool,
         min_units: int = 0,
     ) -> float:
         units = nom_opt // unit_size + (nom_opt % unit_size >= threshold * unit_size)
-        return max(min_units, units) * unit_size
+        block_capacity = max(min_units, units) * unit_size
+
+        if unit_size < nom_max:
+            return block_capacity
+        if (unit_size > nom_max) or (block_capacity > nom_max):
+            # cut down the capacity to the last full unit_size
+            if not fractional_last_unit_size:
+                return max(block_capacity - unit_size, 0)
+            # allow for a fractional last unit_size
+            else:
+                if nom_max == 0:
+                    return 0
+                else:
+                    return nom_max if nom_opt / nom_max > threshold else 0
 
     def discretize_branch_components(
         n: Network,
@@ -135,6 +151,7 @@ def optimize_transmission_expansion_iteratively(
         link_unit_size: dict | None,
         line_threshold: float | None,
         link_threshold: dict | None,
+        fractional_last_unit_size: bool | False,
     ) -> None:
         """
         Discretizes the branch components of a network based on the specified
@@ -146,20 +163,31 @@ def optimize_transmission_expansion_iteratively(
 
         if line_unit_size:
             min_units = 1
-            n.lines["s_nom"] = n.lines["s_nom_opt"].apply(
-                discretized_capacity, args=(line_unit_size, line_threshold, min_units)
+            n.lines["s_nom"] = n.lines.apply(
+                lambda row: discretized_capacity(
+                    nom_opt = row["s_nom_opt"],
+                    nom_max = row["s_nom_max"],
+                    unit_size = line_unit_size,
+                    threshold = line_threshold,
+                    min_units = min_units,
+                    fractional_last_unit_size=fractional_last_unit_size,
+                ),
+                axis=1
             )
 
         if link_unit_size:
             for carrier in link_unit_size.keys() & n.links.carrier.unique():
                 idx = n.links.carrier == carrier
-                n.links.loc[idx, "p_nom"] = n.links.loc[idx, "p_nom_opt"].apply(
-                    discretized_capacity,
-                    args=(
-                        link_unit_size[carrier],
-                        link_threshold.get(carrier, 0.3),
+                n.links.loc[idx, "p_nom"] = n.links.loc[idx].apply(
+                    lambda row: discretized_capacity(
+                        nom_opt = row["p_nom_opt"],
+                        nom_max = row["p_nom_max"],
+                        unit_size = link_unit_size[carrier],
+                        threshold = link_threshold.get(carrier, 0.3),
+                        fractional_last_unit_size=fractional_last_unit_size,
                     ),
-                )
+                    axis=1
+                )             
 
     if link_threshold is None:
         link_threshold = {}
@@ -222,6 +250,7 @@ def optimize_transmission_expansion_iteratively(
         link_unit_size,
         line_threshold,
         link_threshold,
+        fractional_last_unit_size,
     )
 
     n.calculate_dependent_values()

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from pypsa import Network
 logger = logging.getLogger(__name__)
 
+
 def discretized_capacity(
     nom_opt: float,
     nom_max: float,
@@ -34,16 +35,20 @@ def discretized_capacity(
     units = nom_opt // unit_size + (nom_opt % unit_size >= threshold * unit_size)
     block_capacity = max(min_units, units) * unit_size
     if nom_max % unit_size == 0:
-        return block_capacity        
+        return block_capacity
 
     else:
         if (nom_max - nom_opt) < unit_size:
-            if fractional_last_unit_size and ((nom_opt % unit_size) / (nom_max % unit_size)) >= threshold:
+            if (
+                fractional_last_unit_size
+                and ((nom_opt % unit_size) / (nom_max % unit_size)) >= threshold
+            ):
                 return nom_max
             else:
                 return (nom_opt // unit_size) * unit_size
         else:
             return block_capacity
+
 
 def optimize_transmission_expansion_iteratively(
     n: Network,

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -181,7 +181,11 @@ def optimize_transmission_expansion_iteratively(
             for carrier in link_unit_size.keys() & n.links.carrier.unique():
                 idx = n.links.carrier == carrier
                 logger.warning("Debugging: changing p_nom to p_nom_max")
-                logger.info(n.links[(n.links.carrier == carrier) & (n.links.p_nom_opt > 0)][["p_nom", "p_nom_opt", "p_nom_max"]])
+                logger.info(
+                    n.links[(n.links.carrier == carrier) & (n.links.p_nom_opt > 0)][
+                        ["p_nom", "p_nom_opt", "p_nom_max"]
+                    ]
+                )
                 n.links.loc[idx, "p_nom"] = n.links.loc[idx].apply(
                     lambda row: discretized_capacity(
                         nom_opt=row["p_nom_opt"],

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -180,6 +180,8 @@ def optimize_transmission_expansion_iteratively(
         if link_unit_size:
             for carrier in link_unit_size.keys() & n.links.carrier.unique():
                 idx = n.links.carrier == carrier
+                logger.warning("Debugging: changing p_nom to p_nom_max")
+                logger.info(n.links[(n.links.carrier == carrier) & (n.links.p_nom_opt > 0)][["p_nom", "p_nom_opt", "p_nom_max"]])
                 n.links.loc[idx, "p_nom"] = n.links.loc[idx].apply(
                     lambda row: discretized_capacity(
                         nom_opt=row["p_nom_opt"],

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -180,12 +180,6 @@ def optimize_transmission_expansion_iteratively(
         if link_unit_size:
             for carrier in link_unit_size.keys() & n.links.carrier.unique():
                 idx = n.links.carrier == carrier
-                logger.warning("Debugging: changing p_nom to p_nom_max")
-                logger.info(
-                    n.links[(n.links.carrier == carrier) & (n.links.p_nom_opt > 0)][
-                        ["p_nom", "p_nom_opt", "p_nom_max"]
-                    ]
-                )
                 n.links.loc[idx, "p_nom"] = n.links.loc[idx].apply(
                     lambda row: discretized_capacity(
                         nom_opt=row["p_nom_opt"],

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -165,14 +165,14 @@ def optimize_transmission_expansion_iteratively(
             min_units = 1
             n.lines["s_nom"] = n.lines.apply(
                 lambda row: discretized_capacity(
-                    nom_opt = row["s_nom_opt"],
-                    nom_max = row["s_nom_max"],
-                    unit_size = line_unit_size,
-                    threshold = line_threshold,
-                    min_units = min_units,
+                    nom_opt=row["s_nom_opt"],
+                    nom_max=row["s_nom_max"],
+                    unit_size=line_unit_size,
+                    threshold=line_threshold,
+                    min_units=min_units,
                     fractional_last_unit_size=fractional_last_unit_size,
                 ),
-                axis=1
+                axis=1,
             )
 
         if link_unit_size:
@@ -180,14 +180,14 @@ def optimize_transmission_expansion_iteratively(
                 idx = n.links.carrier == carrier
                 n.links.loc[idx, "p_nom"] = n.links.loc[idx].apply(
                     lambda row: discretized_capacity(
-                        nom_opt = row["p_nom_opt"],
-                        nom_max = row["p_nom_max"],
-                        unit_size = link_unit_size[carrier],
-                        threshold = link_threshold.get(carrier, 0.3),
+                        nom_opt=row["p_nom_opt"],
+                        nom_max=row["p_nom_max"],
+                        unit_size=link_unit_size[carrier],
+                        threshold=link_threshold.get(carrier, 0.3),
                         fractional_last_unit_size=fractional_last_unit_size,
                     ),
-                    axis=1
-                )             
+                    axis=1,
+                )
 
     if link_threshold is None:
         link_threshold = {}

--- a/test/test_link_post_discretization.py
+++ b/test/test_link_post_discretization.py
@@ -1,74 +1,77 @@
-import pytest
-
 import pypsa
-
 from pypsa.optimization.abstract import discretized_capacity
 
+
 def build_network(unit_size=10):
-    ''''
+    """
+    '
     Build a network with two buses and links that are have
     - p_nom_max = unit_size
     - p_nom_max = 2*unit_size
     - p_nom_max < unit_size
     - p_nom_max > unit_size and not a multiple of unit_size
     - p_nom_max = np.inf
-    '''
+    """
     n = pypsa.Network()
 
     # add buses
-    n.add("Bus",
-          "Bus0")
-    n.add("Bus",
-          "Bus1")
+    n.add("Bus", "Bus0")
+    n.add("Bus", "Bus1")
 
     # add links
-    n.add("Link",
-          "Link0",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=0,
-          p_nom_opt=0.5*unit_size,
-          p_nom_max=unit_size,
-          p_nom_extendable=True,
-          )
+    n.add(
+        "Link",
+        "Link0",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=0,
+        p_nom_opt=0.5 * unit_size,
+        p_nom_max=unit_size,
+        p_nom_extendable=True,
+    )
 
-    n.add("Link",
-          "Link1",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=0,
-          p_nom_opt=1.5*unit_size,
-          p_nom_max=2*unit_size,
-          p_nom_extendable=True,
-          )
-    n.add("Link",
-          "Link2",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=0,
-          p_nom_opt=0.5*unit_size,
-          p_nom_max=0.8*unit_size,
-          p_nom_extendable=True,
-          )
-    n.add("Link",
-          "Link3",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=0,
-          p_nom_opt=1.3*unit_size,
-          p_nom_max=1.5*unit_size,
-          p_nom_extendable=True,
-          )
-    n.add("Link",
-          "Link4",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=0,
-          p_nom_opt=1.5*unit_size,
-          p_nom_extendable=True,
-          )
+    n.add(
+        "Link",
+        "Link1",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=0,
+        p_nom_opt=1.5 * unit_size,
+        p_nom_max=2 * unit_size,
+        p_nom_extendable=True,
+    )
+    n.add(
+        "Link",
+        "Link2",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=0,
+        p_nom_opt=0.5 * unit_size,
+        p_nom_max=0.8 * unit_size,
+        p_nom_extendable=True,
+    )
+    n.add(
+        "Link",
+        "Link3",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=0,
+        p_nom_opt=1.3 * unit_size,
+        p_nom_max=1.5 * unit_size,
+        p_nom_extendable=True,
+    )
+    n.add(
+        "Link",
+        "Link4",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=0,
+        p_nom_opt=1.5 * unit_size,
+        p_nom_extendable=True,
+    )
     return n
-    
+
+
 def test_post_discretization():
     """
     This test checks the post discretization function.
@@ -93,11 +96,11 @@ def test_post_discretization():
         axis=1,
     )
 
-    assert (n.links.loc["Link0"].p_nom == unit_size)
-    assert (n.links.loc["Link1"].p_nom == 2*unit_size)
-    assert (n.links.loc["Link2"].p_nom == 0.8*unit_size)
-    assert (n.links.loc["Link3"].p_nom == 1.5*unit_size)
-    assert (n.links.loc["Link4"].p_nom == 2*unit_size)
+    assert n.links.loc["Link0"].p_nom == unit_size
+    assert n.links.loc["Link1"].p_nom == 2 * unit_size
+    assert n.links.loc["Link2"].p_nom == 0.8 * unit_size
+    assert n.links.loc["Link3"].p_nom == 1.5 * unit_size
+    assert n.links.loc["Link4"].p_nom == 2 * unit_size
 
     n = build_network(unit_size=unit_size)
 
@@ -111,9 +114,9 @@ def test_post_discretization():
         ),
         axis=1,
     )
-    
-    assert (n.links.loc["Link0"].p_nom == unit_size)
-    assert (n.links.loc["Link1"].p_nom == 2*unit_size)
-    assert (n.links.loc["Link2"].p_nom == 0)
-    assert (n.links.loc["Link3"].p_nom == unit_size)
-    assert (n.links.loc["Link4"].p_nom == 2*unit_size)
+
+    assert n.links.loc["Link0"].p_nom == unit_size
+    assert n.links.loc["Link1"].p_nom == 2 * unit_size
+    assert n.links.loc["Link2"].p_nom == 0
+    assert n.links.loc["Link3"].p_nom == unit_size
+    assert n.links.loc["Link4"].p_nom == 2 * unit_size

--- a/test/test_link_post_discretization.py
+++ b/test/test_link_post_discretization.py
@@ -1,0 +1,119 @@
+import pytest
+
+import pypsa
+
+from pypsa.optimization.abstract import discretized_capacity
+
+def build_network(unit_size=10):
+    ''''
+    Build a network with two buses and links that are have
+    - p_nom_max = unit_size
+    - p_nom_max = 2*unit_size
+    - p_nom_max < unit_size
+    - p_nom_max > unit_size and not a multiple of unit_size
+    - p_nom_max = np.inf
+    '''
+    n = pypsa.Network()
+
+    # add buses
+    n.add("Bus",
+          "Bus0")
+    n.add("Bus",
+          "Bus1")
+
+    # add links
+    n.add("Link",
+          "Link0",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=0,
+          p_nom_opt=0.5*unit_size,
+          p_nom_max=unit_size,
+          p_nom_extendable=True,
+          )
+
+    n.add("Link",
+          "Link1",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=0,
+          p_nom_opt=1.5*unit_size,
+          p_nom_max=2*unit_size,
+          p_nom_extendable=True,
+          )
+    n.add("Link",
+          "Link2",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=0,
+          p_nom_opt=0.5*unit_size,
+          p_nom_max=0.8*unit_size,
+          p_nom_extendable=True,
+          )
+    n.add("Link",
+          "Link3",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=0,
+          p_nom_opt=1.3*unit_size,
+          p_nom_max=1.5*unit_size,
+          p_nom_extendable=True,
+          )
+    n.add("Link",
+          "Link4",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=0,
+          p_nom_opt=1.5*unit_size,
+          p_nom_extendable=True,
+          )
+    return n
+    
+def test_post_discretization():
+    """
+    This test checks the post discretization function.
+    If a Link has a p_nom_max that is not a multiple of the unit_size,
+    depending on the variable fractional_last_unit_size the p_nom should
+    either be the last full unit_size or the p_nom_max.
+    """
+
+    unit_size = 10
+    threshold = 0.1
+
+    n = build_network(unit_size=unit_size)
+
+    n.links["p_nom"] = n.links.apply(
+        lambda row: discretized_capacity(
+            nom_opt=row["p_nom_opt"],
+            nom_max=row["p_nom_max"],
+            unit_size=unit_size,
+            threshold=threshold,
+            fractional_last_unit_size=True,
+        ),
+        axis=1,
+    )
+
+    assert (n.links.loc["Link0"].p_nom == unit_size)
+    assert (n.links.loc["Link1"].p_nom == 2*unit_size)
+    assert (n.links.loc["Link2"].p_nom == 0.8*unit_size)
+    assert (n.links.loc["Link3"].p_nom == 1.5*unit_size)
+    assert (n.links.loc["Link4"].p_nom == 2*unit_size)
+
+    n = build_network(unit_size=unit_size)
+
+    n.links["p_nom"] = n.links.apply(
+        lambda row: discretized_capacity(
+            nom_opt=row["p_nom_opt"],
+            nom_max=row["p_nom_max"],
+            unit_size=unit_size,
+            threshold=threshold,
+            fractional_last_unit_size=False,
+        ),
+        axis=1,
+    )
+    
+    assert (n.links.loc["Link0"].p_nom == unit_size)
+    assert (n.links.loc["Link1"].p_nom == 2*unit_size)
+    assert (n.links.loc["Link2"].p_nom == 0)
+    assert (n.links.loc["Link3"].p_nom == unit_size)
+    assert (n.links.loc["Link4"].p_nom == 2*unit_size)

--- a/test/test_link_post_discretization.py
+++ b/test/test_link_post_discretization.py
@@ -30,45 +30,50 @@ def build_network(unit_size=10):
         p_nom_extendable=True,
     )
 
-    n.add(
-        "Link",
-        "Link1",
-        bus0="Bus0",
-        bus1="Bus1",
-        p_nom=0,
-        p_nom_opt=1.5 * unit_size,
-        p_nom_max=2 * unit_size,
-        p_nom_extendable=True,
-    )
-    n.add(
-        "Link",
-        "Link2",
-        bus0="Bus0",
-        bus1="Bus1",
-        p_nom=0,
-        p_nom_opt=0.5 * unit_size,
-        p_nom_max=0.8 * unit_size,
-        p_nom_extendable=True,
-    )
-    n.add(
-        "Link",
-        "Link3",
-        bus0="Bus0",
-        bus1="Bus1",
-        p_nom=0,
-        p_nom_opt=1.3 * unit_size,
-        p_nom_max=1.5 * unit_size,
-        p_nom_extendable=True,
-    )
-    n.add(
-        "Link",
-        "Link4",
-        bus0="Bus0",
-        bus1="Bus1",
-        p_nom=0,
-        p_nom_opt=1.5 * unit_size,
-        p_nom_extendable=True,
-    )
+    n.add("Link",
+          "Link1",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=0,
+          p_nom_opt=1.5*unit_size,
+          p_nom_max=2*unit_size,
+          p_nom_extendable=True,
+          )
+    n.add("Link",
+          "Link2",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=0,
+          p_nom_opt=0.5*unit_size,
+          p_nom_max=0.8*unit_size,
+          p_nom_extendable=True,
+          )
+    n.add("Link",
+          "Link3",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=0,
+          p_nom_opt=1.3*unit_size,
+          p_nom_max=1.5*unit_size,
+          p_nom_extendable=True,
+          )
+    n.add("Link",
+          "Link4",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=5,
+          p_nom_opt=1.1*unit_size,
+          p_nom_max=1.5*unit_size,
+          p_nom_extendable=True,
+          )
+    n.add("Link",
+          "Link5",
+          bus0="Bus0",
+          bus1="Bus1",
+          p_nom=0,
+          p_nom_opt=1.5*unit_size,
+          p_nom_extendable=True,
+          )
     return n
 
 
@@ -81,7 +86,6 @@ def test_post_discretization():
     """
 
     unit_size = 10
-    threshold = 0.1
 
     n = build_network(unit_size=unit_size)
 
@@ -90,17 +94,25 @@ def test_post_discretization():
             nom_opt=row["p_nom_opt"],
             nom_max=row["p_nom_max"],
             unit_size=unit_size,
-            threshold=threshold,
+            threshold=0.3,
             fractional_last_unit_size=True,
         ),
         axis=1,
     )
 
-    assert n.links.loc["Link0"].p_nom == unit_size
-    assert n.links.loc["Link1"].p_nom == 2 * unit_size
-    assert n.links.loc["Link2"].p_nom == 0.8 * unit_size
-    assert n.links.loc["Link3"].p_nom == 1.5 * unit_size
-    assert n.links.loc["Link4"].p_nom == 2 * unit_size
+    # p_nom_opt   | p_nom_max | p_nom     | unit_size
+    # 5           | 10        | 10        | 10
+    assert (n.links.loc["Link0"].p_nom == unit_size)
+    # 15          | 20        | 20        | 10
+    assert (n.links.loc["Link1"].p_nom == 2*unit_size)
+    # 5           | 8         | 8         | 10
+    assert (n.links.loc["Link2"].p_nom == 0.8*unit_size)
+    # 13          | 15        | 15        | 10
+    assert (n.links.loc["Link3"].p_nom == 1.5*unit_size)
+    # 11          | 15        | 5         | 10
+    assert (n.links.loc["Link4"].p_nom == unit_size)
+    # 15          | inf       | 20        | 10
+    assert (n.links.loc["Link5"].p_nom == 2*unit_size)
 
     n = build_network(unit_size=unit_size)
 
@@ -109,14 +121,22 @@ def test_post_discretization():
             nom_opt=row["p_nom_opt"],
             nom_max=row["p_nom_max"],
             unit_size=unit_size,
-            threshold=threshold,
+            threshold=0.3,
             fractional_last_unit_size=False,
         ),
         axis=1,
     )
-
-    assert n.links.loc["Link0"].p_nom == unit_size
-    assert n.links.loc["Link1"].p_nom == 2 * unit_size
-    assert n.links.loc["Link2"].p_nom == 0
-    assert n.links.loc["Link3"].p_nom == unit_size
-    assert n.links.loc["Link4"].p_nom == 2 * unit_size
+    
+    # p_nom_opt   | p_nom_max | p_nom     | unit_size
+    # 5           | 10        | 10        | 10
+    assert (n.links.loc["Link0"].p_nom == unit_size)
+    # 15          | 20        | 20        | 10
+    assert (n.links.loc["Link1"].p_nom == 2*unit_size)
+    # 5           | 8         | 0         | 10
+    assert (n.links.loc["Link2"].p_nom == 0)
+    # 13          | 15        | 10        | 10
+    assert (n.links.loc["Link3"].p_nom == unit_size)
+    # 11          | 15        | 10        | 10
+    assert (n.links.loc["Link4"].p_nom == unit_size)
+    # 15          | inf       | 20        | 10
+    assert (n.links.loc["Link5"].p_nom == 2*unit_size)

--- a/test/test_link_post_discretization.py
+++ b/test/test_link_post_discretization.py
@@ -30,50 +30,55 @@ def build_network(unit_size=10):
         p_nom_extendable=True,
     )
 
-    n.add("Link",
-          "Link1",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=0,
-          p_nom_opt=1.5*unit_size,
-          p_nom_max=2*unit_size,
-          p_nom_extendable=True,
-          )
-    n.add("Link",
-          "Link2",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=0,
-          p_nom_opt=0.5*unit_size,
-          p_nom_max=0.8*unit_size,
-          p_nom_extendable=True,
-          )
-    n.add("Link",
-          "Link3",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=0,
-          p_nom_opt=1.3*unit_size,
-          p_nom_max=1.5*unit_size,
-          p_nom_extendable=True,
-          )
-    n.add("Link",
-          "Link4",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=5,
-          p_nom_opt=1.1*unit_size,
-          p_nom_max=1.5*unit_size,
-          p_nom_extendable=True,
-          )
-    n.add("Link",
-          "Link5",
-          bus0="Bus0",
-          bus1="Bus1",
-          p_nom=0,
-          p_nom_opt=1.5*unit_size,
-          p_nom_extendable=True,
-          )
+    n.add(
+        "Link",
+        "Link1",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=0,
+        p_nom_opt=1.5 * unit_size,
+        p_nom_max=2 * unit_size,
+        p_nom_extendable=True,
+    )
+    n.add(
+        "Link",
+        "Link2",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=0,
+        p_nom_opt=0.5 * unit_size,
+        p_nom_max=0.8 * unit_size,
+        p_nom_extendable=True,
+    )
+    n.add(
+        "Link",
+        "Link3",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=0,
+        p_nom_opt=1.3 * unit_size,
+        p_nom_max=1.5 * unit_size,
+        p_nom_extendable=True,
+    )
+    n.add(
+        "Link",
+        "Link4",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=5,
+        p_nom_opt=1.1 * unit_size,
+        p_nom_max=1.5 * unit_size,
+        p_nom_extendable=True,
+    )
+    n.add(
+        "Link",
+        "Link5",
+        bus0="Bus0",
+        bus1="Bus1",
+        p_nom=0,
+        p_nom_opt=1.5 * unit_size,
+        p_nom_extendable=True,
+    )
     return n
 
 
@@ -102,17 +107,17 @@ def test_post_discretization():
 
     # p_nom_opt   | p_nom_max | p_nom     | unit_size
     # 5           | 10        | 10        | 10
-    assert (n.links.loc["Link0"].p_nom == unit_size)
+    assert n.links.loc["Link0"].p_nom == unit_size
     # 15          | 20        | 20        | 10
-    assert (n.links.loc["Link1"].p_nom == 2*unit_size)
+    assert n.links.loc["Link1"].p_nom == 2 * unit_size
     # 5           | 8         | 8         | 10
-    assert (n.links.loc["Link2"].p_nom == 0.8*unit_size)
+    assert n.links.loc["Link2"].p_nom == 0.8 * unit_size
     # 13          | 15        | 15        | 10
-    assert (n.links.loc["Link3"].p_nom == 1.5*unit_size)
+    assert n.links.loc["Link3"].p_nom == 1.5 * unit_size
     # 11          | 15        | 5         | 10
-    assert (n.links.loc["Link4"].p_nom == unit_size)
+    assert n.links.loc["Link4"].p_nom == unit_size
     # 15          | inf       | 20        | 10
-    assert (n.links.loc["Link5"].p_nom == 2*unit_size)
+    assert n.links.loc["Link5"].p_nom == 2 * unit_size
 
     n = build_network(unit_size=unit_size)
 
@@ -126,17 +131,17 @@ def test_post_discretization():
         ),
         axis=1,
     )
-    
+
     # p_nom_opt   | p_nom_max | p_nom     | unit_size
     # 5           | 10        | 10        | 10
-    assert (n.links.loc["Link0"].p_nom == unit_size)
+    assert n.links.loc["Link0"].p_nom == unit_size
     # 15          | 20        | 20        | 10
-    assert (n.links.loc["Link1"].p_nom == 2*unit_size)
+    assert n.links.loc["Link1"].p_nom == 2 * unit_size
     # 5           | 8         | 0         | 10
-    assert (n.links.loc["Link2"].p_nom == 0)
+    assert n.links.loc["Link2"].p_nom == 0
     # 13          | 15        | 10        | 10
-    assert (n.links.loc["Link3"].p_nom == unit_size)
+    assert n.links.loc["Link3"].p_nom == unit_size
     # 11          | 15        | 10        | 10
-    assert (n.links.loc["Link4"].p_nom == unit_size)
+    assert n.links.loc["Link4"].p_nom == unit_size
     # 15          | inf       | 20        | 10
-    assert (n.links.loc["Link5"].p_nom == 2*unit_size)
+    assert n.links.loc["Link5"].p_nom == 2 * unit_size


### PR DESCRIPTION
## Problem
When post discretizing links with a `p_nom_max` the current code assigned the full `link_unit_size` from the config once the `link_threshold` was passed even if the `p_nom_max` was smaller than that.
This especially came into play when post discretizing the `H2 pipeline retrofitted` links.
E.g. 
``` 
unit_size = 13000
threshold = 0.05
p_nom_max = 900
p_nom_opt = 450
``` 
A pipeline with a maximum capacity of 900 MW reached the threshold of 5 % of the unit_size (13 000 MW) with a `p_nom_opt` of 700 MW. So far, this link would now be assigned a `p_nom_opt` of 13000 MW.

## Changes proposed in this Pull Request
This PR introduces a new config setting `[solving][post_discretization][fractional_last_unit]`

### True
With this configuration, the example from above would be built up to the full `p_nom_max` as soon as the threshold is reached (but this time compared to the `p_nom_max` value not the `unit_size`.
In general, if the `p_nom_max` does not happen to be a multiple of the `unit_size`, the optimization will take the maximum possible capacity (= `p_nom_max`).

### False
With this configuration, the example from above would not build out any capacity.
In general, if the `p_nom_max` does not happen to be a multiple of the `unit_size`, the optimization will take the last full unit_size and does not allow for any fractional expansion.

### Testing
Tested with the pypsa-ariadne workflow
```
post_discretization:
      enable: true
      link_unit_size:
        H2 pipeline retrofitted: 13000
      link_threshold:
        H2 pipeline retrofitted: 0.05
      fractional_last_unit_size: false
```

Before applying the function `discretized_capacity`
```
WARNING:pypsa.optimization.abstract:Debugging: changing p_nom to p_nom_max
INFO:pypsa.optimization.abstract:                                                    p_nom    p_nom_opt  p_nom_max
Link                                                                             
H2 pipeline retrofitted BE0 0 -> FR0 0-2030      0.817805     0.817805     2700.0
H2 pipeline retrofitted BE0 0 -> NL0 0-2030      1.310970     1.310970      900.0
H2 pipeline retrofitted BE0 0 <-> FR0 0-2030  1055.665993  1055.665993     2700.0
H2 pipeline retrofitted BE0 0 <-> NL0 0-2030   840.418866   840.418866      900.0
H2 pipeline retrofitted CH0 0 -> AT0 0-2030    882.221856   882.221856      900.0
H2 pipeline retrofitted CZ0 0 -> PL0 0-2030      2.993816     2.993816     1800.0
H2 pipeline retrofitted DE0 0 -> DE0 6-2030    330.090328   330.090328      900.0
H2 pipeline retrofitted DE0 0 -> DE0 7-2030   1341.291056  1341.291056     7605.0
H2 pipeline retrofitted DE0 0 -> NL0 0-2030      7.760653     7.760653      900.0
H2 pipeline retrofitted DE0 1 -> DE0 4-2030    475.828494   475.828494      900.0
H2 pipeline retrofitted DE0 1 -> PL0 0-2030    899.999958   899.999958      900.0
H2 pipeline retrofitted DE0 1 <-> CZ0 0-2030   899.999848   899.999848      900.0
H2 pipeline retrofitted DE0 2 -> CH0 0-2030     36.502717    36.502717      900.0
H2 pipeline retrofitted DE0 2 -> FR0 0-2030     29.094191    29.094191     1800.0
H2 pipeline retrofitted DE0 2 <-> CH0 0-2030   899.524929   899.524929      900.0
H2 pipeline retrofitted DE0 3 -> DE0 1-2030    899.999910   899.999910      900.0
H2 pipeline retrofitted DE0 3 -> DE0 4-2030    686.406707   686.406707     1800.0
H2 pipeline retrofitted DE0 3 -> DE0 7-2030      0.242473     0.242473     1800.0
H2 pipeline retrofitted DE0 4 -> DE0 6-2030    911.993633   911.993633     1800.0
H2 pipeline retrofitted DE0 6 -> DE0 7-2030      0.021228     0.021228     1800.0
H2 pipeline retrofitted DE0 6 -> FR0 0-2030    475.767482   475.767482      900.0
H2 pipeline retrofitted DE0 7 -> DE0 0-2030      0.522896     0.522896     1800.0
H2 pipeline retrofitted DE0 7 -> DE0 3-2030   5044.820056  5044.820056     6300.0
H2 pipeline retrofitted DE0 7 -> NL0 0-2030    899.999687   899.999687      900.0
H2 pipeline retrofitted DE0 7 <-> DE0 0-2030     0.430769     0.430769      900.0
H2 pipeline retrofitted DE0 7 <-> NL0 0-2030   899.999686   899.999686      900.0
H2 pipeline retrofitted DK0 0 -> DE0 3-2030    899.999963   899.999963      900.0
H2 pipeline retrofitted DK0 0 -> DK1 0-2030     78.417225    78.417225      900.0
H2 pipeline retrofitted DK0 0 -> NO1 0-2030    228.663939   228.663939     1800.0
H2 pipeline retrofitted ES0 0 -> FR0 0-2030   1799.999905  1799.999905     1800.0
H2 pipeline retrofitted ES2 0 -> ES0 0-2030    899.999965   899.999965      900.0
H2 pipeline retrofitted FR0 0 -> DE0 0-2030    326.820553   326.820553     1800.0
H2 pipeline retrofitted FR0 0 -> DE0 2-2030    110.702222   110.702222    13020.0
H2 pipeline retrofitted FR0 0 -> ES0 0-2030    899.999965   899.999965      900.0
H2 pipeline retrofitted FR0 0 <-> BE0 0-2030     0.162018     0.162018      900.0
H2 pipeline retrofitted GB3 0 -> NL0 0-2030    869.670379   869.670379     1800.0
H2 pipeline retrofitted GB3 0 -> NO1 0-2030      0.001575     0.001575     3600.0
H2 pipeline retrofitted GB4 0 -> GB3 0-2030    899.999868   899.999868      900.0
H2 pipeline retrofitted LU0 0 -> FR0 0-2030     15.711970    15.711970      900.0
H2 pipeline retrofitted NL0 0 -> BE0 0-2030    566.262431   566.262431      900.0
H2 pipeline retrofitted NL0 0 -> DE0 0-2030    133.025466   133.025466     1800.0
H2 pipeline retrofitted NL0 0 -> DE0 7-2030    899.999804   899.999804      900.0
H2 pipeline retrofitted NL0 0 -> GB3 0-2030     71.835365    71.835365      900.0
H2 pipeline retrofitted NL0 0 -> NO1 0-2030      0.001044     0.001044      900.0
H2 pipeline retrofitted NL0 0 <-> DE0 7-2030   899.999804   899.999804      900.0
H2 pipeline retrofitted NO1 0 -> GB3 0-2030      0.001275     0.001275     1449.0
H2 pipeline retrofitted PL0 0 -> CZ0 0-2030   1523.127874  1523.127874     3600.0
``` 
After applying the function
```
INFO:pypsa.optimization.abstract:                                              p_nom    p_nom_opt  p_nom_max
Link                                                                       
H2 pipeline retrofitted BE0 0 -> FR0 0-2030     0.0     0.817805     2700.0
H2 pipeline retrofitted BE0 0 -> NL0 0-2030     0.0     1.310970      900.0
H2 pipeline retrofitted BE0 0 <-> FR0 0-2030    0.0  1055.665993     2700.0
H2 pipeline retrofitted BE0 0 <-> NL0 0-2030    0.0   840.418866      900.0
H2 pipeline retrofitted CH0 0 -> AT0 0-2030     0.0   882.221856      900.0
H2 pipeline retrofitted CZ0 0 -> PL0 0-2030     0.0     2.993816     1800.0
H2 pipeline retrofitted DE0 0 -> DE0 6-2030     0.0   330.090328      900.0
H2 pipeline retrofitted DE0 0 -> DE0 7-2030     0.0  1341.291056     7605.0
H2 pipeline retrofitted DE0 0 -> NL0 0-2030     0.0     7.760653      900.0
H2 pipeline retrofitted DE0 1 -> DE0 4-2030     0.0   475.828494      900.0
H2 pipeline retrofitted DE0 1 -> PL0 0-2030     0.0   899.999958      900.0
H2 pipeline retrofitted DE0 1 <-> CZ0 0-2030    0.0   899.999848      900.0
H2 pipeline retrofitted DE0 2 -> CH0 0-2030     0.0    36.502717      900.0
H2 pipeline retrofitted DE0 2 -> FR0 0-2030     0.0    29.094191     1800.0
H2 pipeline retrofitted DE0 2 <-> CH0 0-2030    0.0   899.524929      900.0
H2 pipeline retrofitted DE0 3 -> DE0 1-2030     0.0   899.999910      900.0
H2 pipeline retrofitted DE0 3 -> DE0 4-2030     0.0   686.406707     1800.0
H2 pipeline retrofitted DE0 3 -> DE0 7-2030     0.0     0.242473     1800.0
H2 pipeline retrofitted DE0 4 -> DE0 6-2030     0.0   911.993633     1800.0
H2 pipeline retrofitted DE0 6 -> DE0 7-2030     0.0     0.021228     1800.0
H2 pipeline retrofitted DE0 6 -> FR0 0-2030     0.0   475.767482      900.0
H2 pipeline retrofitted DE0 7 -> DE0 0-2030     0.0     0.522896     1800.0
H2 pipeline retrofitted DE0 7 -> DE0 3-2030     0.0  5044.820056     6300.0
H2 pipeline retrofitted DE0 7 -> NL0 0-2030     0.0   899.999687      900.0
H2 pipeline retrofitted DE0 7 <-> DE0 0-2030    0.0     0.430769      900.0
H2 pipeline retrofitted DE0 7 <-> NL0 0-2030    0.0   899.999686      900.0
H2 pipeline retrofitted DK0 0 -> DE0 3-2030     0.0   899.999963      900.0
H2 pipeline retrofitted DK0 0 -> DK1 0-2030     0.0    78.417225      900.0
H2 pipeline retrofitted DK0 0 -> NO1 0-2030     0.0   228.663939     1800.0
H2 pipeline retrofitted ES0 0 -> FR0 0-2030     0.0  1799.999905     1800.0
H2 pipeline retrofitted ES2 0 -> ES0 0-2030     0.0   899.999965      900.0
H2 pipeline retrofitted FR0 0 -> DE0 0-2030     0.0   326.820553     1800.0
H2 pipeline retrofitted FR0 0 -> DE0 2-2030     0.0   110.702222    13020.0
H2 pipeline retrofitted FR0 0 -> ES0 0-2030     0.0   899.999965      900.0
H2 pipeline retrofitted FR0 0 <-> BE0 0-2030    0.0     0.162018      900.0
H2 pipeline retrofitted GB3 0 -> NL0 0-2030     0.0   869.670379     1800.0
H2 pipeline retrofitted GB3 0 -> NO1 0-2030     0.0     0.001575     3600.0
H2 pipeline retrofitted GB4 0 -> GB3 0-2030     0.0   899.999868      900.0
H2 pipeline retrofitted LU0 0 -> FR0 0-2030     0.0    15.711970      900.0
H2 pipeline retrofitted NL0 0 -> BE0 0-2030     0.0   566.262431      900.0
H2 pipeline retrofitted NL0 0 -> DE0 0-2030     0.0   133.025466     1800.0
H2 pipeline retrofitted NL0 0 -> DE0 7-2030     0.0   899.999804      900.0
H2 pipeline retrofitted NL0 0 -> GB3 0-2030     0.0    71.835365      900.0
H2 pipeline retrofitted NL0 0 -> NO1 0-2030     0.0     0.001044      900.0
H2 pipeline retrofitted NL0 0 <-> DE0 7-2030    0.0   899.999804      900.0
H2 pipeline retrofitted NO1 0 -> GB3 0-2030     0.0     0.001275     1449.0
H2 pipeline retrofitted PL0 0 -> CZ0 0-2030     0.0  1523.127874     3600.0
``` 

```
post_discretization:
      enable: true
      link_unit_size:
        H2 pipeline retrofitted: 13000
      link_threshold:
        H2 pipeline retrofitted: 0.05
      fractional_last_unit_size: true
```
Before applying the function `discretized_capacity`
```
INFO:pypsa.optimization.abstract:                                                    p_nom    p_nom_opt  p_nom_max
Link                                                                             
H2 pipeline retrofitted BE0 0 -> FR0 0-2030      3.917499     3.917499     2700.0
H2 pipeline retrofitted BE0 0 -> NL0 0-2030      4.824701     4.824701      900.0
H2 pipeline retrofitted BE0 0 <-> FR0 0-2030  1053.779734  1053.779734     2700.0
H2 pipeline retrofitted BE0 0 <-> NL0 0-2030   837.093523   837.093523      900.0
H2 pipeline retrofitted CH0 0 -> AT0 0-2030    881.895727   881.895727      900.0
H2 pipeline retrofitted CZ0 0 -> PL0 0-2030      4.363079     4.363079     1800.0
H2 pipeline retrofitted DE0 0 -> DE0 6-2030    329.717862   329.717862      900.0
H2 pipeline retrofitted DE0 0 -> DE0 7-2030   1338.735698  1338.735698     7605.0
H2 pipeline retrofitted DE0 0 -> NL0 0-2030      6.992419     6.992419      900.0
H2 pipeline retrofitted DE0 1 -> DE0 4-2030    475.946811   475.946811      900.0
H2 pipeline retrofitted DE0 1 -> PL0 0-2030    899.999704   899.999704      900.0
H2 pipeline retrofitted DE0 1 <-> CZ0 0-2030   899.998967   899.998967      900.0
H2 pipeline retrofitted DE0 2 -> CH0 0-2030     38.339587    38.339587      900.0
H2 pipeline retrofitted DE0 2 -> FR0 0-2030     27.990061    27.990061     1800.0
H2 pipeline retrofitted DE0 2 <-> CH0 0-2030   897.140323   897.140323      900.0
H2 pipeline retrofitted DE0 3 -> DE0 1-2030    899.999373   899.999373      900.0
H2 pipeline retrofitted DE0 3 -> DE0 4-2030    686.420406   686.420406     1800.0
H2 pipeline retrofitted DE0 3 -> DE0 7-2030      1.061111     1.061111     1800.0
H2 pipeline retrofitted DE0 4 -> DE0 6-2030    911.990801   911.990801     1800.0
H2 pipeline retrofitted DE0 6 -> DE0 7-2030      0.101101     0.101101     1800.0
H2 pipeline retrofitted DE0 6 -> FR0 0-2030    475.603808   475.603808      900.0
H2 pipeline retrofitted DE0 7 -> DE0 0-2030      1.874504     1.874504     1800.0
H2 pipeline retrofitted DE0 7 -> DE0 3-2030   5044.198457  5044.198457     6300.0
H2 pipeline retrofitted DE0 7 -> NL0 0-2030    899.997245   899.997245      900.0
H2 pipeline retrofitted DE0 7 <-> DE0 0-2030     1.538789     1.538789      900.0
H2 pipeline retrofitted DE0 7 <-> NL0 0-2030   899.997224   899.997224      900.0
H2 pipeline retrofitted DK0 0 -> DE0 3-2030    899.999731   899.999731      900.0
H2 pipeline retrofitted DK0 0 -> DK1 0-2030     78.713367    78.713367      900.0
H2 pipeline retrofitted DK0 0 -> NO1 0-2030    228.657212   228.657212     1800.0
H2 pipeline retrofitted ES0 0 -> FR0 0-2030   1799.999556  1799.999556     1800.0
H2 pipeline retrofitted ES2 0 -> ES0 0-2030    899.999763   899.999763      900.0
H2 pipeline retrofitted FR0 0 -> DE0 0-2030    326.778926   326.778926     1800.0
H2 pipeline retrofitted FR0 0 -> DE0 2-2030    111.423235   111.423235    13020.0
H2 pipeline retrofitted FR0 0 -> ES0 0-2030    899.999862   899.999862      900.0
H2 pipeline retrofitted FR0 0 <-> BE0 0-2030     0.756194     0.756194      900.0
H2 pipeline retrofitted GB3 0 -> NL0 0-2030    870.128868   870.128868     1800.0
H2 pipeline retrofitted GB3 0 -> NO1 0-2030      0.008271     0.008271     3600.0
H2 pipeline retrofitted GB4 0 -> GB3 0-2030    899.999085   899.999085      900.0
H2 pipeline retrofitted LU0 0 -> FR0 0-2030     15.714430    15.714430      900.0
H2 pipeline retrofitted NL0 0 -> BE0 0-2030    567.857019   567.857019      900.0
H2 pipeline retrofitted NL0 0 -> DE0 0-2030    133.406518   133.406518     1800.0
H2 pipeline retrofitted NL0 0 -> DE0 7-2030    899.998491   899.998491      900.0
H2 pipeline retrofitted NL0 0 -> GB3 0-2030     72.940968    72.940968      900.0
H2 pipeline retrofitted NL0 0 -> NO1 0-2030      0.005187     0.005187      900.0
H2 pipeline retrofitted NL0 0 <-> DE0 7-2030   899.998494   899.998494      900.0
H2 pipeline retrofitted NO1 0 -> GB3 0-2030      0.006431     0.006431     1449.0
H2 pipeline retrofitted PL0 0 -> CZ0 0-2030   1521.603683  1521.603683     3600.0
```
after applying the function
```
INFO:pypsa.optimization.abstract:                                               p_nom    p_nom_opt  p_nom_max
Link                                                                        
H2 pipeline retrofitted BE0 0 -> FR0 0-2030      0.0     3.917499     2700.0
H2 pipeline retrofitted BE0 0 -> NL0 0-2030      0.0     4.824701      900.0
H2 pipeline retrofitted BE0 0 <-> FR0 0-2030  2700.0  1053.779734     2700.0
H2 pipeline retrofitted BE0 0 <-> NL0 0-2030   900.0   837.093523      900.0
H2 pipeline retrofitted CH0 0 -> AT0 0-2030    900.0   881.895727      900.0
H2 pipeline retrofitted CZ0 0 -> PL0 0-2030      0.0     4.363079     1800.0
H2 pipeline retrofitted DE0 0 -> DE0 6-2030    900.0   329.717862      900.0
H2 pipeline retrofitted DE0 0 -> DE0 7-2030   7605.0  1338.735698     7605.0
H2 pipeline retrofitted DE0 0 -> NL0 0-2030      0.0     6.992419      900.0
H2 pipeline retrofitted DE0 1 -> DE0 4-2030    900.0   475.946811      900.0
H2 pipeline retrofitted DE0 1 -> PL0 0-2030    900.0   899.999704      900.0
H2 pipeline retrofitted DE0 1 <-> CZ0 0-2030   900.0   899.998967      900.0
H2 pipeline retrofitted DE0 2 -> CH0 0-2030      0.0    38.339587      900.0
H2 pipeline retrofitted DE0 2 -> FR0 0-2030      0.0    27.990061     1800.0
H2 pipeline retrofitted DE0 2 <-> CH0 0-2030   900.0   897.140323      900.0
H2 pipeline retrofitted DE0 3 -> DE0 1-2030    900.0   899.999373      900.0
H2 pipeline retrofitted DE0 3 -> DE0 4-2030   1800.0   686.420406     1800.0
H2 pipeline retrofitted DE0 3 -> DE0 7-2030      0.0     1.061111     1800.0
H2 pipeline retrofitted DE0 4 -> DE0 6-2030   1800.0   911.990801     1800.0
H2 pipeline retrofitted DE0 6 -> DE0 7-2030      0.0     0.101101     1800.0
H2 pipeline retrofitted DE0 6 -> FR0 0-2030    900.0   475.603808      900.0
H2 pipeline retrofitted DE0 7 -> DE0 0-2030      0.0     1.874504     1800.0
H2 pipeline retrofitted DE0 7 -> DE0 3-2030   6300.0  5044.198457     6300.0
H2 pipeline retrofitted DE0 7 -> NL0 0-2030    900.0   899.997245      900.0
H2 pipeline retrofitted DE0 7 <-> DE0 0-2030     0.0     1.538789      900.0
H2 pipeline retrofitted DE0 7 <-> NL0 0-2030   900.0   899.997224      900.0
H2 pipeline retrofitted DK0 0 -> DE0 3-2030    900.0   899.999731      900.0
H2 pipeline retrofitted DK0 0 -> DK1 0-2030    900.0    78.713367      900.0
H2 pipeline retrofitted DK0 0 -> NO1 0-2030   1800.0   228.657212     1800.0
H2 pipeline retrofitted ES0 0 -> FR0 0-2030   1800.0  1799.999556     1800.0
H2 pipeline retrofitted ES2 0 -> ES0 0-2030    900.0   899.999763      900.0
H2 pipeline retrofitted FR0 0 -> DE0 0-2030   1800.0   326.778926     1800.0
H2 pipeline retrofitted FR0 0 -> DE0 2-2030      0.0   111.423235    13020.0
H2 pipeline retrofitted FR0 0 -> ES0 0-2030    900.0   899.999862      900.0
H2 pipeline retrofitted FR0 0 <-> BE0 0-2030     0.0     0.756194      900.0
H2 pipeline retrofitted GB3 0 -> NL0 0-2030   1800.0   870.128868     1800.0
H2 pipeline retrofitted GB3 0 -> NO1 0-2030      0.0     0.008271     3600.0
H2 pipeline retrofitted GB4 0 -> GB3 0-2030    900.0   899.999085      900.0
H2 pipeline retrofitted LU0 0 -> FR0 0-2030      0.0    15.714430      900.0
H2 pipeline retrofitted NL0 0 -> BE0 0-2030    900.0   567.857019      900.0
H2 pipeline retrofitted NL0 0 -> DE0 0-2030   1800.0   133.406518     1800.0
H2 pipeline retrofitted NL0 0 -> DE0 7-2030    900.0   899.998491      900.0
H2 pipeline retrofitted NL0 0 -> GB3 0-2030    900.0    72.940968      900.0
H2 pipeline retrofitted NL0 0 -> NO1 0-2030      0.0     0.005187      900.0
H2 pipeline retrofitted NL0 0 <-> DE0 7-2030   900.0   899.998494      900.0
H2 pipeline retrofitted NO1 0 -> GB3 0-2030      0.0     0.006431     1449.0
H2 pipeline retrofitted PL0 0 -> CZ0 0-2030   3600.0  1521.603683     3600.0
```
Lines and links stay untouched. This can be checked by inserting
`logger.info(n.links[(n.links.carrier == carrier) & (n.links.p_nom_opt > 0)][["p_nom", "p_nom_opt", "p_nom_max"]])`
before and after the application of the function

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
