### PR TITLE
docs: update issue types and use link to discord instead

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,13 +1,14 @@
 name: Bug Report
 description: Create a report if something doesn't work quite right.
-labels: ["bug", "needs triage"]
+labels: ["needs triage"]
+type: "Bug"
 
 body:
 - type: markdown
   attributes:
     value: |
       Thanks for taking the time to fill out this bug report!
-      Please do not post usage questions here. Ask them on the [PyPSA mailing list](https://groups.google.com/forum/#!forum/pypsa).
+      Please do not post usage questions here. Ask them on the [PyPSA Discord server](https://discord.gg/AnuJBk23FU).
 
 - type: checkboxes
   id: checks

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-- name: PyPSA Mailing List
-  url: https://groups.google.com/forum/#!forum/pypsa
+- name: PyPSA Discord server
+  url: https://discord.gg/AnuJBk23FU
   about: Please ask and answer general usage questions here.
-
-- name: Stackoverflow
-  url: https://stackoverflow.com/questions/tagged/pypsa
-  about: Please ask and answer code-related questions here.

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yaml
@@ -1,6 +1,7 @@
 name: Documentation Improvement
 description: Report wrong or missing documentation
-labels: ["documentation", "needs triage"]
+labels: ["needs triage"]
+type: 'Docs'
 
 body:
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,12 +2,13 @@
 name: Feature Request
 about: Suggest an idea for this project
 title: ''
-labels: ["feature", "needs triage"]
+labels: ["needs triage"]
+type: 'Feature'
 assignees: ''
 
 ---
 
-<!-- Please do not post usage questions here. Ask them on the PyPSA mailing list: https://groups.google.com/forum/#!forum/pypsa -->
+<!-- Please do not post usage questions here. Ask them on the PyPSA Discord server: https://discord.gg/AnuJBk23FU -->
 
 ## Describe the feature you'd like to see
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![Zenodo](https://zenodo.org/badge/DOI/10.5281/zenodo.3946412.svg)](https://doi.org/10.5281/zenodo.3946412)
 [![Discord](https://img.shields.io/discord/911692131440148490?logo=discord)](https://discord.gg/AnuJBk23FU)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
-[![Stack Exchange questions](https://img.shields.io/stackexchange/stackoverflow/t/pypsa)](https://stackoverflow.com/questions/tagged/pypsa)
 
 PyPSA stands for "Python for Power System Analysis". It is pronounced
 "pipes-ah".
@@ -175,9 +174,7 @@ the preferred solver. You can use e.g. one of the free solvers
 
 We strongly welcome anyone interested in contributing to this project. If you have any ideas, suggestions or encounter problems, feel invited to file issues or make pull requests on GitHub.
 
--   In case of code-related **questions**, please post on [stack overflow](https://stackoverflow.com/questions/tagged/pypsa).
--   For non-programming related and more general questions please refer to the [mailing list](https://groups.google.com/group/pypsa).
--   To **discuss** with other PyPSA users, organise projects, share news, and get in touch with the community you can use the [discord server](https://discord.gg/AnuJBk23FU).
+-   To **discuss** with other PyPSA users, organise projects, share news, and get in touch with the community you can use the [Discord server](https://discord.gg/AnuJBk23FU).
 -   For **bugs and feature requests**, please use the [PyPSA Github Issues page](https://github.com/PyPSA/PyPSA/issues).
 -   For **troubleshooting**, please check the [troubleshooting](https://pypsa.readthedocs.io/en/latest/troubleshooting.html) in the documentation.
 

--- a/doc/contributing/contributing.rst
+++ b/doc/contributing/contributing.rst
@@ -15,9 +15,7 @@ with new ideas, suggestions, submitting bug reports or contributing code changes
 
 **Where to go for help**
 
-* In case of code-related **questions**, please post on `stack overflow <https://stackoverflow.com/questions/tagged/pypsa>`_.
-* For non-programming related and more general questions please refer to the `mailing list <https://groups.google.com/group/pypsa>`_.
-* To **discuss** with other PyPSA users, organise projects, share news, and get in touch with the community you can use the `discord server <https://discord.gg/AnuJBk23FU>`_.
+* To **discuss** with other PyPSA users, organise projects, share news, and get in touch with the community you can use the `Discord server <https://discord.gg/AnuJBk23FU>`_.
 * For **troubleshooting**, please check the `troubleshooting <https://pypsa.readthedocs.io/en/latest/contributing/troubleshooting.html>`_ in the documentation.
 * For **guidelines to contribute** to PyPSA, stay right here.
 

--- a/doc/contributing/support.rst
+++ b/doc/contributing/support.rst
@@ -5,9 +5,7 @@ Support
 
 Please consider the following ways to reach out to the community and the developers:
 
-* In case of code-related **questions**, please post on `stack overflow <https://stackoverflow.com/questions/tagged/pypsa>`_.
-* For non-programming related and more general questions please refer to the `mailing list <https://groups.google.com/group/pypsa>`_.
-* To **discuss** with other PyPSA users, organise projects, share news, and get in touch with the community you can use the `discord server <https://discord.gg/AnuJBk23FU>`_.
+* To **discuss** with other PyPSA users, organise projects, share news, and get in touch with the community you can use the `Discord server <https://discord.gg/AnuJBk23FU>`_.
 * For **bugs and feature requests**, please use the `issue tracker <https://github.com/PyPSA/PyPSA/issues>`_.
 * We strongly welcome anyone interested in providing **contributions** to this project. If you have any ideas, suggestions or encounter problems, feel invited to file issues or make pull requests on `Github <https://github.com/PyPSA/PyPSA>`_.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,9 +53,6 @@ PyPSA: Python for Power System Analysis
     :target: CODE_OF_CONDUCT.md
     :alt: Contributor Covenant
 
-.. image:: https://img.shields.io/stackexchange/stackoverflow/t/pypsa
-    :target: https://stackoverflow.com/questions/tagged/pypsa
-    :alt: Stack Exchange questions
 
 | PyPSA stands for "Python for Power System Analysis". It is pronounced "pipes-ah".
 

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -2234,4 +2234,3 @@ Release process
   `zenodo <https://zenodo.org/>`_ to archive the release with its own DOI.
 * To update to conda-forge, check the pull request generated at the `feedstock repository
   <https://github.com/conda-forge/pypsa-feedstock>`_.
-* Inform the PyPSA mailing list.


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Use issue types in tempaltes
- Removes stackoverflow and pypsa mailing list and point to discord server instead