### PR TITLE
feat: groupers and statistics package refactor

### DIFF
--- a/doc/api/statistics.rst
+++ b/doc/api/statistics.rst
@@ -31,22 +31,48 @@ Statistic methods
 Statistic groupers
 ~~~~~~~~~~~~~~~~~~~
 
-Groupers can be used in combination with the statistic methods. For example
+Groupers can be used via the ``groupby`` argument in the statistic methods. 
 
 .. code-block:: python
     
     groupers = n.statistics.groupers
-    n.statistics.capex(groupby=groupers.get_carrier)
+    n.statistics.capex(groupby=groupers.carrier)
+    # or simply
+    n.statistics.capex(groupby='carrier')
 
-Or any other grouper could be used.
+All default groupers are defined in the :class:`pypsa.statistics.grouping.Groupers` 
+class and currently included are, grouping by ..
+
+* .. :meth:`carrier <pypsa.statistics.grouping.Groupers.carrier>`
+* .. :meth:`bus_carrier <pypsa.statistics.grouping.Groupers.bus_carrier>`
+* .. :meth:`name <pypsa.statistics.grouping.Groupers.name>`
+* .. :meth:`bus <pypsa.statistics.grouping.Groupers.bus>`
+* .. :meth:`country <pypsa.statistics.grouping.Groupers.country>`
+* .. :meth:`unit <pypsa.statistics.grouping.Groupers.unit>`
+
+Custom groupers can be registered on module level via
+:meth:`pypsa.statistics.groupers.add_grouper <pypsa.statistics.grouping.Groupers.add_grouper>`.
+The key will be used as identifier in the ``groupby`` argument.
+
+Groupers can also be used to create multiindexed groupers. For example, to group by 
+bus and carrier:
+
+.. code-block:: python
+    
+    groupers = n.statistics.groupers
+    n.statistics.capex(groupby=groupers['bus', 'carrier'])
+    # or simply
+    n.statistics.capex(groupby=['bus', 'carrier'])
 
 .. autosummary::
     :toctree: _source/
 
-    ~pypsa.statistics.Groupers.get_carrier
-    ~pypsa.statistics.Groupers.get_bus_and_carrier
-    ~pypsa.statistics.Groupers.get_name_bus_and_carrier
-    ~pypsa.statistics.Groupers.get_country_and_carrier
-    ~pypsa.statistics.Groupers.get_carrier_and_bus_carrier
-    ~pypsa.statistics.Groupers.get_bus_and_carrier_and_bus_carrier
-    ~pypsa.statistics.Groupers.get_bus_unit_and_carrier
+    ~pypsa.statistics.grouping.Groupers.add_grouper
+    ~pypsa.statistics.grouping.Groupers.list_groupers
+    ~pypsa.statistics.grouping.Groupers.carrier
+    ~pypsa.statistics.grouping.Groupers.bus_carrier
+    ~pypsa.statistics.grouping.Groupers.name
+    ~pypsa.statistics.grouping.Groupers.bus
+    ~pypsa.statistics.grouping.Groupers.country
+    ~pypsa.statistics.grouping.Groupers.unit
+

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,38 +11,47 @@ Upcoming Release
   To use the features already you have to install the ``master`` branch, e.g. 
   ``pip install git+https://github.com/pypsa/pypsa``.
 
