### PR TITLE
Deprecate custom components

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -31,16 +31,19 @@ Features
 
   * This is an experimental feature, will be developed further and is not yet 
     recommended for general use. More features, documentation and examples will 
-    follow. Most users will not notice any changes. If you wanna play around with
-    it, you could do so for example via: ``c = n.components.generators``.
-  
-  * While the changes try to maintain full backwards compatibility, there may be some 
-    breaking changes or bugs, especially if you use custom components or custom 
-    component attributes in your network attributes in your network. 
-  
-  * Please report any issues and bugs you might encounter
-    via the `issue tracker <https://github.com/PyPSA/PyPSA/issues/new>`__ on 
-    GitHub.
+    follow. Most users will not notice any changes.
+
+* Deprecation of custom components (https://github.com/PyPSA/PyPSA/pull/1130)
+
+   * This version of PyPSA deprecates custom components. While we don't see many use 
+     cases for them, they might be added in an improved way in future again. For a 
+     potential reimplementation we would be happy to hear your use case and 
+     requirements via the `issue tracker <https://www.github.com/PyPSA/PyPSA/issues>`_.
+   
+   * If you don't know what this is or have never used the ``override_components``
+     and ``override_component_attrs`` arguments during Network initialisation, you can
+     safely ignore this deprecation.
+     
 
 * New network attributes :meth:`n.timesteps <pypsa.networks.Network.timesteps>`, 
   :meth:`n.periods <pypsa.networks.Network.periods>` and 

--- a/doc/user-guide/components.rst
+++ b/doc/user-guide/components.rst
@@ -492,3 +492,11 @@ correspond to the repository CSV files ``pypsa/data/components.csv`` and
 ``list_name``, ``description`` and ``type``. ``default_component_attrs`` is a special
 :meth:`Dict <pypsa.definitions.structures.Dict>` of pandas.DataFrame with the attribute
 properties for each component.  Just follow the formatting for the standard components.
+
+.. warning::
+
+   Version 0.33.0 of PyPSA, deprecates custom components. They most likely will be 
+   added in a different way in future again. If you rely on custom components,
+   please do not update to this version. For the reimplementation we would also be 
+   happy to hear your use case and requirements via the 
+   `issue tracker <https://www.github.com/PyPSA/PyPSA/issues>`_.

--- a/pypsa/components/types.py
+++ b/pypsa/components/types.py
@@ -7,7 +7,6 @@ Additional types can be added by the user.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
@@ -218,35 +217,6 @@ def get(name: str) -> ComponentType:
             f"Component type '{name}' not found. If you use a custom component, make "
             f"sure to have it added. Available types are: "
             f"{list_as_string(all_components)}."
-        )
-        raise ValueError(msg)
-
-
-def check_if_added(components: str | Sequence) -> None:
-    """
-    Check if components are registered package-wide.
-
-    Parameters
-    ----------
-    components : list of str
-        List of component type names.
-
-    Raises
-    ------
-    ValueError
-        If a component is not registered package-wide.
-
-    """
-    if np.isscalar(components):
-        components = [components]
-
-    # Make sure any custom components are registered package-wide
-    if not_registered := [
-        c_name for c_name in components if c_name not in all_components.keys()
-    ]:
-        msg = (
-            f"Network contains custom components which are not registered "
-            f"package-wide. Add them first: {not_registered}components_"
         )
         raise ValueError(msg)
 

--- a/test/test_components_custom.py
+++ b/test/test_components_custom.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pandas as pd
-import pytest
 
 import pypsa
 from pypsa.components.types import component_types_df, default_components, get
@@ -47,8 +46,8 @@ def test_custom_component_registration():
     assert custom_component.defaults.equals(defaults_df)
 
 
-def test_unregistered_custom_components():
-    import pypsa
+# def test_unregistered_custom_components():
+#     import pypsa
 
-    with pytest.raises(ValueError, match="Component type 'MyComponent' not found."):
-        pypsa.Network(custom_components=["MyComponent"])
+#     with pytest.raises(ValueError, match="Component type 'MyComponent' not found."):
+#         pypsa.Network(custom_components=["MyComponent"])


### PR DESCRIPTION
As discussed @fneum 

- Since #1128 got way to big, I would publish a release to get those components classes out
- After 1128 custom components can be implemented way nicer then done before. Another question is if this is even needed. The API will change significantly in any case
