### PR TITLE
fix: fix linearized unit commitment with equal startup and shutdown costs

### DIFF
--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -217,32 +217,34 @@ def define_operational_constraints_for_committables(
     )
 
     # min up time
-    mask = get_activity_mask(n, c, sns[1:], com_i)
-    expr = []
     min_up_time_i = com_i[min_up_time_set.astype(bool)]
     if not min_up_time_i.empty:
+        expr = []
         for g in min_up_time_i:
             su = start_up.loc[:, g]
             expr.append(su.rolling(snapshot=min_up_time_set[g]).sum())
         lhs = -status.loc[:, min_up_time_i] + merge(expr, dim=com_i.name)
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-up-time", mask=mask[min_up_time_i]
+            lhs, "<=", 0, name=f"{c}-com-up-time", mask=active[min_up_time_i].iloc[1:]
         )
 
     # min down time
-    expr = []
     min_down_time_i = com_i[min_down_time_set.astype(bool)]
     if not min_down_time_i.empty:
+        expr = []
         for g in min_down_time_i:
             su = shut_down.loc[:, g]
             expr.append(su.rolling(snapshot=min_down_time_set[g]).sum())
         lhs = status.loc[:, min_down_time_i] + merge(expr, dim=com_i.name)
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 1, name=f"{c}-com-down-time", mask=mask[min_down_time_i]
+            lhs,
+            "<=",
+            1,
+            name=f"{c}-com-down-time",
+            mask=active[min_down_time_i].iloc[1:],
         )
-
     # up time before
     timesteps = pd.DataFrame([range(1, len(sns) + 1)] * len(com_i), com_i, sns).T
     if initially_up.any():