+Features
+--------
+
+* Improvements to groupers in the statistics module 
+  (https://github.com/PyPSA/PyPSA/pull/1093, https://github.com/PyPSA/PyPSA/pull/1078)
+
+  * The ``groupby`` argument now accepts keys to allow for more granular and flexible 
+    grouping.
+    For example,
+    :meth:`n.statistics.energy_balance(groupby=["bus_carrier", "carrier"]) <pypsa.statistics.StatisticsAccessor.energy_balance>`
+    groups the energy balance by bus carrier and carrier.
+
+    * Build in groupers include: 
+
+      * :meth:`pypsa.statistics.groupers.carrier <pypsa.statistics.grouping.Groupers.carrier>`
+      * :meth:`pypsa.statistics.groupers.bus_carrier <pypsa.statistics.grouping.Groupers.bus_carrier>`
+      * :meth:`pypsa.statistics.groupers.name <pypsa.statistics.grouping.Groupers.name>`
+      * :meth:`pypsa.statistics.groupers.bus <pypsa.statistics.grouping.Groupers.bus>`
+      * :meth:`pypsa.statistics.groupers.country <pypsa.statistics.grouping.Groupers.country>`
+      * :meth:`pypsa.statistics.groupers.unit <pypsa.statistics.grouping.Groupers.unit>`
+      * A list of registered groupers can be accessed via
+        :meth:`pypsa.statistics.groupers.list_groupers <pypsa.statistics.grouping.Groupers.list_groupers>`
+  
+  * Custom groupers can be registered on module level via
+    :meth:`pypsa.statistics.groupers.add_grouper <pypsa.statistics.grouping.Groupers.add_grouper>`.
+    The key will be used as identifier in the ``groupby`` argument. Check the API reference
+    for more information.
+
+  * Accessing default groupers was moved to module level and an improved API was 
+    introduced. ``n.statistics.get_carrier`` can now be accessed as 
+    :meth:`pypsa.statistics.groupers.carrier <pypsa.statistics.grouping.Groupers.carrier>`
+    and a combination of groupers can be accessed as 
+    :meth:`pypsa.statistics.groupers['bus', 'carrier'] <pypsa.statistics.grouping.Groupers.__call__>`
+    instead of ``n.statistics.groupers.get_bus_and_carrier``.
+
 * A new module ``pypsa.optimize.expressions`` was added. It contains functions to quickly 
   create expressions for the optimization model. The behavior of the functions is 
   mirroring the behavior of the ``statistics``` module and allows for similar complexity 
-  in grouping and filtering. Use it with e.g. ``n.optimize.expressions.energy_balance()``.
-
-* The constraint to account for `e_sum_max`/`e_sum_min` is now skipped if not applied to any asset.   
-* The statistics and expressions modules now supports setting the groupby argument by keys. This allows for more flexibility grouping strategy. For example, ``n.statistics.energy_balance(groupby=["bus_carrier", "carrier"])`` groups the energy balance by bus carrier and carrier.
-* Added flexible grouping support in statistics and expressions modules:
-
-  * The ``groupby`` argument now accepts keys to allow for more granular and flexible grouping.
-    Example: ``n.statistics.energy_balance(groupby=["bus", "carrier"])`` groups by both bus and carrier.
-
-  * Added custom grouping function registration via ``Groupers`` class:
-    * Register custom groupers using ``n.statistics.groupers.register_grouper(key, function)``
-    * The key will be used as identifier in the ``groupby`` argument
-    * Custom grouper functions must accept:
-      * n (Network): The PyPSA network instance
-      * c (str): Component name 
-      * port (str): Component port as integer string
-      * nice_names (bool, optional): Whether to use nice carrier names
-
-    * The function must return a pandas Series with the same length as the component index
-
-  * Built-in groupers include: "carrier", "bus_carrier", "name", "bus", "country", "unit"
-
-  * Example::
-
-      def my_custom_grouper(n, c, port=""):
-          return n.static(c)["my_column"].rename("custom")
-          
-      n.statistics.groupers.register_grouper("custom", my_custom_grouper)
-      n.statistics.energy_balance(groupby=["custom", "carrier"])
+  in grouping and filtering. Use it with e.g. 
+  :meth:`n.optimize.expressions.energy_balance() <pypsa.Network.expressions.energy_balance>`.
+  (https://github.com/PyPSA/PyPSA/pull/1044)
 
 
 `v0.31.2 <https://github.com/PyPSA/PyPSA/releases/tag/v0.31.2>`__ (27th November 2024)

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -53,9 +53,9 @@ Features
   :meth:`n.optimize.expressions.energy_balance() <pypsa.Network.expressions.energy_balance>`.
   (https://github.com/PyPSA/PyPSA/pull/1044)
 
-  * ``pytables`` is now an optional dependency for using the HDF5 format. Install 
-    it via ``pip install pypsa[hdf5]``. Otherwise it is not installed by default 
-    anymore. (https://github.com/PyPSA/PyPSA/pull/1100)
+* ``pytables`` is now an optional dependency for using the HDF5 format. Install 
+  it via ``pip install pypsa[hdf5]``. Otherwise it is not installed by default 
+  anymore. (https://github.com/PyPSA/PyPSA/pull/1100)
 
 `v0.31.2 <https://github.com/PyPSA/PyPSA/releases/tag/v0.31.2>`__ (27th November 2024)
 =======================================================================================

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -16,11 +16,11 @@ from xarray import DataArray
 
 from pypsa.descriptors import nominal_attrs
 from pypsa.statistics import (
-    AbstractStatisticsAccessor,
     get_transmission_branches,
     get_weightings,
     port_efficiency,
 )
+from pypsa.statistics.abstract import AbstractStatisticsAccessor
 from pypsa.utils import pass_none_if_keyerror
 
 logger = logging.getLogger(__name__)
@@ -137,12 +137,12 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
     def capex(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_groups: str = "sum",
         aggregate_across_components: bool = False,
-        groupby: list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
         cost_attribute: str = "capital_cost",
         include_non_extendable: bool = True,
@@ -181,12 +181,12 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
     def capacity(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_groups: str = "sum",
         aggregate_across_components: bool = False,
-        groupby: list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool | None = None,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: str | Sequence[str] | bool | None = None,
+        bus_carrier: str | Sequence[str] | None = None,
         storage: bool = False,
         nice_names: bool | None = None,
         include_non_extendable: bool = True,
@@ -236,13 +236,13 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
     def opex(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: str = "sum",
         aggregate_across_components: bool = False,
-        groupby: list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> LinearExpression:
         """
@@ -290,9 +290,9 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
         aggregate_time: str | bool = "sum",
         aggregate_groups: str = "sum",
         aggregate_across_components: bool = False,
-        groupby: list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> LinearExpression:
         """
@@ -340,13 +340,13 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
     def energy_balance(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: str = "sum",
         aggregate_across_components: bool = False,
-        groupby: list[str] | Callable | None = ["carrier", "bus_carrier"],
-        at_port: Sequence[str] | str | bool = True,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = ["carrier", "bus_carrier"],
+        at_port: bool | str | Sequence[str] = True,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
         kind: str | None = None,
     ) -> LinearExpression:
@@ -409,13 +409,13 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
     def supply(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: str = "sum",
         aggregate_across_components: bool = False,
-        groupby: list[str] | Callable | None = ["carrier", "bus_carrier"],
-        at_port: Sequence[str] | str | bool = True,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = ["carrier", "bus_carrier"],
+        at_port: bool | str | Sequence[str] = True,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> LinearExpression:
         """
@@ -442,13 +442,13 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
     def withdrawal(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: str = "sum",
         aggregate_across_components: bool = False,
-        groupby: list[str] | Callable | None = ["carrier", "bus_carrier"],
-        at_port: Sequence[str] | str | bool = True,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = ["carrier", "bus_carrier"],
+        at_port: bool | str | Sequence[str] = True,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> LinearExpression:
         """
@@ -475,13 +475,13 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
     def curtailment(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: str = "sum",
         aggregate_across_components: bool = False,
-        groupby: list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> LinearExpression:
         """
@@ -533,13 +533,13 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
     def operation(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "mean",
         aggregate_groups: str = "sum",
         aggregate_across_components: bool = False,
-        at_port: Sequence[str] | str | bool = False,
-        groupby: list[str] | Callable | None = None,
-        bus_carrier: Sequence[str] | str | None = None,
+        at_port: bool | str | Sequence[str] = False,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> LinearExpression:
         """

--- a/pypsa/statistics/__init__.py
+++ b/pypsa/statistics/__init__.py
@@ -1,0 +1,64 @@
+"""
+Statistics Accessor.
+"""
+
+from pypsa.statistics.deprecated import (
+    aggregate_timeseries,
+    filter_active_assets,
+    filter_bus_carrier,
+    get_grouping,
+)
+from pypsa.statistics.expressions import (
+    StatisticsAccessor,
+    get_operation,
+    get_transmission_branches,
+    get_transmission_carriers,
+    get_weightings,
+    port_efficiency,
+)
+from pypsa.statistics.grouping import deprecated_groupers, groupers
+from pypsa.utils import pass_empty_series_if_keyerror
+
+# Backwards compatibility
+get_carrier = deprecated_groupers.get_carrier
+get_bus_carrier = deprecated_groupers.get_bus_carrier
+get_bus = deprecated_groupers.get_bus
+get_country = deprecated_groupers.get_country
+get_unit = deprecated_groupers.get_unit
+get_name = deprecated_groupers.get_name
+get_bus_and_carrier = deprecated_groupers.get_bus_and_carrier
+get_bus_unit_and_carrier = deprecated_groupers.get_bus_unit_and_carrier
+get_name_bus_and_carrier = deprecated_groupers.get_name_bus_and_carrier
+get_country_and_carrier = deprecated_groupers.get_country_and_carrier
+get_bus_and_carrier_and_bus_carrier = (
+    deprecated_groupers.get_bus_and_carrier_and_bus_carrier
+)
+get_carrier_and_bus_carrier = deprecated_groupers.get_carrier_and_bus_carrier
+
+__all__ = [
+    groupers,
+    StatisticsAccessor,
+    get_transmission_branches,
+    get_transmission_carriers,
+    get_weightings,
+    get_operation,
+    port_efficiency,
+    # Deprecated
+    pass_empty_series_if_keyerror,
+    get_carrier,
+    get_bus_carrier,
+    get_bus,
+    get_country,
+    get_unit,
+    get_name,
+    get_bus_and_carrier,
+    get_bus_unit_and_carrier,
+    get_name_bus_and_carrier,
+    get_country_and_carrier,
+    get_bus_and_carrier_and_bus_carrier,
+    get_carrier_and_bus_carrier,
+    aggregate_timeseries,
+    filter_active_assets,
+    filter_bus_carrier,
+    get_grouping,
+]

--- a/pypsa/statistics/abstract.py
+++ b/pypsa/statistics/abstract.py
@@ -1,0 +1,290 @@
+"""
+Statistics Accessor.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Collection, Sequence
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pypsa import Network
+
+import warnings
+
+import pandas as pd
+
+from pypsa.statistics.grouping import deprecated_groupers, groupers
+
+logger = logging.getLogger(__name__)
+
+
+class Parameters:
+    """
+    Container for all the parameters.
+
+    Attributes
+    ----------
+        drop_zero (bool): Flag indicating whether to drop zero values in statistic metrics.
+        nice_names (bool): Flag indicating whether to use nice names in statistic metrics.
+        round (int): Number of decimal places to round the values to in statistic metrics.
+
+    Methods
+    -------
+        set_parameters(**kwargs): Sets the values of the parameters based on the provided keyword arguments.
+    """
+
+    PARAMETER_TYPES = {
+        "drop_zero": bool,
+        "nice_names": bool,
+        "round": int,
+    }
+
+    def __init__(self) -> None:
+        self.drop_zero = True
+        self.nice_names = True
+        self.round = 5
+
+    def __repr__(self) -> str:
+        param_str = ", ".join(
+            f"{key}={getattr(self, key)}" for key in self.PARAMETER_TYPES
+        )
+        return f"Parameters({param_str})"
+
+    def set_parameters(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            expected_type = self.PARAMETER_TYPES.get(key)
+            if expected_type is None:
+                raise ValueError(
+                    f"Invalid parameter name: {key} \n Possible parameters are {list(self.PARAMETER_TYPES.keys())}"
+                )
+            elif not isinstance(value, expected_type):
+                raise ValueError(
+                    f"Invalid type for parameter {key}: expected {expected_type.__name__}, got {type(value).__name__}"
+                )
+            else:
+                setattr(self, key, value)
+
+
+class AbstractStatisticsAccessor(ABC):
+    """
+    Abstract accessor to calculate different statistical values.
+    """
+
+    def __init__(self, n: Network) -> None:
+        self.n = n
+        self.groupers = deprecated_groupers
+        self.parameters = Parameters()
+
+    def set_parameters(self, **kwargs: Any) -> None:
+        """
+        Setting the parameters for the statistics accessor.
+
+        To see the list of parameters, one can simply call `n.statistics.parameters`.
+        """
+        self.parameters.set_parameters(**kwargs)
+
+    def _get_grouping(
+        self,
+        n: Network,
+        c: str,
+        groupby: Callable | Sequence[str] | str | bool,
+        port: str | None = None,
+        nice_names: bool = False,
+    ) -> dict:
+        by = None
+        level = None
+        if callable(groupby):
+            try:
+                by = groupby(n, c, port=port, nice_names=nice_names)
+            except TypeError:
+                by = groupby(n, c, nice_names=nice_names)
+        elif isinstance(groupby, (str, list)):
+            by = groupers[groupby](n, c, port=port, nice_names=nice_names)
+        elif groupby is not False:
+            msg = f"Argument `groupby` must be a function, list, string, False or dict, got {repr(groupby)}."
+            raise ValueError(msg)
+        return dict(by=by, level=level)
+
+    @property
+    def is_multi_indexed(self) -> bool:
+        return isinstance(self.n.snapshots, pd.MultiIndex)
+
+    @classmethod
+    def _aggregate_timeseries(
+        cls, obj: Any, weights: pd.Series, agg: str | Callable | bool = "sum"
+    ) -> Any:
+        """
+        Calculate the weighted sum or average of a DataFrame or Series.
+        """
+        if not agg:
+            return obj.T if isinstance(obj, pd.DataFrame) else obj
+
+        if agg == "mean":
+            if isinstance(weights.index, pd.MultiIndex):
+                weights = weights.groupby(level=0).transform(lambda w: w / w.sum())
+            else:
+                weights = weights / weights.sum()
+            agg = "sum"
+
+        return cls._aggregate_with_weights(obj, weights, agg)
+
+    # The following methods are implemented in the concrete classes
+    @abstractmethod
+    def _aggregate_with_weights(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    @abstractmethod
+    def _aggregate_components_groupby(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    @abstractmethod
+    def _aggregate_components_concat_values(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    @abstractmethod
+    def _aggregate_components_concat_data(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    @abstractmethod
+    def _aggregate_across_components(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    @abstractmethod
+    def _get_component_index(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    @abstractmethod
+    def _concat_periods(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    def _aggregate_components(
+        self,
+        func: Callable,
+        agg: Callable | str = "sum",
+        comps: Collection[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        aggregate_across_components: bool = False,
+        at_port: str | Sequence[str] | bool | None = None,
+        bus_carrier: str | Sequence[str] | None = None,
+        nice_names: bool | None = True,
+    ) -> pd.Series | pd.DataFrame:
+        """
+        Apply a function and group the result for a collection of components.
+        """
+        d = {}
+        n = self.n
+
+        if is_one_component := isinstance(comps, str):
+            comps = [comps]
+        if comps is None:
+            comps = n.branch_components | n.one_port_components
+        if nice_names is None:
+            nice_names = self.parameters.nice_names
+        for c in comps:
+            if n.static(c).empty:
+                continue
+
+            ports = [str(col)[3:] for col in n.static(c) if str(col).startswith("bus")]
+            if not at_port:
+                ports = [ports[0]]
+
+            values = []
+            for port in ports:
+                vals = func(n, c, port)
+                if self._aggregate_components_skip_iteration(vals):
+                    continue
+
+                vals = self._filter_active_assets(n, c, vals)  # for multiinvest
+                vals = self._filter_bus_carrier(n, c, port, bus_carrier, vals)
+
+                if self._aggregate_components_skip_iteration(vals):
+                    continue
+
+                if groupby is not False:
+                    if groupby is None:
+                        warnings.warn(
+                            "Passing `groupby=None` is deprecated. Drop the "
+                            "argument to get the default grouping (by carrier), which "
+                            "was also the previous default behavior.",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
+                        groupby = "carrier"
+                    grouping = self._get_grouping(
+                        n, c, groupby, port=port, nice_names=nice_names
+                    )
+                    vals = self._aggregate_components_groupby(vals, grouping, agg)
+                values.append(vals)
+
+            if not values:
+                continue
+
+            df = self._aggregate_components_concat_values(values, agg)
+
+            d[c] = df
+
+        df = self._aggregate_components_concat_data(d, is_one_component)
+
+        if aggregate_across_components:
+            df = self._aggregate_across_components(df, agg)
+
+        return df
+
+    def _aggregate_components_skip_iteration(self, vals: Any) -> bool:
+        return False
+
+    def _filter_active_assets(self, n: Network, c: str, obj: Any) -> Any:
+        """
+        For static values iterate over periods and concat values.
+        """
+        if isinstance(obj, pd.DataFrame) or "snapshot" in getattr(obj, "dims", []):
+            return obj
+        idx = self._get_component_index(obj, c)
+        if not self.is_multi_indexed:
+            mask = n.get_active_assets(c)
+            idx = mask.index[mask].intersection(idx)
+            return obj.loc[idx]
+
+        per_period = {}
+        for p in n.investment_periods:
+            mask = n.get_active_assets(c, p)
+            idx = mask.index[mask].intersection(idx)
+            per_period[p] = obj.loc[idx]
+
+        return self._concat_periods(per_period, c)
+
+    def _filter_bus_carrier(
+        self,
+        n: Network,
+        c: str,
+        port: str,
+        bus_carrier: str | Sequence[str] | None,
+        obj: Any,
+    ) -> Any:
+        """
+        Filter the DataFrame for components which are connected to a bus with
+        carrier `bus_carrier`.
+        """
+        if bus_carrier is None:
+            return obj
+
+        idx = self._get_component_index(obj, c)
+        ports = n.static(c).loc[idx, f"bus{port}"]
+        port_carriers = ports.map(n.buses.carrier)
+        if isinstance(bus_carrier, str):
+            if bus_carrier in n.buses.carrier.unique():
+                mask = port_carriers == bus_carrier
+            else:
+                mask = port_carriers.str.contains(bus_carrier)
+        elif isinstance(bus_carrier, list):
+            mask = port_carriers.isin(bus_carrier)
+        else:
+            raise ValueError(
+                f"Argument `bus_carrier` must be a string or list, got {type(bus_carrier)}"
+            )
+        # links may have empty ports which results in NaNs
+        mask = mask.where(mask.notnull(), False)
+        return obj.loc[ports.index[mask]]

--- a/pypsa/statistics/deprecated.py
+++ b/pypsa/statistics/deprecated.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pypsa import Network
+
+import pandas as pd
+from deprecation import deprecated
+
+from pypsa.statistics.abstract import AbstractStatisticsAccessor
+
+logger = logging.getLogger(__name__)
+
+
+@deprecated("Use n.statistics._get_grouping instead.")
+def get_grouping(
+    n: Network,
+    c: str,
+    groupby: Callable | Sequence[str] | str | bool,
+    port: str | None = None,
+    nice_names: bool = False,
+) -> dict:
+    return n.statistics._get_grouping(n, c, groupby, port, nice_names)
+
+
+@deprecated("Use n.statistics._aggregate_timeseries instead.")
+def aggregate_timeseries(
+    df: pd.DataFrame, weights: pd.Series, agg: str = "sum"
+) -> pd.Series:
+    return AbstractStatisticsAccessor._aggregate_timeseries(df, weights, agg)
+
+
+@deprecated("Use n.statistics._filter_active_assets instead.")
+def filter_active_assets(
+    n: Network, c: str, df: pd.Series | pd.DataFrame
+) -> pd.Series | pd.DataFrame:
+    return n.statistics._filter_active_assets(n, c, df)
+
+
+@deprecated("Use n.statistics._filter_bus_carrier instead.")
+def filter_bus_carrier(
+    n: Network,
+    c: str,
+    port: str,
+    bus_carrier: str | Sequence[str] | None,
+    df: pd.DataFrame,
+) -> pd.DataFrame:
+    return n.statistics._filter_bus_carrier(n, c, port, bus_carrier, df)

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -5,145 +5,19 @@ Statistics Accessor.
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection, Sequence
-from functools import wraps
-from inspect import signature
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pypsa import Network
 
 import pandas as pd
-from deprecation import deprecated
 
 from pypsa.descriptors import nominal_attrs
+from pypsa.statistics.abstract import AbstractStatisticsAccessor
+from pypsa.utils import pass_empty_series_if_keyerror
 
 logger = logging.getLogger(__name__)
-
-
-def get_carrier(n: Network, c: str, nice_names: bool = True) -> pd.Series:
-    """
-    Get the nice carrier names for a component.
-    """
-    static = n.static(c)
-    fall_back = pd.Series("", index=static.index)
-    carrier_series = static.get("carrier", fall_back).rename("carrier")
-    if nice_names:
-        carrier_series = carrier_series.replace(
-            n.carriers.nice_name[lambda ds: ds != ""]
-        ).replace("", "-")
-    return carrier_series
-
-
-def get_bus_carrier(
-    n: Network, c: str, port: str = "", nice_names: bool = True
-) -> pd.Series:
-    """
-    Get the bus carrier for a component.
-    """
-    bus = f"bus{port}"
-    buses_carrier = get_carrier(n, "Bus", nice_names=nice_names)
-    return n.static(c)[bus].map(buses_carrier).rename("bus_carrier")
-
-
-def get_bus(n: Network, c: str, port: str = "") -> pd.Series:
-    """
-    Get the buses for a component.
-    """
-    bus = f"bus{port}"
-    return n.static(c)[bus].rename("bus")
-
-
-def get_country(n: Network, c: str, port: str = "") -> pd.Series:
-    """
-    Get the country for a component.
-    """
-    bus = f"bus{port}"
-    return n.static(c)[bus].map(n.buses.country).rename("country")
-
-
-def get_unit(n: Network, c: str, port: str = "") -> pd.Series:
-    """
-    Get the unit for a component.
-    """
-    bus = f"bus{port}"
-    return n.static(c)[bus].map(n.buses.unit).rename("unit")
-
-
-def get_name(n: Network, c: str) -> pd.Series:
-    """
-    Get the name for a component.
-    """
-    return n.static(c).index.to_series().rename("name")
-
-
-def get_bus_and_carrier(
-    n: Network, c: str, port: str = "", nice_names: bool = True
-) -> list[pd.Series]:
-    """
-    Get the buses and nice carrier names for a component.
-    """
-    return LOCAL_GROUPERS.create_grouper(["bus", "carrier"])(
-        n, c, port, nice_names=nice_names
-    )
-
-
-def get_bus_unit_and_carrier(
-    n: Network, c: str, port: str = "", nice_names: bool = True
-) -> list[pd.Series]:
-    """
-    Get the buses and nice carrier names for a component.
-    """
-    return LOCAL_GROUPERS.create_grouper(["bus", "unit", "carrier"])(
-        n, c, port, nice_names=nice_names
-    )
-
-
-def get_name_bus_and_carrier(
-    n: Network, c: str, port: str = "", nice_names: bool = True
-) -> list[pd.Series]:
-    """
-    Get the name, buses and nice carrier names for a component.
-    """
-    return LOCAL_GROUPERS.create_grouper(["name", "bus", "carrier"])(
-        n, c, port, nice_names=nice_names
-    )
-
-
-def get_country_and_carrier(
-    n: Network, c: str, port: str = "", nice_names: bool = True
-) -> list[pd.Series]:
-    """
-    Get component country and carrier.
-    """
-    return LOCAL_GROUPERS.create_grouper(["country", "carrier"])(
-        n, c, port, nice_names=nice_names
-    )
-
-
-def get_bus_and_carrier_and_bus_carrier(
-    n: Network, c: str, port: str = "", nice_names: bool = True
-) -> list[pd.Series]:
-    """
-    Get component's carrier, bus and bus carrier in one combined list.
-
-    Used for MultiIndex in energy balance.
-    """
-    return LOCAL_GROUPERS.create_grouper(["bus", "carrier", "bus_carrier"])(
-        n, c, port, nice_names=nice_names
-    )
-
-
-def get_carrier_and_bus_carrier(
-    n: Network, c: str, port: str = "", nice_names: bool = True
-) -> list[pd.Series]:
-    """
-    Get component carrier and bus carrier in one combined list.
-    """
-    return LOCAL_GROUPERS.create_grouper(["carrier", "bus_carrier"])(
-        n, c, port, nice_names=nice_names
-    )
 
 
 def get_operation(n: Network, c: str) -> pd.DataFrame:
@@ -188,7 +62,7 @@ def port_efficiency(
 
 
 def get_transmission_branches(
-    n: Network, bus_carrier: Sequence[str] | str | None = None
+    n: Network, bus_carrier: str | Sequence[str] | None = None
 ) -> pd.MultiIndex:
     """
     Get the list of assets which transport between buses of the carrier
@@ -215,7 +89,7 @@ def get_transmission_branches(
 
 
 def get_transmission_carriers(
-    n: Network, bus_carrier: Sequence[str] | str | None = None
+    n: Network, bus_carrier: str | Sequence[str] | None = None
 ) -> pd.MultiIndex:
     """
     Get the carriers which transport between buses of the carrier
@@ -230,53 +104,6 @@ def get_transmission_carriers(
         [(c, i) for c, idx in carriers.items() for i in idx],
         names=["component", "carrier"],
     )
-
-
-@deprecated("Use n.statistics._get_grouping instead.")
-def get_grouping(
-    n: Network,
-    c: str,
-    groupby: Callable | Sequence[str] | str | bool,
-    port: str | None = None,
-    nice_names: bool = False,
-) -> dict:
-    return n.statistics._get_grouping(n, c, groupby, port, nice_names)
-
-
-@deprecated("Use n.statistics._aggregate_timeseries instead.")
-def aggregate_timeseries(
-    df: pd.DataFrame, weights: pd.Series, agg: str = "sum"
-) -> pd.Series:
-    return AbstractStatisticsAccessor._aggregate_timeseries(df, weights, agg)
-
-
-@deprecated("Use n.statistics._filter_active_assets instead.")
-def filter_active_assets(
-    n: Network, c: str, df: pd.Series | pd.DataFrame
-) -> pd.Series | pd.DataFrame:
-    return n.statistics._filter_active_assets(n, c, df)
-
-
-@deprecated("Use n.statistics._filter_bus_carrier instead.")
-def filter_bus_carrier(
-    n: Network,
-    c: str,
-    port: str,
-    bus_carrier: Sequence[str] | str | None,
-    df: pd.DataFrame,
-) -> pd.DataFrame:
-    return n.statistics._filter_bus_carrier(n, c, port, bus_carrier, df)
-
-
-def pass_empty_series_if_keyerror(func: Callable) -> Callable:
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> pd.Series:
-        try:
-            return func(*args, **kwargs)
-        except (KeyError, AttributeError):
-            return pd.Series([], dtype=float)
-
-    return wrapper
 
 
 class Parameters:
@@ -324,299 +151,6 @@ class Parameters:
                 )
             else:
                 setattr(self, key, value)
-
-
-class Groupers:
-    """
-    Container for all the get_ methods.
-    """
-
-    # Class-level dictionary for registered groupers
-    _registered_groupers: dict[str, Callable] = {
-        "carrier": get_carrier,
-        "bus_carrier": get_bus_carrier,
-        "name": get_name,
-        "bus": get_bus,
-        "country": get_country,
-        "unit": get_unit,
-    }
-
-    def __init__(self) -> None:
-        pass
-
-    @classmethod
-    def __repr__(cls) -> str:
-        return f"Groupers with registered groupers: {list(cls._registered_groupers.keys())}"
-
-    @classmethod
-    def register_grouper(cls, name: str, func: Callable) -> None:
-        """Register a new grouper function"""
-        cls._registered_groupers[name] = func
-
-    @classmethod
-    def create_grouper(cls, keys: str | tuple[str] | list[str]) -> Callable:
-        if scalar_passed := isinstance(keys, str):
-            keys = (keys,)
-
-        def group_by_keys(
-            n: Network, c: str, port: str, nice_names: bool = False
-        ) -> list:
-            grouped_data = []
-            for key in keys:
-                if key not in cls._registered_groupers:
-                    grouped_data.append(n.static(c)[key].rename(key))
-                    continue
-
-                method = cls._registered_groupers[key]
-                kwargs: dict[str, str | bool] = {}
-                if "port" in signature(method).parameters:
-                    kwargs["port"] = port
-                if "nice_names" in signature(method).parameters:
-                    kwargs["nice_names"] = nice_names
-                grouped_data.append(method(n, c, **kwargs))
-
-            return grouped_data[0] if scalar_passed else grouped_data
-
-        return group_by_keys
-
-    # Single groupers
-    get_carrier = staticmethod(get_carrier)
-    get_bus = staticmethod(get_bus)
-    get_bus_carrier = staticmethod(get_bus_carrier)
-    get_country = staticmethod(get_country)
-    get_name = staticmethod(get_name)
-    get_unit = staticmethod(get_unit)
-
-    # Combined groupers
-    get_bus_and_carrier = staticmethod(get_bus_and_carrier)
-    get_bus_unit_and_carrier = staticmethod(get_bus_unit_and_carrier)
-    get_name_bus_and_carrier = staticmethod(get_name_bus_and_carrier)
-    get_country_and_carrier = staticmethod(get_country_and_carrier)
-    get_bus_and_carrier_and_bus_carrier = staticmethod(
-        get_bus_and_carrier_and_bus_carrier
-    )
-    get_carrier_and_bus_carrier = staticmethod(get_carrier_and_bus_carrier)
-
-
-LOCAL_GROUPERS = Groupers()
-
-
-class AbstractStatisticsAccessor(ABC):
-    """
-    Abstract accessor to calculate different statistical values.
-    """
-
-    def __init__(self, n: Network) -> None:
-        self.n = n
-        self.groupers = Groupers()  # Create an instance of the Groupers class
-        self.parameters = Parameters()  # Create an instance of the Parameters class
-
-    def set_parameters(self, **kwargs: Any) -> None:
-        """
-        Setting the parameters for the statistics accessor.
-
-        To see the list of parameters, one can simply call `n.statistics.parameters`.
-        """
-        self.parameters.set_parameters(**kwargs)
-
-    def _get_grouping(
-        self,
-        n: Network,
-        c: str,
-        groupby: Callable | Sequence[str] | str | bool,
-        port: str | None = None,
-        nice_names: bool = False,
-    ) -> dict:
-        by = None
-        level = None
-        if callable(groupby):
-            if "port" in signature(groupby).parameters:
-                by = groupby(n, c, port=port, nice_names=nice_names)
-            else:
-                by = groupby(n, c, nice_names=nice_names)
-        elif isinstance(groupby, (str, list)):
-            by = self.groupers.create_grouper(groupby)(
-                n, c, port=port, nice_names=nice_names
-            )
-        elif groupby is not False:
-            raise ValueError(
-                f"Argument `groupby` must be a function, list, string, False or dict, got {type(groupby)}"
-            )
-        return dict(by=by, level=level)
-
-    @property
-    def is_multi_indexed(self) -> bool:
-        return isinstance(self.n.snapshots, pd.MultiIndex)
-
-    @classmethod
-    def _aggregate_timeseries(
-        cls, obj: Any, weights: pd.Series, agg: str | Callable | bool = "sum"
-    ) -> Any:
-        """
-        Calculate the weighted sum or average of a DataFrame or Series.
-        """
-        if not agg:
-            return obj.T if isinstance(obj, pd.DataFrame) else obj
-
-        if agg == "mean":
-            if isinstance(weights.index, pd.MultiIndex):
-                weights = weights.groupby(level=0).transform(lambda w: w / w.sum())
-            else:
-                weights = weights / weights.sum()
-            agg = "sum"
-
-        return cls._aggregate_with_weights(obj, weights, agg)
-
-    # The following methods are implemented in the concrete classes
-    @abstractmethod
-    def _aggregate_with_weights(self, *args: Any, **kwargs: Any) -> Any:
-        pass
-
-    @abstractmethod
-    def _aggregate_components_groupby(self, *args: Any, **kwargs: Any) -> Any:
-        pass
-
-    @abstractmethod
-    def _aggregate_components_concat_values(self, *args: Any, **kwargs: Any) -> Any:
-        pass
-
-    @abstractmethod
-    def _aggregate_components_concat_data(self, *args: Any, **kwargs: Any) -> Any:
-        pass
-
-    @abstractmethod
-    def _aggregate_across_components(self, *args: Any, **kwargs: Any) -> Any:
-        pass
-
-    @abstractmethod
-    def _get_component_index(self, *args: Any, **kwargs: Any) -> Any:
-        pass
-
-    @abstractmethod
-    def _concat_periods(self, *args: Any, **kwargs: Any) -> Any:
-        pass
-
-    def _aggregate_components(
-        self,
-        func: Callable,
-        agg: Callable | str = "sum",
-        comps: Collection[str] | str | None = None,
-        groupby: str | list[str] | Callable | None = None,
-        aggregate_across_components: bool = False,
-        at_port: Sequence[str] | str | bool | None = None,
-        bus_carrier: Sequence[str] | str | None = None,
-        nice_names: bool | None = True,
-    ) -> pd.Series | pd.DataFrame:
-        """
-        Apply a function and group the result for a collection of components.
-        """
-        d = {}
-        n = self.n
-
-        if is_one_component := isinstance(comps, str):
-            comps = [comps]
-        if comps is None:
-            comps = n.branch_components | n.one_port_components
-        if groupby is None:
-            groupby = get_carrier
-        if nice_names is None:
-            nice_names = self.parameters.nice_names
-        for c in comps:
-            if n.static(c).empty:
-                continue
-
-            ports = [str(col)[3:] for col in n.static(c) if str(col).startswith("bus")]
-            if not at_port:
-                ports = [ports[0]]
-
-            values = []
-            for port in ports:
-                vals = func(n, c, port)
-                if self._aggregate_components_skip_iteration(vals):
-                    continue
-
-                vals = self._filter_active_assets(n, c, vals)  # for multiinvest
-                vals = self._filter_bus_carrier(n, c, port, bus_carrier, vals)
-
-                if self._aggregate_components_skip_iteration(vals):
-                    continue
-
-                if groupby is not False:
-                    grouping = self._get_grouping(
-                        n, c, groupby, port=port, nice_names=nice_names
-                    )
-                    vals = self._aggregate_components_groupby(vals, grouping, agg)
-                values.append(vals)
-
-            if not values:
-                continue
-
-            df = self._aggregate_components_concat_values(values, agg)
-
-            d[c] = df
-
-        df = self._aggregate_components_concat_data(d, is_one_component)
-
-        if aggregate_across_components:
-            df = self._aggregate_across_components(df, agg)
-
-        return df
-
-    def _aggregate_components_skip_iteration(self, vals: Any) -> bool:
-        return False
-
-    def _filter_active_assets(self, n: Network, c: str, obj: Any) -> Any:
-        """
-        For static values iterate over periods and concat values.
-        """
-        if isinstance(obj, pd.DataFrame) or "snapshot" in getattr(obj, "dims", []):
-            return obj
-        idx = self._get_component_index(obj, c)
-        if not self.is_multi_indexed:
-            mask = n.get_active_assets(c)
-            idx = mask.index[mask].intersection(idx)
-            return obj.loc[idx]
-
-        per_period = {}
-        for p in n.investment_periods:
-            mask = n.get_active_assets(c, p)
-            idx = mask.index[mask].intersection(idx)
-            per_period[p] = obj.loc[idx]
-
-        return self._concat_periods(per_period, c)
-
-    def _filter_bus_carrier(
-        self,
-        n: Network,
-        c: str,
-        port: str,
-        bus_carrier: Sequence[str] | str | None,
-        obj: Any,
-    ) -> Any:
-        """
-        Filter the DataFrame for components which are connected to a bus with
-        carrier `bus_carrier`.
-        """
-        if bus_carrier is None:
-            return obj
-
-        idx = self._get_component_index(obj, c)
-        ports = n.static(c).loc[idx, f"bus{port}"]
-        port_carriers = ports.map(n.buses.carrier)
-        if isinstance(bus_carrier, str):
-            if bus_carrier in n.buses.carrier.unique():
-                mask = port_carriers == bus_carrier
-            else:
-                mask = port_carriers.str.contains(bus_carrier)
-        elif isinstance(bus_carrier, list):
-            mask = port_carriers.isin(bus_carrier)
-        else:
-            raise ValueError(
-                f"Argument `bus_carrier` must be a string or list, got {type(bus_carrier)}"
-            )
-        # links may have empty ports which results in NaNs
-        mask = mask.where(mask.notnull(), False)
-        return obj.loc[ports.index[mask]]
 
 
 class StatisticsAccessor(AbstractStatisticsAccessor):
@@ -687,9 +221,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def __call__(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
-        groupby: Callable = get_carrier,
+        groupby: str | Sequence[str] | Callable = "carrier",
         nice_names: bool = True,
         **kwargs: Any,
     ) -> pd.DataFrame:
@@ -727,8 +261,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             )
             kwargs.pop("aggregate_time")
 
-        # TODO replace dispatch by energy_balance
-
         funcs: list[Callable] = [
             self.optimal_capacity,
             self.installed_capacity,
@@ -760,12 +292,12 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def capex(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
         cost_attribute: str = "capital_cost",
     ) -> pd.DataFrame:
@@ -805,12 +337,12 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def installed_capex(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
         cost_attribute: str = "capital_cost",
     ) -> pd.DataFrame:
@@ -848,12 +380,12 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def expanded_capex(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
         cost_attribute: str = "capital_cost",
     ) -> pd.DataFrame:
@@ -896,12 +428,12 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def optimal_capacity(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool | None = None,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: str | Sequence[str] | bool | None = None,
+        bus_carrier: str | Sequence[str] | None = None,
         storage: bool = False,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
@@ -950,12 +482,12 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def installed_capacity(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool | None = None,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: str | Sequence[str] | bool | None = None,
+        bus_carrier: str | Sequence[str] | None = None,
         storage: bool = False,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
@@ -1004,12 +536,12 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def expanded_capacity(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool | None = None,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: str | Sequence[str] | bool | None = None,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
         """
@@ -1048,13 +580,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def opex(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
         """
@@ -1103,13 +635,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def supply(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = True,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = True,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
         """
@@ -1139,13 +671,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def withdrawal(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = True,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = True,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
         """
@@ -1179,9 +711,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         aggregate_time: str | bool = "sum",
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
         """
@@ -1230,13 +762,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def energy_balance(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = ["carrier", "bus_carrier"],
-        at_port: Sequence[str] | str | bool = True,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = ["carrier", "bus_carrier"],
+        at_port: bool | str | Sequence[str] = True,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
         kind: str | None = None,
     ) -> pd.DataFrame:
@@ -1301,13 +833,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def curtailment(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = False,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = False,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
         """
@@ -1355,13 +887,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def capacity_factor(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "mean",
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        at_port: Sequence[str] | str | bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        bus_carrier: Sequence[str] | str | None = None,
+        at_port: bool | str | Sequence[str] = False,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
         """
@@ -1405,13 +937,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def revenue(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = True,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = True,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
         kind: str | None = None,
     ) -> pd.DataFrame:
@@ -1476,13 +1008,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     def market_value(
         self,
-        comps: Sequence[str] | str | None = None,
+        comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "mean",
         aggregate_groups: Callable | str = "sum",
         aggregate_across_components: bool = False,
-        groupby: str | list[str] | Callable | None = None,
-        at_port: Sequence[str] | str | bool = True,
-        bus_carrier: Sequence[str] | str | None = None,
+        groupby: str | Sequence[str] | Callable = "carrier",
+        at_port: bool | str | Sequence[str] = True,
+        bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
     ) -> pd.DataFrame:
         """

--- a/pypsa/statistics/grouping.py
+++ b/pypsa/statistics/grouping.py
@@ -136,7 +136,8 @@ class Groupers:
         >>> groupers[["carrier", "bus"]] # for multi-indexed grouper
 
         """
-        if scalar_passed := isinstance(keys, str):
+        keys_: Sequence[str | Callable]
+        if scalar_passed := isinstance(keys, str) or callable(keys):
             keys_ = (keys,)
         else:
             keys_ = keys

--- a/pypsa/statistics/grouping.py
+++ b/pypsa/statistics/grouping.py
@@ -1,0 +1,526 @@
+"""
+Groupers for PyPSA statistics.
+
+Use them via the groupers instance via `pypsa.statistics.groupers`. Do not use the
+grouping module directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from inspect import signature
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pypsa import Network
+
+import warnings
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class Groupers:
+    """Container for all the get_ methods."""
+
+    @classmethod
+    def __repr__(cls) -> str:
+        """
+        Return a string representation of the grouper container.
+
+        Returns
+        -------
+        str
+            String representation.
+
+        """
+        return (
+            f"Grouper container with the following groupers: "
+            f"{', '.join(cls.list_groupers())}"
+        )
+
+    @classmethod
+    def __getitem__(cls, keys: str | Callable | Sequence[str | Callable]) -> Callable:
+        """
+        Get a single or multi-indexed grouper method.
+
+        Parameters
+        ----------
+        keys : str | Callable | Sequence[str | Callable]
+            Single or multiple keys to get the grouper method.
+
+        Returns
+        -------
+        Callable
+            Grouper method.
+
+        Examples
+        --------
+        >>> groupers["carrier"] # for single grouper
+        >>> groupers[["carrier", "bus"]] # for multi-indexed grouper
+
+        """
+        return cls._multi_grouper(keys)
+
+    @classmethod
+    def __setitem__(cls, key: str, value: Callable) -> None:
+        """
+        Set a custom grouper method.
+
+        Parameters
+        ----------
+        key : str
+            Name of the custom grouper.
+
+        value : Callable
+            Custom grouper function.
+
+        Returns
+        -------
+        None
+
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def _get_generic_grouper(n: Network, c: str, key: str) -> pd.Series:
+        try:
+            return n.static(c)[key].rename(key)
+        except KeyError:
+            msg = f"Unknown grouper {key}."
+            raise ValueError(msg)
+
+    @classmethod
+    def list_groupers(cls) -> dict:
+        """
+        List all available groupers which are avaliable on the module level.
+
+        Returns
+        -------
+        dict
+            Dictionary with all available groupers. The keys are the grouper names and
+            the values are the grouper methods. The keys can be used to directly
+            access the grouper in any `groupby` argument.
+
+
+        """
+        no_groupers = ["add_grouper", "list_groupers"]
+        return {
+            key: value
+            for key, value in cls.__dict__.items()
+            if not key.startswith("_") and key not in no_groupers
+        }
+
+    @staticmethod
+    def _multi_grouper(keys: str | Callable | Sequence[str | Callable]) -> Callable:
+        """
+        Get a single or multi-indexed grouper method.
+
+        Should be used via groupers __getitem__ method and not directly.
+
+        Parameters
+        ----------
+        keys : str | Callable | Sequence[str | Callable]
+            Single or multiple keys to get the grouper method.
+
+        Returns
+        -------
+        Callable
+            Grouper method.
+
+        Examples
+        --------
+        >>> groupers["carrier"] # for single grouper
+        >>> groupers[["carrier", "bus"]] # for multi-indexed grouper
+
+        """
+        if scalar_passed := isinstance(keys, str):
+            keys_ = (keys,)
+        else:
+            keys_ = keys
+
+        def multi_grouper(
+            n: Network, c: str, port: str = "", nice_names: bool = False
+        ) -> list:
+            grouped_data = []
+            for key in keys_:
+                if isinstance(key, str):
+                    if key not in Groupers.list_groupers():
+                        grouped_data.append(Groupers._get_generic_grouper(n, c, key))
+                        continue
+                    method = Groupers.list_groupers()[key]
+                else:
+                    method = key
+
+                kwargs: dict[str, str | bool] = {}
+                if "port" in signature(method).parameters:
+                    kwargs["port"] = port
+                if "nice_names" in signature(method).parameters:
+                    kwargs["nice_names"] = nice_names
+                grouped_data.append(method(n, c, **kwargs))
+
+            return grouped_data[0] if scalar_passed else grouped_data
+
+        return multi_grouper
+
+    @classmethod
+    def add_grouper(cls, name: str, func: Callable) -> None:
+        """
+        Add a custom grouper to groupers on module level.
+
+        After registering a custom grouper, it can be accessed via the groupers module
+        level object and used in the statistics methods or as a groupers method.
+
+        Parameters
+        ----------
+        name : str
+            Name of the custom grouper. This will be used as the key in the groupby
+            argument.
+        func : Callable
+            Custom grouper function, which must return a pandas Series with the same
+            length as the component index and accept as arguments:
+            * n (Network): The PyPSA network instance
+            * c (str): Component name
+            * port (str): Component port as integer string
+            * nice_names (bool, optional): Whether to use nice carrier names
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> def my_custom_grouper(n, c, port=""):
+        ...     return n.static(c)["my_column"].rename("custom")
+        >>> Groupers.add_grouper("custom", my_custom_grouper)
+        >>> n.statistics.energy_balance(groupby=["custom", "carrier"])
+
+
+        """
+        setattr(cls, name, staticmethod(func))
+
+    @staticmethod
+    def carrier(n: Network, c: str, nice_names: bool = True) -> pd.Series:
+        """
+        Grouper method to group by the carrier of the components.
+
+        Parameters
+        ----------
+        n : Network
+            PyPSA network instance.
+        c : str
+            Components type name. E.g. "Generator", "StorageUnit", etc.
+        nice_names : bool, optional
+            Whether to use nice carrier names.
+
+        Returns
+        -------
+        pd.Series
+            Series with the carrier of the components.
+
+        """
+        static = n.static(c)
+        fall_back = pd.Series("", index=static.index)
+        carrier_series = static.get("carrier", fall_back).rename("carrier")
+        if nice_names:
+            carrier_series = carrier_series.replace(
+                n.carriers.nice_name[lambda ds: ds != ""]
+            ).replace("", "-")
+        return carrier_series
+
+    @staticmethod
+    def bus_carrier(
+        n: Network, c: str, port: str = "", nice_names: bool = True
+    ) -> pd.Series:
+        """
+        Grouper method to group by the carrier of the attached bus of a component.
+
+        Parameters
+        ----------
+        n : Network
+            PyPSA network instance.
+        c : str
+            Components type name. E.g. "Generator", "StorageUnit", etc.
+        port : str, optional
+            Port of corresponding bus, which should be used.
+        nice_names : bool, optional
+            Whether to use nice carrier names.
+
+        Returns
+        -------
+        pd.Series
+            Series with the bus and carrier of the components.
+
+        """
+        bus = f"bus{port}"
+        buses_carrier = Groupers.carrier(n, "Bus", nice_names=nice_names)
+        return n.static(c)[bus].map(buses_carrier).rename("bus_carrier")
+
+    @staticmethod
+    def bus(n: Network, c: str, port: str = "") -> pd.Series:
+        """
+        Grouper method to group by the attached bus of the components.
+
+        Parameters
+        ----------
+        n : Network
+            PyPSA network instance.
+        c : str
+            Components type name. E.g. "Generator", "StorageUnit", etc.
+        port : str, optional
+            Port of corresponding bus, which should be used.
+
+        Returns
+        -------
+        pd.Series
+            Series with the bus of the components.
+
+        """
+        bus = f"bus{port}"
+        return n.static(c)[bus].rename("bus")
+
+    @staticmethod
+    def country(n: Network, c: str, port: str = "") -> pd.Series:
+        """
+        Grouper method to group by the country of the components corresponding bus.
+
+        Parameters
+        ----------
+        n : Network
+            PyPSA network instance.
+        c : str
+            Components type name. E.g. "Generator", "StorageUnit", etc.
+        port : str, optional
+            Port of corresponding bus, which should be used.
+
+        Returns
+        -------
+        pd.Series
+            Series with the country of the components corresponding bus.
+
+        """
+        bus = f"bus{port}"
+        return n.static(c)[bus].map(n.buses.country).rename("country")
+
+    @staticmethod
+    def unit(n: Network, c: str, port: str = "") -> pd.Series:
+        """
+        Grouper method to group by the unit of the components corresponding bus.
+
+        Parameters
+        ----------
+        n : Network
+            PyPSA network instance.
+        c : str
+            Components type name. E.g. "Generator", "StorageUnit", etc.
+        port : str, optional
+            Port of corresponding bus, which should be used.
+
+        Returns
+        -------
+        pd.Series
+            Series with the unit of the components corresponding bus.
+
+        """
+        bus = f"bus{port}"
+        return n.static(c)[bus].map(n.buses.unit).rename("unit")
+
+    @staticmethod
+    def name(n: Network, c: str) -> pd.Series:
+        """
+        Grouper method to group by the name of components.
+
+        Parameters
+        ----------
+        n : Network
+            PyPSA network instance.
+        c : str
+            Components type name. E.g. "Generator", "StorageUnit", etc.
+
+        Returns
+        -------
+        pd.Series
+            Series with the component names.
+
+        """
+        return n.static(c).index.to_series().rename("name")
+
+
+groupers = Groupers()
+
+new_grouper_access = {
+    "get_carrier": ".carrier",
+    "get_bus_carrier": ".bus_carrier",
+    "get_bus": ".bus",
+    "get_country": ".country",
+    "get_unit": ".unit",
+    "get_name": ".name",
+    "get_bus_and_carrier": '["bus", "carrier"]',
+    "get_bus_unit_and_carrier": '["bus", "unit", "carrier"]',
+    "get_name_bus_and_carrier": '["name", "bus", "carrier"]',
+    "get_country_and_carrier": '["country", "carrier"]',
+    "get_bus_and_carrier_and_bus_carrier": '["bus", "carrier", "bus_carrier"]',
+    "get_carrier_and_bus_carrier": '["carrier", "bus_carrier"]',
+}
+
+
+def deprecated_grouper(func: Callable) -> Callable:
+    """
+    Decorator to deprecate old grouper methods with custom deprecation warning.
+
+    Parameters
+    ----------
+    func : Callable
+        Function to deprecate.
+
+    Returns
+    -------
+    Callable
+        Same function wrapped with deprecation warning.
+
+    """
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        msg = (
+            f"`n.statistics.{func.__name__}` and `pypsa.statistics.{func.__name__}` "
+            f"are deprecated. Use "
+            f"`pypsa.statistics.groupers{new_grouper_access[func.__name__]}` instead."
+        )
+        warnings.warn(msg, DeprecationWarning)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+class DeprecatedGroupers:
+    """
+    Grouper class to allow full backwards compatiblity with old grouper methods.
+
+    Allows access to the old grouper methods, points them to new structure on
+    module level and raises a DeprecationWarning.
+    """
+
+    @staticmethod
+    @deprecated_grouper
+    def get_carrier(*args: Any, **kwargs: Any) -> pd.Series:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers.carrier` instead.
+        """
+        return groupers.carrier(*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_bus_carrier(*args: Any, **kwargs: Any) -> pd.Series:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers.bus_carrier` instead.
+        """
+        return groupers.bus_carrier(*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_bus(*args: Any, **kwargs: Any) -> pd.Series:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers.bus` instead.
+        """
+        return groupers.bus(*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_country(*args: Any, **kwargs: Any) -> pd.Series:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers.country` instead.
+        """
+        return groupers.country(*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_unit(*args: Any, **kwargs: Any) -> pd.Series:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers.unit` instead.
+        """
+        return groupers.unit(*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_name(*args: Any, **kwargs: Any) -> pd.Series:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers.name` instead.
+        """
+        return groupers.name(*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_bus_and_carrier(*args: Any, **kwargs: Any) -> list:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers["bus", "carrier"]` instead.
+        """
+        return groupers["bus", "carrier"](*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_bus_unit_and_carrier(*args: Any, **kwargs: Any) -> list:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers["bus", "unit", "carrier"]` instead.
+        """
+        return groupers["bus", "unit", "carrier"](*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_name_bus_and_carrier(*args: Any, **kwargs: Any) -> list:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers["name", "bus", "carrier"]` instead.
+        """
+        return groupers["name", "bus", "carrier"](*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_country_and_carrier(*args: Any, **kwargs: Any) -> list:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers["country", "carrier"]` instead.
+        """
+        return groupers["country", "carrier"](*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_bus_and_carrier_and_bus_carrier(*args: Any, **kwargs: Any) -> list:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers["bus", "carrier", "bus_carrier"]` instead.
+        """
+        return groupers["bus", "carrier", "bus_carrier"](*args, **kwargs)
+
+    @staticmethod
+    @deprecated_grouper
+    def get_carrier_and_bus_carrier(*args: Any, **kwargs: Any) -> list:
+        """
+        Deprecated grouper method.
+
+        Use `pypsa.statistics.groupers["carrier", "bus_carrier"]` instead.
+        """
+        return groupers["carrier", "bus_carrier"](*args, **kwargs)
+
+
+deprecated_groupers = DeprecatedGroupers()

--- a/pypsa/statistics/grouping.py
+++ b/pypsa/statistics/grouping.py
@@ -195,7 +195,7 @@ class Groupers:
 
 
         """
-        setattr(self, name, staticmethod(func))
+        setattr(self, name, func)
 
     def carrier(self, n: Network, c: str, nice_names: bool = True) -> pd.Series:
         """

--- a/pypsa/utils.py
+++ b/pypsa/utils.py
@@ -155,7 +155,6 @@ def pass_none_if_keyerror(func: Callable) -> Callable:
     return wrapper
 
 
-
 def pass_empty_series_if_keyerror(func: Callable) -> Callable:
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> pd.Series:
@@ -165,6 +164,7 @@ def pass_empty_series_if_keyerror(func: Callable) -> Callable:
             return pd.Series([], dtype=float)
 
     return wrapper
+
 
 def check_optional_dependency(module_name: str, install_message: str) -> None:
     """
@@ -176,4 +176,3 @@ def check_optional_dependency(module_name: str, install_message: str) -> None:
         __import__(module_name)
     except ImportError:
         raise ImportError(install_message)
-

--- a/pypsa/utils.py
+++ b/pypsa/utils.py
@@ -153,3 +153,14 @@ def pass_none_if_keyerror(func: Callable) -> Callable:
             return None
 
     return wrapper
+
+
+def pass_empty_series_if_keyerror(func: Callable) -> Callable:
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> pd.Series:
+        try:
+            return func(*args, **kwargs)
+        except (KeyError, AttributeError):
+            return pd.Series([], dtype=float)
+
+    return wrapper

--- a/test/test_optimization_expressions.py
+++ b/test/test_optimization_expressions.py
@@ -1,22 +1,19 @@
 import pytest
 from linopy import LinearExpression
 
-from pypsa.statistics import (
-    get_bus_and_carrier,
-    get_carrier_and_bus_carrier,
-    get_name_bus_and_carrier,
-)
+from pypsa.statistics import groupers
 
 TOLERANCE = 1e-2
 
 
 GROUPER_PARAMETERS = [
-    get_bus_and_carrier,
-    get_name_bus_and_carrier,
-    get_carrier_and_bus_carrier,
+    groupers.carrier,
+    groupers["carrier"],
+    [groupers.bus, groupers.carrier],
+    ["name", "bus", "carrier"],
+    ["carrier", "bus_carrier"],
     ["bus", "carrier", "bus_carrier"],
     False,
-    None,
 ]
 KWARGS_PARAMETERS = [
     {"at_port": True},

--- a/test/test_plotting.py
+++ b/test/test_plotting.py
@@ -19,7 +19,7 @@ from pypsa.plot import (  # type: ignore[attr-defined]
     add_legend_patches,
     add_legend_semicircles,
 )
-from pypsa.statistics import get_transmission_branches
+from pypsa.statistics import get_transmission_branches, groupers
 
 try:
     import cartopy.crs as ccrs
@@ -188,7 +188,7 @@ def test_plot_from_statistics(ac_dc_network):
     n = ac_dc_network
     bus_carrier = "AC"
 
-    grouper = n.statistics.groupers.get_bus_and_carrier
+    grouper = groupers["bus", "carrier"]
     bus_sizes = n.statistics.installed_capacity(
         bus_carrier=bus_carrier, groupby=grouper, nice_names=False
     )


### PR DESCRIPTION
Closes #961

## Changes proposed in this Pull Request
- Addition to #1078 
  - Probably we wanna keep that as two PRs though, so merge 1078 first and change base
- Restructure `statistics.py` to `statistics` package
- Put groupers on module level `pypsa.statistics.groupers`
  - Merge single and multiple groupers instead of many get_x methods, e.g.
    - `groupers.bus` or `groupers['bus']` and
    -  groupers["bus", "carrier"]
  - Deprecates all `get_x` methods and also any access via `n`

Todos:
- [x] Tests
- [x] Docs
- [x] pass single str as groupby
- [ ] maybe even auto register for custom callables, this would clean up a lot again

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
