### PR TITLE
test: mock cloudpathlib

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,6 +11,12 @@ Release Notes
 ..   To use the features already you have to install the ``master`` branch, e.g. 
 ..   ``pip install git+https://github.com/pypsa/pypsa``.
 
+* `pypsa[cloudpath]` optional dependency will now only install `cloudpathlib` without extra 
+  cloud storage provider client libraries, these will be left to the user to install.
+
+* Fixed bugs with `import_from_netcdf` and `import_from_hdf5` not working when a URI is
+  passed as a string instead of a CloudPath object.
+
 `v0.33.0 <https://github.com/PyPSA/PyPSA/releases/tag/v0.33.0>`__ (7th February 2025)
 =======================================================================================
 

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -2,14 +2,14 @@
 Release Notes
 #######################
 
-.. Upcoming Release
-.. ================
+Upcoming Release
+================
 
-.. .. warning:: 
+.. warning:: 
   
-..   The features listed below are not released yet, but will be part of the next release! 
-..   To use the features already you have to install the ``master`` branch, e.g. 
-..   ``pip install git+https://github.com/pypsa/pypsa``.
+  The features listed below are not released yet, but will be part of the next release! 
+  To use the features already you have to install the ``master`` branch, e.g. 
+  ``pip install git+https://github.com/pypsa/pypsa``.
 
 * `pypsa[cloudpath]` optional dependency will now only install `cloudpathlib` without extra 
   cloud storage provider client libraries, these will be left to the user to install.

--- a/doc/user-guide/import-export.rst
+++ b/doc/user-guide/import-export.rst
@@ -82,7 +82,9 @@ CSV, netCDF and HDF5 files in cloud object storage can be imported and exported 
 the :code:`[cloudpath]` optional dependency, installable via :code:`pip install 'pypsa[cloudpath]'`.
 
 :code:`cloudpathlib` supports AWS S3 (:code:`s3://`), Google Cloud Storage (:code:`gs://`) and
-Azure Blob Storage (:code:`az://`) as cloud object storage providers.
+Azure Blob Storage (:code:`az://`) as cloud object storage providers. Users will need to additionally
+install the appropriate cloud storage provider client library to interface with the corresponding
+cloud storage provider via cloudpathlib (e.g. `boto3`, `google-cloud-storage` or `azure-storage-blob`).
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ cartopy = [
     "requests",
 ]
 gurobipy = ["gurobipy"]
