### PR TITLE
build: make `tables` optional for `.h5` io

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Install package and dependencies
       run: |
         python -m pip install uv
-        uv pip install --compile --system "$(ls dist/*.whl)[dev]"
+        uv pip install --compile --system "$(ls dist/*.whl)[dev,hdf5]"
         # Use --compile to get pip's behavior. Otherwise the pandapower installation 
         # will be broken on python<3.12
         # See https://github.com/astral-sh/uv/issues/1928#issuecomment-1968857514

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -44,6 +44,9 @@ Upcoming Release
       n.statistics.groupers.register_grouper("custom", my_custom_grouper)
       n.statistics.energy_balance(groupby=["custom", "carrier"])
 
+  * ``pytables`` is now an optional dependency for using the HDF5 format. Install 
+    it via ``pip install pypsa[hdf5]``. Otherwise it is not installed by default 
+    anymore. (https://github.com/PyPSA/PyPSA/pull/1100)
 
 `v0.31.2 <https://github.com/PyPSA/PyPSA/releases/tag/v0.31.2>`__ (27th November 2024)
 =======================================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "pandas>=0.24",
     "xarray",
     "netcdf4",
-    "tables",
     "linopy>=0.4",
     "matplotlib",
     "geopandas>=0.9",
@@ -46,6 +45,13 @@ Homepage = "https://github.com/PyPSA/PyPSA"
 Source = "https://github.com/PyPSA/PyPSA"
 
 [project.optional-dependencies]
+hdf5 = ["tables"]
+cartopy = [
+    "cartopy>=0.16",
+    "requests",
+]
+gurobipy = ["gurobipy"]
+cloudpath = ["cloudpathlib[all]"]
 dev = [
     "pytest", 
     "coverage",
@@ -55,10 +61,6 @@ dev = [
     "pre-commit", 
     "ruff",
     "mypy"
-]
-cartopy = [
-    "cartopy>=0.16",
-    "requests",
 ]
 docs = [
     "numpydoc==1.8.0",
@@ -73,8 +75,6 @@ docs = [
     "ipython==8.26.0",
     "ipykernel==6.29.5",
 ]
-gurobipy = ["gurobipy"]
-cloudpath = ["cloudpathlib[all]"]
 
 # setuptools_scm settings
  

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -14,7 +14,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.request import urlretrieve
 
-from pypsa.utils import deprecated_common_kwargs
+from pypsa.utils import check_optional_dependency, deprecated_common_kwargs
 
 try:
     from cloudpathlib import AnyPath as Path
@@ -250,6 +250,11 @@ class ExporterCSV(Exporter):
 
 class ImporterHDF5(Importer):
     def __init__(self, path: str | pd.HDFStore) -> None:
+        check_optional_dependency(
+            "tables",
+            "Missing optional dependencies to use HDF5 files. Install them via "
+            "`pip install pypsa[hdf5]` or `conda install -c conda-forge pypsa[hdf5]`.",
+        )
         self.path = path
         self.ds: pd.HDFStore
         if isinstance(path, (str, Path)):
@@ -298,6 +303,11 @@ class ImporterHDF5(Importer):
 
 class ExporterHDF5(Exporter):
     def __init__(self, path: str | Path, **kwargs: Any) -> None:
+        check_optional_dependency(
+            "tables",
+            "Missing optional dependencies to use HDF5 files. Install them via "
+            "`pip install pypsa[hdf5]` or `conda install -c conda-forge pypsa[hdf5]`.",
+        )
         path = Path(path)
         self._hdf5_handle = path.open("w")
         self.ds = pd.HDFStore(path, mode="w", **kwargs)

--- a/pypsa/utils.py
+++ b/pypsa/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import importlib.util
 import warnings
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -153,3 +154,14 @@ def pass_none_if_keyerror(func: Callable) -> Callable:
             return None
 
     return wrapper
+
+
+def check_optional_dependency(module_name: str, install_message: str) -> None:
+    """
+    Check if an optional dependency is installed.
+
+    If not, raise an ImportError with an install message.
+    """
+
+    if importlib.util.find_spec(module_name) is None:
+        raise ImportError(install_message)

--- a/pypsa/utils.py
+++ b/pypsa/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import importlib.util
 import warnings
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -162,6 +161,7 @@ def check_optional_dependency(module_name: str, install_message: str) -> None:
 
     If not, raise an ImportError with an install message.
     """
-
-    if importlib.util.find_spec(module_name) is None:
+    try:
+        __import__(module_name)
+    except ImportError:
         raise ImportError(install_message)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -53,6 +53,7 @@ def test_csv_io_Path(scipy_network, tmpdir):
 
 @pytest.mark.parametrize("meta", [{"test": "test"}, {"test": {"test": "test"}}])
 def test_hdf5_io(scipy_network, tmpdir, meta):
+    pytest.importorskip("tables", reason="PyTables not installed")
     fn = os.path.join(tmpdir, "hdf5_export.h5")
     scipy_network.meta = meta
     scipy_network.export_to_hdf5(fn)
@@ -62,6 +63,7 @@ def test_hdf5_io(scipy_network, tmpdir, meta):
 
 
 def test_hdf5_io_Path(scipy_network, tmpdir):
+    pytest.importorskip("tables", reason="PyTables not installed")
     fn = Path(os.path.join(tmpdir, "hdf5_export.h5"))
     scipy_network.export_to_hdf5(fn)
     pypsa.Network(fn)
@@ -94,6 +96,7 @@ def test_csv_io_multiindexed(ac_dc_network_multiindexed, tmpdir):
 
 
 def test_hdf5_io_multiindexed(ac_dc_network_multiindexed, tmpdir):
+    pytest.importorskip("tables", reason="PyTables not installed")
     fn = os.path.join(tmpdir, "hdf5_export.h5")
     ac_dc_network_multiindexed.export_to_hdf5(fn)
     m = pypsa.Network(fn)
@@ -126,6 +129,7 @@ def test_csv_io_shapes(ac_dc_network_shapes, tmpdir):
 
 
 def test_hdf5_io_shapes(ac_dc_network_shapes, tmpdir):
+    pytest.importorskip("tables", reason="PyTables not installed")
     fn = os.path.join(tmpdir, "hdf5_export.h5")
     ac_dc_network_shapes.export_to_hdf5(fn)
     m = pypsa.Network(fn)
@@ -163,6 +167,7 @@ def test_csv_io_shapes_with_missing(ac_dc_network_shapes, tmpdir):
 
 
 def test_hdf5_io_shapes_with_missing(ac_dc_network_shapes, tmpdir):
+    pytest.importorskip("tables", reason="PyTables not installed")
     fn = os.path.join(tmpdir, "hdf5_export.h5")
     n = ac_dc_network_shapes.copy()
     n.shapes.loc["Manchester", "geometry"] = None

--- a/test/test_optional_dependencies.py
+++ b/test/test_optional_dependencies.py
@@ -1,0 +1,26 @@
+import builtins
+
+import pytest
+
+
+@pytest.fixture
+def hide_pytables(monkeypatch):
+    import_orig = builtins.__import__
+
+    def mocked_import(name, *args, **kwargs):
+        if name == "tables":
+            raise ImportError()
+        return import_orig(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mocked_import)
+
+
+@pytest.mark.usefixtures("hide_pytables")
+def test_message(ac_dc_network, hide_pytables):
+    n = ac_dc_network
+
+    with pytest.raises(
+        ImportError,
+        match=r"Missing optional dependencies to use HDF5 files\.",
+    ):
+        n.export_to_hdf5("test.h5")


### PR DESCRIPTION

## Changes proposed in this Pull Request
- make `tables` dependency optional when `.h5` is used in io module
- otherwise it is not needed

## Checklist
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.