### PR TITLE
Adjusted linopt logging v0.24.0

### DIFF
--- a/pypsa/linopt.py
+++ b/pypsa/linopt.py
@@ -1072,8 +1072,8 @@ def run_and_read_gurobi(
         )
     import gurobipy
 
-    # disable logging for this part, as gurobi output is doubled otherwise
-    logging.disable(50)
+    # disable logging aside from warnings and errors for this part, as gurobi output is doubled otherwise
+    logging.disable(20)
 
     m = gurobipy.read(problem_fn)
     if solver_options is not None:


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Changed logging.disable(50) to logging.disable(20) in run_and_read_gurobi in linopt.py

Reason:
- logging.disable() is required to suppress logging, as gurobi outputs would be doubled otherwise. Using logging.disable(50) suppresses nearly all logging. This is problematic as it suppresses errors and warnings which often would not be doubled. As a result, errors with Gurubi are difficult to troubleshoot as they do not output error messages.
- The commit changes this to logging.disable(20), which does not suppress errors and warnings.
- It is important to change this in 0.24.0, since PyPSA-earth still uses this version of PyPSA.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
