### PR TITLE
fix(statistics): fix statistics regression with investment periods

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -33,7 +33,7 @@ Features
 Bug fixes
 ---------
 
-* **Regression hotfix**: Fixed a critical bug in statistics functions for multi-investment networks where built years and lifetimes were not being correctly considered. In version `v0.32.0`, only components active in the first time period were being included in statistics calculations. The fix ensures all components are properly represented according to their respective built years and lifetimes across all investment periods.
+* **Regression hotfix**: Fixed a critical bug in statistics functions for multi-investment networks where built years and lifetimes were not being correctly considered. In version `v0.32.0`, only components active in the first time period were being included in statistics calculations. The fix ensures all components are properly represented according to their respective built years and lifetimes across all investment periods. (https://github.com/PyPSA/PyPSA/pull/1172)
 
 `v0.33.1 <https://github.com/PyPSA/PyPSA/releases/tag/v0.33.0>`__ (3rd March 2025)
 =======================================================================================

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -29,6 +29,12 @@ Features
   expression (regex), enabling more flexible filtering options. 
   (https://github.com/PyPSA/PyPSA/pull/1155)
 
+
+Bug fixes
+---------
+
+* **Regression hotfix**: Fixed a critical bug in statistics functions for multi-investment networks where built years and lifetimes were not being correctly considered. In version `v0.32.0`, only components active in the first time period were being included in statistics calculations. The fix ensures all components are properly represented according to their respective built years and lifetimes across all investment periods.
+
 `v0.33.1 <https://github.com/PyPSA/PyPSA/releases/tag/v0.33.0>`__ (3rd March 2025)
 =======================================================================================
 

--- a/pypsa/statistics/abstract.py
+++ b/pypsa/statistics/abstract.py
@@ -245,14 +245,12 @@ class AbstractStatisticsAccessor(ABC):
         idx = self._get_component_index(obj, c)
         if not self.is_multi_indexed:
             mask = n.get_active_assets(c)
-            idx = mask.index[mask].intersection(idx)
-            return obj.loc[idx]
+            return obj.loc[mask.index[mask].intersection(idx)]
 
         per_period = {}
         for p in n.investment_periods:
             mask = n.get_active_assets(c, p)
-            idx = mask.index[mask].intersection(idx)
-            per_period[p] = obj.loc[idx]
+            per_period[p] = obj.loc[mask.index[mask].intersection(idx)]
 
         return self._concat_periods(per_period, c)
 

--- a/test/test_bugs.py
+++ b/test/test_bugs.py
@@ -5,6 +5,17 @@ from numpy.testing import assert_array_almost_equal as almost_equal
 import pypsa
 
 
+def test_1144():
+    """
+    See https://github.com/PyPSA/PyPSA/issues/1144.
+    """
+    n = pypsa.examples.ac_dc_meshed()
+    n.generators["build_year"] = [2020, 2020, 2030, 2030, 2040, 2040]
+    n.investment_periods = [2020, 2030, 2040]
+    capacity = n.statistics.installed_capacity(comps="Generator")
+    assert capacity[2020].sum() < capacity[2030].sum() < capacity[2040].sum()
+
+
 def test_890():
     """
     See https://github.com/PyPSA/PyPSA/issues/890.


### PR DESCRIPTION
Follow-up to #1044.

Closes #1144.

Iterative intersection in `filter_active_assets` only accounted for components already active in the first time period.

Refer also to comment in PR: https://github.com/PyPSA/PyPSA/pull/1044#discussion_r1990020769

# Regression

The regression was introduced in [0.32.0](https://github.com/PyPSA/PyPSA/releases/tag/v0.32.0), released in Dec. I fear we need to warn users about it.

All multiperiod statistics were only based on components with a `built_year` before the first investment period.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
