### PR TITLE
Add an extra pandas.sort_values() to get an deterministic result of ordered strongly meshed buses.

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -29,6 +29,10 @@ Features
   expression (regex), enabling more flexible filtering options. 
   (https://github.com/PyPSA/PyPSA/pull/1155)
 
+Minor improvements
+------------------
+
+* Ensuring that the created lp/mps file is deterministic by sorting the strongly meshed buses.
 
 `v0.33.2 <https://github.com/PyPSA/PyPSA/releases/tag/v0.33.2>`__ (12th March 2025)
 =======================================================================================

--- a/pypsa/optimization/common.py
+++ b/pypsa/optimization/common.py
@@ -66,4 +66,6 @@ def get_strongly_meshed_buses(n: Network, threshold: int = 45) -> pd.Series:
     )
     all_buses = all_buses[all_buses != ""]
     counts = all_buses.value_counts()
-    return counts.index[counts > threshold].rename("Bus-meshed")
+    results = counts.index[counts > threshold].rename("Bus-meshed")
+    results = results.sort_values()
+    return results


### PR DESCRIPTION
Add an extra pandas.sort_values() to get an deterministic result of ordered strongly meshed buses.
This ensures that the created .lp/.mps file is deterministic and can be used for testing.

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
