### PR TITLE
fix: align variables and coefficients in generators_contraints

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -2,14 +2,16 @@
 Release Notes
 #######################
 
-.. Upcoming Release
-.. ================
+Upcoming Release
+================
 
-.. .. warning:: 
+.. warning:: 
   
-..   The features listed below are not released yet, but will be part of the next release! 
-..   To use the features already you have to install the ``master`` branch, e.g. 
-..   ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
+  The features listed below are not released yet, but will be part of the next release! 
+  To use the features already you have to install the ``master`` branch, e.g. 
+  ``pip install git+https://github.com/pypsa/pypsa#egg=pypsa``.
+
+* The constraint to account for `e_sum_max`/`e_sum_min` is now skipped if not applied to any asset.   
 
 v0.31.1 (1st November 2024)
 ===========================

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1017,13 +1017,25 @@ def define_generator_constraints(n: Network, sns: Sequence) -> None:
     eh = expand_series(n.snapshot_weightings.generators[sns_], static.index)
 
     e_sum_min_set = static[static.e_sum_min > -inf].index
-    e = m[f"{c}-p"].loc[sns_, e_sum_min_set].mul(eh).sum(dim="snapshot")
-    e_sum_min = n.static(c).loc[e_sum_min_set, "e_sum_min"]
+    if not e_sum_min_set.empty:
+        e = (
+            m[f"{c}-p"]
+            .loc[sns_, e_sum_min_set]
+            .mul(eh[e_sum_min_set])
+            .sum(dim="snapshot")
+        )
+        e_sum_min = n.static(c).loc[e_sum_min_set, "e_sum_min"]
 
-    m.add_constraints(e, ">=", e_sum_min, name=f"{c}-e_sum_min")
+        m.add_constraints(e, ">=", e_sum_min, name=f"{c}-e_sum_min")
 
     e_sum_max_set = static[static.e_sum_max < inf].index
-    e = m[f"{c}-p"].loc[sns_, e_sum_max_set].mul(eh).sum(dim="snapshot")
-    e_sum_max = n.static(c).loc[e_sum_max_set, "e_sum_max"]
+    if not e_sum_max_set.empty:
+        e = (
+            m[f"{c}-p"]
+            .loc[sns_, e_sum_max_set]
+            .mul(eh[e_sum_max_set])
+            .sum(dim="snapshot")
+        )
+        e_sum_max = n.static(c).loc[e_sum_max_set, "e_sum_max"]
 
-    m.add_constraints(e, "<=", e_sum_max, name=f"{c}-e_sum_max")
+        m.add_constraints(e, "<=", e_sum_max, name=f"{c}-e_sum_max")

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import linopy
 import pandas as pd
+from deprecation import deprecated
 from linopy import LinearExpression, merge
 from numpy import inf, isfinite
 from scipy import sparse
@@ -975,7 +976,12 @@ def define_loss_constraints(
             )
 
 
-def define_generator_constraints(n: Network, sns: Sequence) -> None:
+@deprecated("Use define_total_supply_constraints instead.")
+def define_generators_constraints(n: Network, sns: Sequence) -> None:
+    return define_total_supply_constraints(n, sns)
+
+
+def define_total_supply_constraints(n: Network, sns: Sequence) -> None:
     """
     Defines energy sum constraints for generators in the network model.
 

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -29,7 +29,6 @@ from pypsa.optimization.common import get_strongly_meshed_buses, set_from_frame
 from pypsa.optimization.constraints import (
     define_fixed_nominal_constraints,
     define_fixed_operation_constraints,
-    define_generator_constraints,
     define_kirchhoff_voltage_constraints,
     define_loss_constraints,
     define_modular_constraints,
@@ -41,6 +40,7 @@ from pypsa.optimization.constraints import (
     define_ramp_limit_constraints,
     define_storage_unit_constraints,
     define_store_constraints,
+    define_total_supply_constraints,
 )
 from pypsa.optimization.global_constraints import (
     define_growth_limit,
@@ -307,7 +307,7 @@ def create_model(
     define_kirchhoff_voltage_constraints(n, sns)
     define_storage_unit_constraints(n, sns)
     define_store_constraints(n, sns)
-    define_generator_constraints(n, sns)
+    define_total_supply_constraints(n, sns)
 
     if transmission_losses:
         for c in n.passive_branch_components:


### PR DESCRIPTION
This aligns the variable with the coefficients, as well as only runs the code if the set of assets to constrain is non-empty. The non-alignment raised a UserWarning in linopy.

I also took the freedom to improve the naming of the constraint function.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
