### PR TITLE
fix: correctly assign branch contributions in supply and withdrawal

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -61,6 +61,8 @@ Bug fixes
   energy balance calculation. Before the fix, the "Load" component was not
   considered. (https://github.com/PyPSA/PyPSA/pull/1110)
 
+* The optimize/expression module now correctly assigns contributions from branch components in the `withdrawal` and `supply` functions. Before, there was a wrong multiplication by -1 for branch components. 
+
 `v0.32.0 <https://github.com/PyPSA/PyPSA/releases/tag/v0.32.0>`__ (5th December 2024)
 =======================================================================================
 

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -383,14 +383,15 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
         @pass_none_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
             var = self._get_operational_variable(c)
+            # negative branch contributions are considered by the efficiency
             efficiency = port_efficiency(n, c, port=port, dynamic=True)
-            sign = -1.0 if c in n.branch_components else n.df(c).get("sign", 1.0)
+            sign = n.df(c).get("sign", 1.0)
             weights = get_weightings(n, c)
             coeffs = DataArray(efficiency * sign)
             if kind == "supply":
                 coeffs = coeffs.clip(min=0)
             elif kind == "withdrawal":
-                coeffs = coeffs.clip(max=0)
+                coeffs = -coeffs.clip(max=0)
             elif kind is not None:
                 raise ValueError(
                     f"Got unexpected argument kind={kind}. Must be 'supply', 'withdrawal' or None."

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -391,6 +391,9 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             if kind == "supply":
                 coeffs = coeffs.clip(min=0)
             elif kind == "withdrawal":
+                logger.warning(
+                    "The sign convention for withdrawal has changed: withdrawal values are now reported as positive numbers instead of negative numbers."
+                )
                 coeffs = -coeffs.clip(max=0)
             elif kind is not None:
                 raise ValueError(


### PR DESCRIPTION
Closes #1122 

There is a problem related to be a duplicated multiplication with -1 for branch components in energy_balance (one time in `sign` and one time through `efficiency`).  

Also in order to be consistent with the statistic module, the withdrawal is set to be positive. Should we add a warning here @lkstrp ?

## Changes proposed in this Pull Request

Remove the -1 multiplication through `sign` for branch components.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