-cloudpath = ["cloudpathlib[all]"]
+cloudpath = ["cloudpathlib"]
 dev = [
     "pytest", 
     "coverage",

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -260,7 +260,7 @@ class ImporterHDF5(Importer):
         if isinstance(path, (str | Path)):
             if validators.url(str(path)):
                 path = _retrieve_from_url(str(path))
-            self.ds = pd.HDFStore(path, mode="r")
+            self.ds = pd.HDFStore(Path(path), mode="r")
         self.index: dict = {}
 
     def get_attributes(self) -> dict:
@@ -366,7 +366,7 @@ class ImporterNetCDF(Importer):
         if isinstance(path, (str | Path)):
             if validators.url(str(path)):
                 path = _retrieve_from_url(str(path))
-            self.ds = xr.open_dataset(path)
+            self.ds = xr.open_dataset(Path(path))
         else:
             self.ds = path
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -278,20 +278,3 @@ def test_io_time_dependent_efficiencies(tmpdir):
     equal(m.generators_t.efficiency, n.generators_t.efficiency)
     equal(m.storage_units_t.efficiency_store, n.storage_units_t.efficiency_store)
     equal(m.storage_units_t.efficiency_dispatch, n.storage_units_t.efficiency_dispatch)
-
-
-def test_cloudpathlib_uses_pathlib_path_locally(scipy_network, tmpdir):
-    cloudpathlib = pytest.importorskip("cloudpathlib")
-    fn = cloudpathlib.AnyPath(tmpdir).joinpath("netcdf_export.nc")
-    assert isinstance(fn, Path)
-    assert not isinstance(fn, cloudpathlib.CloudPath)
-    scipy_network.export_to_netcdf(fn)
-
-
-def test_cloudpathlib_uri_schemes():
-    cloudpathlib = pytest.importorskip("cloudpathlib")
-    assert isinstance(cloudpathlib.AnyPath("s3://bucket/file"), cloudpathlib.S3Path)
-    assert isinstance(cloudpathlib.AnyPath("gs://bucket/file"), cloudpathlib.GSPath)
-    assert isinstance(
-        cloudpathlib.AnyPath("az://bucket/file"), cloudpathlib.AzureBlobPath
-    )

--- a/test/test_io_cloudpathlib.py
+++ b/test/test_io_cloudpathlib.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import pypsa
+
+pytest.importorskip("cloudpathlib", reason="cloudpathlib not installed")
+
+from cloudpathlib import AnyPath, CloudPath, implementation_registry
+from cloudpathlib.local import (
+    local_azure_blob_implementation,
+    local_gs_implementation,
+    local_s3_implementation,
+)
+
+
+@pytest.fixture(
+    params=[
+        local_s3_implementation,
+        local_gs_implementation,
+        local_azure_blob_implementation,
+    ],
+    ids=["s3", "gs", "azure"],
+)
+def cloudpathlib_local_implementation(request):
+    implementation = request.param
+    with (
+        patch.dict(implementation_registry, {implementation.name: implementation}),
+        # NOTE: Bypassing "AzureBlobClient does not support anonymous instantiation"
+        patch.dict("os.environ", {"AZURE_STORAGE_CONNECTION_STRING": ""}),
+    ):
+        yield implementation._path_class
+    implementation._client_class.reset_default_storage_dir()
+
+
+@pytest.fixture
+def cloudpath_local_bucket(cloudpathlib_local_implementation):
+    local_cls = cloudpathlib_local_implementation
+    local_bucket = local_cls(f"{local_cls.cloud_prefix}test-local-bucket")
+    assert isinstance(AnyPath(local_bucket), CloudPath)
+    return local_bucket
+
+
+@pytest.fixture
+def cloudpath_network_parameterized_ext(request, cloudpath_local_bucket):
+    ext = request.param
+    cloudpath = cloudpath_local_bucket / f"network{ext}"
+    assert cloudpath.suffix == request.param
+    return cloudpath
+
+
+@pytest.fixture(params=[True, False], ids=["uri", "cloudpath"])
+def cloudpath_network(request, cloudpath_network_parameterized_ext):
+    if request.param:
+        return cloudpath_network_parameterized_ext.as_uri()
+    return cloudpath_network_parameterized_ext
+
+
+class TestIOCloudpath:
+    @pytest.mark.parametrize(
+        "cloudpath_network_parameterized_ext", [".nc"], indirect=True, ids=["netcdf"]
+    )
+    def test_io_cloudpath_netcdf(self, cloudpath_network, scipy_network):
+        scipy_network.export_to_netcdf(cloudpath_network)
+        n = pypsa.Network()
+        n.import_from_netcdf(cloudpath_network)
+
+    @pytest.mark.parametrize(
+        "cloudpath_network_parameterized_ext", [".h5"], indirect=True, ids=["hdf5"]
+    )
+    def test_io_cloudpath_hdf5(self, cloudpath_network, scipy_network):
+        scipy_network.export_to_hdf5(cloudpath_network)
+        # FIXME: why is this needed for hdf5? cloudpathlib is claiming that the local
+        # cached file from export is newer on disk than the cloud file being imported
+        with patch.dict("os.environ", {"CLOUDPATHLIB_FORCE_OVERWRITE_FROM_CLOUD": "1"}):
+            n = pypsa.Network()
+            n.import_from_hdf5(cloudpath_network)
+
+    @pytest.mark.parametrize(
+        "cloudpath_network_parameterized_ext", [""], indirect=True, ids=["csv_folder"]
+    )
+    def test_io_cloudpath_csv_folder(self, cloudpath_network, scipy_network):
+        scipy_network.export_to_csv_folder(cloudpath_network)
+        n = pypsa.Network()
+        n.import_from_csv_folder(cloudpath_network)
+
+
+def test_cloudpathlib_anypath_uses_pathlib_path_locally():
+    path = AnyPath(".")
+    assert isinstance(path, Path)
+    assert not isinstance(path, CloudPath)


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Follow up to https://github.com/PyPSA/PyPSA/pull/1023
* Implement extensive testing using [mocked local implementations provided by cloudpathlib](https://cloudpathlib.drivendata.org/stable/testing_mocked_cloudpathlib/). This remains an optional feature if you have `cloudpathlib` installed so these tests will be skipped if you don't (including in CI).
* Fix bugs with direct calls to `n.import_from_netcdf(path)` and `n.import_from_hdf5(path)` where `path` was a uri string not a `CloudPath` object.
* Replace installing `cloudpathlib[all]` with just `cloudpathlib` and leave it to the user to install the cloud storage client library of choice - avoids unnecessary bloat of virtual environment, and is not required to run the tests.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
