### PR TITLE
Strict consistency checks by default

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -47,9 +47,13 @@ Features
   :meth:`n.has_periods <pypsa.networks.Network.has_periods>` to simplified level access
   of the snapshots dimension. (https://github.com/PyPSA/PyPSA/pull/1113)
 
-* Consistency checks can now be run with the parameter ``strict``. If set to 
-  ``True``, the consistency check will raise an error if any of the checks fail.
-
+* Consistency checks can now be run with the parameter ``strict``, which will raise 
+  them as ``ConsistenyError``. Pass checks which should be strict in 
+  :meth:`n.consistency_check <pypsa.consistency.consistency_check>` as e.g.
+  ``strict=['unknown_buses']``. :meth:`n.optimize <pypsa.optimization.optimize.optimize>`
+  will run some strict checks by default now. (https://github.com/PyPSA/PyPSA/pull/1120, 
+  https://github.com/PyPSA/PyPSA/pull/1112)
+  
 Bug fixes
 ---------
 

--- a/pypsa/consistency.py
+++ b/pypsa/consistency.py
@@ -7,6 +7,7 @@ Mainly used in the `Network.consistency_check()` method.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class ConsistencyError(Exception):
+class ConsistencyError(ValueError):
     pass
 
 
@@ -31,7 +32,7 @@ def _bus_columns(df: pd.DataFrame) -> pd.Index:
 
 def _log_or_raise(strict: bool, message: str, *args: Any) -> None:
     if strict:
-        raise ConsistencyError(message, *args)
+        raise ConsistencyError(message % args)
     else:
         logger.warning(message, *args)
 
@@ -43,6 +44,9 @@ def check_for_unknown_buses(
     """
     Check if buses are attached to component but are not defined in the network.
 
+    Activate strict mode in general consistency check by passing `['unknown_buses']` to
+    the `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
@@ -52,9 +56,14 @@ def check_for_unknown_buses(
     strict : bool, optional
         If True, raise an error instead of logging a warning.
 
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
     """
     for attr in _bus_columns(component.static):
-        missing = ~component.static[attr].isin(n.buses.index)
+        missing = ~component.static[attr].astype(str).isin(n.buses.index)
         # if bus2, bus3... contain empty strings do not warn
         if component.name in n.branch_components and int(attr[-1]) > 1:
             missing &= component.static[attr] != ""
@@ -72,12 +81,20 @@ def check_for_disconnected_buses(n: Network, strict: bool = False) -> None:
     """
     Check if network has buses that are not connected to any component.
 
+    Activate strict mode in general consistency check by passing `['disconnected_buses']`
+    the `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
         The network to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
 
     """
     connected_buses = set()
@@ -101,6 +118,9 @@ def check_for_unknown_carriers(
     """
     Check if carriers are attached to component but are not defined in the network.
 
+    Activate strict mode in general consistency check by passing `['unknown_carriers']`
+    the `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
@@ -109,6 +129,12 @@ def check_for_unknown_carriers(
         The component to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     if "carrier" in component.static.columns:
@@ -133,6 +159,9 @@ def check_for_zero_impedances(
     """
     Check if component has zero impedances. Only checks passive branch components.
 
+    Activate strict mode in general consistency check by passing `['zero_impedances']`
+    the `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
@@ -141,6 +170,13 @@ def check_for_zero_impedances(
         The component to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     if component.name in n.passive_branch_components:
@@ -161,12 +197,20 @@ def check_for_zero_s_nom(component: Components, strict: bool = False) -> None:
     """
     Check if component has zero s_nom. Only checks transformers.
 
+    Activate strict mode in general consistency check by passing `['zero_s_nom']` to
+    the `strict` argument.
+
     Parameters
     ----------
     component : pypsa.Component
         The component to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
 
     """
     if component.name in {"Transformer"}:
@@ -186,6 +230,9 @@ def check_time_series(n: Network, component: Components, strict: bool = False) -
     """
     Check if time series of component are aligned with network snapshots.
 
+    Activate strict mode in general consistency check by passing `['time_series']` to
+    the `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
@@ -194,6 +241,12 @@ def check_time_series(n: Network, component: Components, strict: bool = False) -
         The component to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     for attr in component.attrs.index[component.attrs.varying & component.attrs.static]:
@@ -229,6 +282,9 @@ def check_static_power_attributes(
     """
     Check static attrs p_now, s_nom, e_nom in any component.
 
+    Activate strict mode in general consistency check by passing `['static_power_attrs']`
+    the `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
@@ -237,6 +293,12 @@ def check_static_power_attributes(
         The component to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     static_attrs = ["p_nom", "s_nom", "e_nom"]
@@ -276,6 +338,9 @@ def check_time_series_power_attributes(
     """
     Check `p_max_pu` and `e_max_pu` nan and infinite values in time series.
 
+    Activate strict mode in general consistency check by passing `['time_series_power_attrs']`
+    the `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
@@ -284,6 +349,11 @@ def check_time_series_power_attributes(
         The component to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
 
     """
     varying_attrs = ["p_max_pu", "e_max_pu"]
@@ -363,6 +433,9 @@ def check_assets(n: Network, component: Components, strict: bool = False) -> Non
     """
     Check if assets are only committable or extendable, but not both.
 
+    Activate strict mode in general consistency check by passing `['assets']` to the
+    `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
@@ -371,6 +444,12 @@ def check_assets(n: Network, component: Components, strict: bool = False) -> Non
         The component to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     if component.name in {"Generator", "Link"}:
@@ -396,6 +475,9 @@ def check_generators(component: Components, strict: bool = False) -> None:
     1. Ensures that committable generators are not both up and down before the simulation.
     2. Verifies that the minimum total energy to be produced (e_sum_min) is not greater than the maximum total energy to be produced (e_sum_max).
 
+    Activate strict mode in general consistency check by passing `['generators']` to the
+    the `strict` argument.
+
     Parameters
     ----------
     component : Component
@@ -406,6 +488,12 @@ def check_generators(component: Components, strict: bool = False) -> None:
     Returns
     -------
     None
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     if component.name in {"Generator"}:
@@ -439,6 +527,9 @@ def check_dtypes_(component: Components, strict: bool = False) -> None:
     """
     Check if the dtypes of the attributes in the component are as expected.
 
+    Activate strict mode in general consistency check by passing `['dtypes']` to the
+    `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
@@ -447,6 +538,12 @@ def check_dtypes_(component: Components, strict: bool = False) -> None:
         The component to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     dtypes_soll = component.attrs.loc[component.attrs["static"], "dtype"].drop("name")
@@ -491,12 +588,21 @@ def check_investment_periods(n: Network, strict: bool = False) -> None:
     """
     Check if investment periods are aligned with snapshots.
 
+    Activate strict mode in general consistency check by passing `['investment_periods']`
+    to the `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
         The network to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     constraint_periods = set(n.global_constraints.investment_period.dropna().unique())
@@ -527,12 +633,21 @@ def check_shapes(n: Network, strict: bool = False) -> None:
     """
     Check if shapes are aligned with related components.
 
+    Activate strict mode in general consistency check by passing `['shapes']` to the
+    `strict` argument.
+
     Parameters
     ----------
     n : pypsa.Network
         The network to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     shape_components = n.shapes.component.unique()
@@ -557,6 +672,9 @@ def check_nans_for_component_default_attrs(
     """
     Check for missing values in component attributes.
 
+    Activate strict mode in general consistency check by passing `['nans_for_component_default_attrs']`
+    the `strict` argument.
+
     Checks for all attributes if they are nan but have a default value, which is not
      nan.
 
@@ -568,6 +686,12 @@ def check_nans_for_component_default_attrs(
         The component to check.
     strict : bool, optional
         If True, raise an error instead of logging a warning.
+
+    See Also
+    --------
+    pypsa.Network.consistency_check : General consistency check method, which can be
+                                      runs all consistency checks.
+
 
     """
     # Get non-NA and not-empty default attributes for the current component
@@ -610,3 +734,131 @@ def check_nans_for_component_default_attrs(
                 nan_cols.to_list(),
                 component.name,
             )
+
+
+def consistency_check(
+    n: Network, check_dtypes: bool = False, strict: Sequence | None = None
+) -> None:
+    """
+    Check network for consistency
+
+    Runs a series of checks on the network to ensure that it is consistent, e.g. that
+    all components are connected to existing buses and that no impedances are singular.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        The network to check.
+    check_dtypes : bool, optional
+        If True, check the dtypes of the attributes in the components.
+    strict : list, optional
+        If some checks should raise an error instead of logging a warning, pass a list
+        of strings with the names of the checks to be strict about. If 'all' is passed,
+        all checks will be strict. The default is no strict checks.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ConsistencyError : If any of the checks fail and strict mode is activated.
+
+    Examples
+    --------
+    >>> import pypsa
+    >>> n = pypsa.examples.ac_dc_meshed()
+    >>> n.consistency_check()
+
+    See Also
+    --------
+    pypsa.consistency.check_for_unknown_buses : Check if buses are attached to
+        component but are not defined in the network.
+    pypsa.consistency.check_for_disconnected_buses : Check if network has buses that
+        are not connected to any component.
+    pypsa.consistency.check_for_unknown_carriers : Check if carriers are attached to
+        component but are not defined in the network.
+    pypsa.consistency.check_for_zero_impedances : Check if component has zero
+        impedances. Only checks passive branch components.
+    pypsa.consistency.check_for_zero_s_nom : Check if component has zero s_nom. Only
+        checks transformers.
+    pypsa.consistency.check_time_series : Check if time series of component are
+        aligned with network snapshots.
+    pypsa.consistency.check_static_power_attributes : Check static attrs p_now, s_nom,
+        e_nom in any component.
+    pypsa.consistency.check_time_series_power_attributes : Check `p_max_pu` and
+        `e_max_pu` nan and infinite values in time series.
+    pypsa.consistency.check_assets : Check if assets are only committable or
+        extendable, but not both.
+    pypsa.consistency.check_generators : Check the consistency of generator attributes
+        before the simulation.
+    pypsa.consistency.check_dtypes_ : Check if the dtypes of the attributes in the
+        component are as expected.
+    pypsa.consistency.check_investment_periods : Check if investment periods are aligned
+        with snapshots.
+    pypsa.consistency.check_shapes : Check if shapes are aligned with related components.
+    pypsa.consistency.check_nans_for_component_default_attrs : Check for missing values
+        in component attributes.
+
+    """
+    if strict is None:
+        strict = []
+
+    strict_options = [
+        "unknown_buses",
+        "unknown_carriers",
+        "time_series",
+        "static_power_attrs",
+        "time_series_power_attrs",
+        "nans_for_component_default_attrs",
+        "zero_impedances",
+        "zero_s_nom",
+        "assets",
+        "generators",
+        "disconnected_buses",
+        "investment_periods",
+        "shapes",
+        "dtypes",
+    ]
+
+    if "all" in strict:
+        strict = strict_options
+    if not all(s in strict_options for s in strict):
+        raise ValueError(
+            f"Invalid strict option(s) {set(strict) - set(strict_options)}. "
+            f"Valid options are {strict_options}. Please check the documentation for "
+            "more details on them."
+        )
+
+    n.calculate_dependent_values()
+
+    # TODO: Check for bidirectional links with efficiency < 1.
+    # TODO: Warn if any ramp limits are 0.
+
+    # Per component checks
+    for c in n.iterate_components():
+        # Checks all components
+        check_for_unknown_buses(n, c, "unknown_buses" in strict)
+        check_for_unknown_carriers(n, c, "unkown_carriers" in strict)
+        check_time_series(n, c, "time_series" in strict)
+        check_static_power_attributes(n, c, "static_power_attrs" in strict)
+        check_time_series_power_attributes(n, c, "time_series_power_attrs" in strict)
+        check_nans_for_component_default_attrs(
+            n, c, "nans_for_component_default_attrs" in strict
+        )
+        # Checks passive_branch_components
+        check_for_zero_impedances(n, c, "zero_impedances" in strict)
+        # Checks transformers
+        check_for_zero_s_nom(c, "zero_s_nom" in strict)
+        # Checks generators and links
+        check_assets(n, c, "assets" in strict)
+        # Checks generators
+        check_generators(c, "generators" in strict)
+
+        if check_dtypes:
+            check_dtypes_(c, "dtypes" in strict)
+
+    # Combined checks
+    check_for_disconnected_buses(n, "disconnected_buses" in strict)
+    check_investment_periods(n, "investment_periods" in strict)
+    check_shapes(n, "shapes" in strict)

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -215,6 +215,7 @@ def create_model(
     multi_investment_periods: bool = False,
     transmission_losses: int = 0,
     linearized_unit_commitment: bool = False,
+    consistency_check: bool = True,
     **kwargs: Any,
 ) -> Model:
     """
@@ -234,6 +235,8 @@ def create_model(
     transmission_losses : int, default 0
     linearized_unit_commitment : bool, default False
         Whether to optimise using the linearised unit commitment formulation or not.
+    consisteny_check : bool, default True
+        Whether to run the consistency check before building the model.
     **kwargs:
         Keyword arguments used by `linopy.Model()`, such as `solver_dir` or `chunk`.
 
@@ -244,7 +247,8 @@ def create_model(
     sns = as_index(n, snapshots, "snapshots")
     n._linearized_uc = int(linearized_unit_commitment)
     n._multi_invest = int(multi_investment_periods)
-    n.consistency_check()
+    if consistency_check:
+        n.consistency_check()
 
     kwargs.setdefault("force_dim_names", True)
     n.model = Model(**kwargs)
@@ -586,13 +590,14 @@ def optimize(
     n._multi_invest = int(multi_investment_periods)
     n._linearized_uc = linearized_unit_commitment
 
-    n.consistency_check()
+    n.consistency_check(strict=["unknown_buses"])
     m = create_model(
         n,
         sns,
         multi_investment_periods,
         transmission_losses,
         linearized_unit_commitment,
+        consistency_check=False,
         **model_kwargs,
     )
     if extra_functionality:


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Adds option for granular strict consistency checks within `n.consistency_check()`
  - Pass it as a list, e.g. `n.consistency_check(strict=["unknown_buses"])`
- Runs the following checks as strict by default in `n.optimise`
  - `unknown_buses`

We could also add more strict checks in `n.optimize`. Let me know what you think

**Context**
> I think we should change the behavior in pypsa that if there is a link with undefined  buses that this throws either an error. I know that it throws a warning that buses of certain links are not defined, but this is often the output in prepare_sector_network because the bus is added later on.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
