### PR TITLE
expressions: add load component to energy balance

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,6 +11,13 @@ Upcoming Release
   To use the features already you have to install the ``master`` branch, e.g. 
   ``pip install git+https://github.com/pypsa/pypsa``.
 
+Bug fixes
+---------
+
+* The expression module now correctly includes the "Load" component in the
+  energy balance calculation. Before the fix, the "Load" component was not
+  considered.
+
 Features
 --------
 

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -16,7 +16,7 @@ Bug fixes
 
 * The expression module now correctly includes the "Load" component in the
   energy balance calculation. Before the fix, the "Load" component was not
-  considered.
+  considered. (https://github.com/PyPSA/PyPSA/pull/1110)
 
 Features
 --------

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -117,7 +117,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
     ) -> LinearExpression:
         if agg != "sum":
             raise ValueError(f"Aggregation method {agg} not supported.")
-        if expr.empty:
+        if expr.empty():
             return expr
         group = expr.indexes["group"].to_frame().drop(columns="component").squeeze()
         return expr.groupby(group).sum()

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -84,7 +84,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             raise ValueError(f"Aggregation method {agg} not supported.")
 
     def _aggregate_components_skip_iteration(self, vals: Any) -> bool:
-        return vals is None or not np.prod(vals.shape)
+        return vals is None or (not np.prod(vals.shape) and (vals.const == 0).all())
 
     def _aggregate_components_groupby(
         self, vals: LinearExpression, grouping: pd.DataFrame, agg: Callable | str
@@ -128,6 +128,8 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
         m = self.n.model
 
+        if c == "Load":
+            return LinearExpression(self.n.get_switchable_as_dense(c, "p_set"), m)
         attr = lookup.query("not nominal and not handle_separately").loc[c].index
         if c == "StorageUnit":
             assert set(["p_store", "p_dispatch"]) <= set(attr)

--- a/test/test_optimization_expressions.py
+++ b/test/test_optimization_expressions.py
@@ -42,9 +42,15 @@ def test_expressions_capacity(prepared_network, groupby):
     assert expr.size > 0
 
 
-def test_expression_capacity_all_filtered(prepared_network):
+@pytest.mark.parametrize("aggregate_across_components", (True, False))
+def test_expression_capacity_all_filtered(
+    prepared_network, aggregate_across_components
+):
     n = prepared_network
-    expr = n.optimize.expressions.capacity(bus_carrier="non-existent")
+    expr = n.optimize.expressions.capacity(
+        bus_carrier="non-existent",
+        aggregate_across_components=aggregate_across_components,
+    )
     assert isinstance(expr, LinearExpression)
     assert expr.size == 0
 


### PR DESCRIPTION
## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
