### PR TITLE
docs: additional ruff rules (`pydocstyle`/ `D`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,35 +136,46 @@ select = [
     'I',   # isort
     'D',   # pydocstyle
     'UP',  # pyupgrade
+    'ANN', # flake-8 annotations
     'TID', # flake8-tidy-imports
     'NPY', # numpy
     'RUF013', # ruff
 ]
 
 ignore = [
-    'E501', # line too long
+    'ANN401', # Dynamically typed expressions are forbidden
     'E741', # ambiguous variable names
-    'D105', # Missing docstring in magic method
+    'D203', # 1 blank line required before class docstring
     'D212', # Multi-line docstring summary should start at the second line
-    'D200', # One-line docstring should fit on one line with quotes
     'D401', # First line should be in imperative mood
-    'D404', # First word of the docstring should not be "This
-    'D413', # Missing blank line after last section
+    ]
 
-    # pydocstyle ignores, which could be enabled in future when existing
-    # issues are fixed
+
+[tool.ruff.lint.per-file-ignores]
+# pydocstyle ignores, which could be enabled in future when existing
+# issues are fixed
+"!**/{grouping.py}" = [
+    'E501', # line too long
     'D100', # Missing docstring in public module
     'D101', # Missing docstring in public class
     'D102', # Missing docstring in public method
     'D103', # Missing docstring in public function
+    'D105', # Missing docstring in magic method
     'D107', # Missing docstring in __init__
+    'D200', # One-line docstring should fit on one line with quotes
     'D202', # No blank lines allowed after function docstring
-    'D203', # 1 blank line required before class docstring
     'D205', # 1 blank line required between summary line and description
     'D400', # First line should end with a period
+    'D404', # First word of the docstring should not be "This
+    'D413', # Missing blank line after last section
     'D415', # First line should end with a period, question mark, or exclamation point
     'D417', # Missing argument descriptions in the docstring
+    # Include once available
+    # https://github.com/astral-sh/ruff/issues/2310
+    ]
 
+"{test,examples}/**"=[
+    'ANN' # flake8-annotations
 ]
 
 [tool.ruff.lint.flake8-tidy-imports]

--- a/pypsa/components.py
+++ b/pypsa/components.py
@@ -264,7 +264,7 @@ class Network:
         override_components: pd.DataFrame | None = None,
         override_component_attrs: Dict | None = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         # Initialise root logger and set its level, if this has not been done before
         logging.basicConfig(level=logging.INFO)
 

--- a/pypsa/optimization/compat.py
+++ b/pypsa/optimization/compat.py
@@ -1,3 +1,5 @@
+# type: ignore
+# ruff: noqa
 """
 Use compatibility methods for optimization problem definition with Linopy.
 
@@ -16,7 +18,6 @@ from deprecation import deprecated
     removed_in="1.0",
     details="Use native linopy syntax instead.",
 )
-# type: ignore
 def get_var(n, c, key):
     """
     Get variables directly from network.
@@ -29,7 +30,6 @@ def get_var(n, c, key):
     removed_in="1.0",
     details="Use native linopy syntax instead.",
 )
-# type: ignore
 def define_variables(
     n, lower, upper, name, attr="", axes=None, spec="", mask=None, **kwargs
 ):
@@ -50,7 +50,6 @@ def define_variables(
     removed_in="1.0",
     details="Use native linopy syntax instead.",
 )
-# type: ignore
 def define_constraints(
     n, lhs, sense, rhs, name, attr="", axes=None, spec="", mask=None, **kwargs
 ):
@@ -70,7 +69,6 @@ def define_constraints(
     removed_in="1.0",
     details="Use native linopy syntax instead.",
 )
-# type: ignore
 def linexpr(*tuples, as_pandas=True, return_axes=False):
     """
     Define a linear expression.
@@ -86,7 +84,6 @@ def linexpr(*tuples, as_pandas=True, return_axes=False):
     removed_in="1.0",
     details="Use native linopy syntax instead.",
 )
-# type: ignore
 def join_exprs(arr, **kwargs):
     """
     Sum over linear expression.

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -1,4 +1,8 @@
-# type: ignore #TODO: remove with #912
+# TODO: remove with #912
+# type: ignore
+# ruff: noqa: ANN001
+# ruff: noqa: ANN201
+# ruff: noqa: ANN202
 """
 Functions for plotting networks.
 """


### PR DESCRIPTION

## Changes proposed in this Pull Request
- Adds additional ruff rules for docstrings.
- To see which changes are still needed for specific parts, add the relevant file to the following line:
``` toml
"!**/{grouping.py}" = [
```
to for example 
``` toml
"!**/{grouping.py,components.py}" = [
```
to include `components.py` in the pre-commit/ ruff checks.


## Checklist
- [x] I consent to the release of this PR's code under the MIT license.