@@ -261,58 +263,76 @@ def define_operational_constraints_for_committables(
         n.model.add_constraints(status, "=", 0, name=name, mask=mask)
 
     # linearized approximation because committable can partly start up and shut down
-    cost_equal = all(
+    cost_equal = (
         n.static(c).loc[com_i, "start_up_cost"]
         == n.static(c).loc[com_i, "shut_down_cost"]
-    )
+    ).values
     # only valid additional constraints if start up costs equal to shut down costs
-    if n._linearized_uc and not cost_equal:
+    if n._linearized_uc and not cost_equal.all():
         logger.warning(
             "The linear relaxation of the unit commitment cannot be "
-            "tightened since the start up costs are not equal to the "
-            "shut down costs. Proceed with the linear relaxation "
-            "without the tightening by additional constraints. "
-            "This might result in a longer solving time."
+            "tightened for all generators since the start up costs "
+            "are not equal to the shut down costs. Proceed with the "
+            "linear relaxation without the tightening by additional "
+            "constraints for these. This might result in a longer "
+            "solving time."
         )
-    if n._linearized_uc and cost_equal:
+    if n._linearized_uc and cost_equal.any():
         # dispatch limit for partly start up/shut down for t-1
+        p_ce = p.loc[:, cost_equal]
+        start_up_ce = start_up.loc[:, cost_equal]
+        status_ce = status.loc[:, cost_equal]
+        active_ce = active.loc[:, cost_equal]
+
+        # parameters
+        upper_p_ce = upper_p.loc[:, cost_equal]
+        lower_p_ce = lower_p.loc[:, cost_equal]
+        ramp_shut_down_ce = ramp_shut_down.loc[cost_equal]
+        ramp_start_up_ce = ramp_start_up.loc[cost_equal]
+        ramp_up_limit_ce = ramp_up_limit.loc[cost_equal]
+        ramp_down_limit_ce = ramp_down_limit.loc[cost_equal]
+
         lhs = (
-            p.shift(snapshot=1)
-            - ramp_shut_down * status.shift(snapshot=1)
-            - (upper_p - ramp_shut_down) * (status - start_up)
+            p_ce.shift(snapshot=1)
+            - ramp_shut_down_ce * status_ce.shift(snapshot=1)
+            - (upper_p_ce - ramp_shut_down_ce) * (status_ce - start_up_ce)
         )
         lhs = lhs.sel(snapshot=sns[1:])
-        n.model.add_constraints(lhs, "<=", 0, name=f"{c}-com-p-before", mask=active)
+        n.model.add_constraints(lhs, "<=", 0, name=f"{c}-com-p-before", mask=active_ce)
 
         # dispatch limit for partly start up/shut down for t
-        lhs = p - upper_p * status + (upper_p - ramp_start_up) * start_up
+        lhs = (
+            p_ce
+            - upper_p_ce * status_ce
+            + (upper_p_ce - ramp_start_up_ce) * start_up_ce
+        )
         lhs = lhs.sel(snapshot=sns[1:])
-        n.model.add_constraints(lhs, "<=", 0, name=f"{c}-com-p-current", mask=active)
+        n.model.add_constraints(lhs, "<=", 0, name=f"{c}-com-p-current", mask=active_ce)
 
         # ramp up if committable is only partly active and some capacity is starting up
         lhs = (
-            p
-            - p.shift(snapshot=1)
-            - (lower_p + ramp_up_limit) * status
-            + lower_p * status.shift(snapshot=1)
-            + (lower_p + ramp_up_limit - ramp_start_up) * start_up
+            p_ce
+            - p_ce.shift(snapshot=1)
+            - (lower_p_ce + ramp_up_limit_ce) * status_ce
+            + lower_p_ce * status_ce.shift(snapshot=1)
+            + (lower_p_ce + ramp_up_limit_ce - ramp_start_up_ce) * start_up_ce
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-start-up", mask=active
+            lhs, "<=", 0, name=f"{c}-com-partly-start-up", mask=active_ce
         )
 
         # ramp down if committable is only partly active and some capacity is shutting up
         lhs = (
-            p.shift(snapshot=1)
-            - p
-            - ramp_shut_down * status.shift(snapshot=1)
-            + (ramp_shut_down - ramp_down_limit) * status
-            - (lower_p + ramp_down_limit - ramp_shut_down) * start_up
+            p_ce.shift(snapshot=1)
+            - p_ce
+            - ramp_shut_down_ce * status_ce.shift(snapshot=1)
+            + (ramp_shut_down_ce - ramp_down_limit_ce) * status_ce
+            - (lower_p_ce + ramp_down_limit_ce - ramp_shut_down_ce) * start_up_ce
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-shut-down", mask=active
+            lhs, "<=", 0, name=f"{c}-com-partly-shut-down", mask=active_ce
         )
 
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -298,7 +298,9 @@ def define_operational_constraints_for_committables(
             - (upper_p_ce - ramp_shut_down_ce) * (status_ce - start_up_ce)
         )
         lhs = lhs.sel(snapshot=sns[1:])
-        n.model.add_constraints(lhs, "<=", 0, name=f"{c}-com-p-before", mask=active_ce)
+        n.model.add_constraints(
+            lhs, "<=", 0, name=f"{c}-com-p-before", mask=active_ce.iloc[1:]
+        )
 
         # dispatch limit for partly start up/shut down for t
         lhs = (
@@ -307,7 +309,9 @@ def define_operational_constraints_for_committables(
             + (upper_p_ce - ramp_start_up_ce) * start_up_ce
         )
         lhs = lhs.sel(snapshot=sns[1:])
-        n.model.add_constraints(lhs, "<=", 0, name=f"{c}-com-p-current", mask=active_ce)
+        n.model.add_constraints(
+            lhs, "<=", 0, name=f"{c}-com-p-current", mask=active_ce.iloc[1:]
+        )
 
         # ramp up if committable is only partly active and some capacity is starting up
         lhs = (
@@ -319,7 +323,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-start-up", mask=active_ce
+            lhs, "<=", 0, name=f"{c}-com-partly-start-up", mask=active_ce.iloc[1:]
         )
 
         # ramp down if committable is only partly active and some capacity is shutting up
@@ -332,7 +336,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-shut-down", mask=active_ce
+            lhs, "<=", 0, name=f"{c}-com-partly-shut-down", mask=active_ce.iloc[1:]
         )
 
 

--- a/test/test_lopf_unit_commitment.py
+++ b/test/test_lopf_unit_commitment.py
@@ -390,7 +390,11 @@ def test_linearized_unit_commitment():
         min_down_time = rng.integers(0, 6)
         p_nom = rng.integers(1, 10) * 5
         start_up_cost = rng.integers(1, 5) * 100
-        shut_down_cost = rng.integers(1, 5) * 100
+
+        # the constraint tightening proposed in Baldick et al. depends on start_up_cost
+        # and shut_down_cost being equal therefore, we force them to be equal for first
+        # 20 generators
+        shut_down_cost = rng.integers(1, 5) * 100 if i >= 20 else start_up_cost
 
         n.add(
             "Generator",


### PR DESCRIPTION
## Changes proposed in this Pull Request

Updates the test for linearized unit commitment to also test the special case
of equal startup and shutdown costs, where additional constraints can be 
added for the subset of generators with equal startup and shutdown costs.

The first commit illustrates a failure in the tightened constraints of linearized commitment.
```python
File ~/work/pypsa/pypsa/optimization/optimize.py:288, in create_model(n, snapshots, multi_investment_periods, transmission_losses, linearized_unit_commitment, consistency_check, **kwargs)
    282 define_operational_constraints_for_non_extendables(
    283     n, sns, c, attr, transmission_losses
    284 )
    285 define_operational_constraints_for_extendables(
    286     n, sns, c, attr, transmission_losses
    287 )
--> 288 define_operational_constraints_for_committables(n, sns, c)
    289 define_ramp_limit_constraints(n, sns, c, attr)
    290 define_fixed_operation_constraints(n, sns, c, attr)

File ~/work/pypsa/pypsa/optimization/constraints.py:299, in define_operational_constraints_for_committables(n, sns, c)
    293 lhs = (
    294     p_ce.shift(snapshot=1)
    295     - ramp_shut_down_ce * status_ce.shift(snapshot=1)
    296     - (upper_p_ce - ramp_shut_down_ce) * (status_ce - start_up_ce)
    297 )
    298 lhs = lhs.sel(snapshot=sns[1:])
--> 299 n.model.add_constraints(lhs, "<=", 0, name=f"{c}-com-p-before", mask=active_ce)
    301 # dispatch limit for partly start up/shut down for t
    302 lhs = (
    303     p_ce
    304     - upper_p_ce * status_ce
    305     + (upper_p_ce - ramp_start_up_ce) * start_up_ce
    306 )

[...]

ValueError: cannot align objects with join='exact' where index/labels/sizes are not equal along these coordinates (dimensions): 'snapshot' ('snapshot',)
```

Also refer to runner failure: https://github.com/PyPSA/PyPSA/actions/runs/13546783090/job/37860304197

The follow-up commit fixes the alignment.




## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
