### PR TITLE
Bugfix in post_discretization

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,6 +11,8 @@ Release Notes
 ..   To use the features already you have to install the ``master`` branch, e.g. 
 ..   ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
 
+* Abolishing ``min_units`` in the post discretization. If the maximum capacity of a component is smaller than the specified unit size, the maximum capacity is built as soon as the threshold is passed (https://github.com/PyPSA/PyPSA/pull/1052)
+
 v0.31.0 (1st October 2024)
 ==========================
 

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -1281,8 +1281,8 @@ class Network:
             Copy snapshots and time-varying n.component_names_t data too.
 
             .. deprecated:: 0.29.0
-              Will be removed in a future version. Pass an empty list to 'snapshots'
-              instead.
+              The 'with_time' argument is deprecated in 0.29 and will be removed in a
+              future version. Pass an empty list to 'snapshots' instead.
 
         Returns
         -------

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -233,6 +233,8 @@ def optimize_transmission_expansion_iteratively(
                 ),
                 axis=1,
             )
+            # take care of the edge case of s_nom > s_nom_max
+            n.lines["s_nom_max"] = n.lines[["s_nom", "s_nom_max"]].max(axis=1)
 
         if link_unit_size:
             for carrier in link_unit_size.keys() & n.links.carrier.unique():

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -29,7 +29,7 @@ def discretized_capacity(
     nom_max: float,
     unit_size: float,
     threshold: float,
-    fractional_last_unit_size: bool
+    fractional_last_unit_size: bool,
 ) -> float:
     """
     Discretize a optimal capacity to a capacity that is either a multiple of a unit size

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -30,18 +30,20 @@ def discretized_capacity(
     unit_size: float,
     threshold: float,
     fractional_last_unit_size: bool,
+    min_units: int | None = None,
 ) -> float:
     """
     Discretize a optimal capacity to a capacity that is either a multiple of a unit size
     or the maximum capacity, depending on the variable `fractional_last_unit_size`.
 
-    This function checks if the optimal capacity is within the threshold of the unit size.
-    If so, it returns the next multiple of the unit size - if not it returns the last multiple
-    of the unit size.
-    In the special case that the maximum capacity is not a multiple of the unit size, the variable
-    `fractional_last_unit_size` determines if the returned capacity is the maximum capacity (True)
-    or the last multiple of the unit size (False).
-    In case the maximum capacity is lower than the unit size, the function returns the maximum capacity.
+    This function checks if the optimal capacity is within the threshold of the unit
+    size. If so, it returns the next multiple of the unit size - if not it returns the
+    last multiple of the unit size.
+    In the special case that the maximum capacity is not a multiple of the unit size,
+    the variable `fractional_last_unit_size` determines if the returned capacity is the
+    maximum capacity (True) or the last multiple of the unit size (False).
+    In case the maximum capacity is lower than the unit size, the function returns the
+    maximum capacity.
 
     Parameters
     ----------
@@ -50,11 +52,16 @@ def discretized_capacity(
     nom_max : float
         The maximum capacity as defined in the network.
     unit_size : float
-        The unit size for the capacity as defined in the config[solving][post_discretization].
+        The unit size for the capacity.
     threshold : float
-        The threshold relative to the unit size for discretizing the capacity as defined in the config[solving][post_discretization].
+        The threshold relative to the unit size for discretizing the capacity.
     fractional_last_unit_size : bool
-        Whether only multiples of the unit size or the maximum capacity is allowed as defined in the config[solving][post_discretization].
+        Whether only multiples of the unit size or the maximum capacity.
+    min_units: int, default None
+        The minimum number of units that should be installed.
+
+        .. deprecated:: 0.31
+            The `min_units` parameter is deprecated and will be removed in future versions.
 
     Returns
     -------
@@ -92,8 +99,17 @@ def discretized_capacity(
     fractional_last_unit_size = False)
     4
     """
+    if min_units is not None:
+        raise DeprecationWarning(
+            "The `min_units` parameter is deprecated and will be removed in future "
+            "versions."
+        )
     units = nom_opt // unit_size + (nom_opt % unit_size >= threshold * unit_size)
-    block_capacity = units * unit_size
+
+    if min_units is not None:
+        block_capacity = max(min_units, units) * unit_size
+    else:
+        block_capacity = units * unit_size
     if nom_max % unit_size == 0:
         return block_capacity
 

--- a/test/test_link_post_discretization.py
+++ b/test/test_link_post_discretization.py
@@ -138,7 +138,7 @@ def test_post_discretization():
     # 15          | 20        | 20        | 10
     assert n.links.loc["Link1"].p_nom == 2 * unit_size
     # 5           | 8         | 0         | 10
-    assert n.links.loc["Link2"].p_nom == 0
+    assert n.links.loc["Link2"].p_nom == 8
     # 13          | 15        | 10        | 10
     assert n.links.loc["Link3"].p_nom == unit_size
     # 11          | 15        | 10        | 10


### PR DESCRIPTION
The motivation of this PR was, that there are edge cases in which `nom_max >= nom_opt`.
With the following variables
```
nom_opt = 10
unit_size = 10
threshold = 0.3
min_units = 2
nom_max = 10
fractional_last_unit_size = False
```
the function `discretized_capacity` would return `nom=20`.
Since the variable `min_units` is not available as a config it is abolished. Instead if there is a `nom_max` that is smaller than one unit size, the `nom_max` is built regardless of the `fractional_last_unit_size`.
The test was altered as well.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
