### PR TITLE
build: pin `scipy!=1.15.0` for python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "numpy",
-    "scipy>=1.14.1; python_version >= '3.13'",
+    "scipy>=1.14.1,!=1.15.0; python_version >= '3.13'",
     "scipy; python_version < '3.13'",
     "pandas>=0.24",
     "xarray",


### PR DESCRIPTION
Scipy `1.15.0` leads to issues with highs and python 3.13