### PR TITLE
fix(expressions): use the absolute efficiency for capacity w/o bus_carrier

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -29,6 +29,12 @@ Features
   expression (regex), enabling more flexible filtering options. 
   (https://github.com/PyPSA/PyPSA/pull/1155)
 
+
+* The expressions function `n.optimize.expressions.capacity` now uses the absolute efficiency 
+  to calculate the capacity at link ports, unless a `bus_carrier` is defined or `at_port` is set to True. 
+  This is in line with the behavior of the statistics functions (`statistics.installed_capacity`, `statistics.optimal_capacity`). 
+  Before, the efficiency was allowed to be negative, which lead to inconsistent results.
+
 `v0.33.1 <https://github.com/PyPSA/PyPSA/releases/tag/v0.33.0>`__ (3rd March 2025)
 =======================================================================================
 

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -220,6 +220,8 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
                 query = f"~{nominal_attrs[c]}_extendable"
                 capacity = capacity + n.df(c).query(query)["p_nom"]
             efficiency = port_efficiency(n, c, port=port)[capacity.indexes[c]]
+            if not at_port:
+                efficiency = abs(efficiency)
             res = capacity * efficiency
             if storage and (c == "StorageUnit"):
                 res = res * n.df(c).max_hours


### PR DESCRIPTION
## Changes proposed in this Pull Request

`n.optimize.expressions.capacity` needs to use the absolute efficiency, unless a bus_carrier chooses a non-standard viewpoint.

the change is in strict analogy to statistics.installed_capacity (ref. https://github.com/PyPSA/pypsa/blob/0566423ff32c309008129b134e323e00d0bf9b1e/pypsa/statistics/expressions.py#L514-L521 )

I guess we should add a warning to the release notes, since that is in principle a breaking change? I am a bit fuzzy about the intricate details of `at_port` and `bus_carrier`. Do you think you can add the release notes, @FabianHofmann ?

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
