### PR TITLE
feat: use statistics handler as drop in method replacement

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -29,6 +29,8 @@ Features
   expression (regex), enabling more flexible filtering options. 
   (https://github.com/PyPSA/PyPSA/pull/1155)
 
+* All statistics function have a new argument ``carrier`` to filter by carriers.
+
 Minor improvements
 ------------------
 

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -24,12 +24,23 @@ Features
     different engines can be passed. By default they are not installed, but can be
     installed via ``pip install pypsa[excel]``.
 
+* Statistics module
 
-* All statistics functions now interpret the bus_carrier argument as a regular 
-  expression (regex), enabling more flexible filtering options. 
-  (https://github.com/PyPSA/PyPSA/pull/1155)
+  * All statistics functions now interpret the bus_carrier argument as a regular 
+    expression (regex), enabling more flexible filtering options. 
+    (https://github.com/PyPSA/PyPSA/pull/1155)
 
-* All statistics function have a new argument ``carrier`` to filter by carriers.
+  * All statistics functions have a new argument ``carrier`` to filter by carriers.
+    (https://github.com/PyPSA/PyPSA/pull/1176)
+
+  * All statistics functions have two new arguments ``drop_zero`` and ``round`` to
+    control the output. ``drop_zero`` drops all rows with zero values and ``round``
+    rounds the output to the specified number of decimal places. Those settings have been
+    used before already via the statistics parameters, but are deprecated now. Use the
+    new arguments or the module level settings instead (to set them globally). E.g. 
+    ``pypsa.options.params.statistics.nice_names = False``. List all available parameter 
+    settings via ``pypsa.options.params.describe()``. 
+    (https://github.com/PyPSA/PyPSA/pull/1173)
 
 Minor improvements
 ------------------

--- a/pypsa/common.py
+++ b/pypsa/common.py
@@ -74,6 +74,9 @@ class MethodHandlerWrapper:
         if obj is None:
             return self
 
+        if self.func is None:
+            raise TypeError("Method has not been set correctly in MethodHandlerWrapper")
+
         # Create a bound method wrapper
         bound_method = self.func.__get__(obj, objtype)
 

--- a/pypsa/common.py
+++ b/pypsa/common.py
@@ -34,10 +34,25 @@ class MethodHandlerWrapper:
     and not changed. The handler class can be used as a drop-in replacement for the
     method.
 
+    Needs to be used as a callable decorator, i.e. with parentheses:
+    >>> class MyHandlerClass:
+    ...     def __init__(self, bound_method: Callable) -> None:
+    ...         self.bound_method = bound_method
+    ...     def __call__(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
+    ...         return self.bound_method(*args, **kwargs)
+
+    >>> @MethodHandlerWrapper(handler_class=MyHandlerClass)
+    ... def my_method(self, *args, **kwargs):
+    ...     pass
+
     """
 
     def __init__(
-        self, func: Callable | None = None, *, handler_class: Any = None
+        self,
+        func: Callable | None = None,
+        *,
+        handler_class: Any = None,
+        inject_attrs: dict[str, str] | None = None,
     ) -> None:
         """
         Initialize the decorator.
@@ -49,24 +64,22 @@ class MethodHandlerWrapper:
         handler_class : Type, optional
             The handler class to use for wrapping the method. It should be callable
             with same signature as the method to guarantee compatibility.
+        inject_attrs : dict[str, str], optional
+            A mapping of instance attributes to be passed to the handler class
+            as keyword arguments. The keys are the names of the attributes to be
+            passed, and the values are the names of the attributes in the handler
+            class. If None, no attributes are passed. Pass only strings, not
+            attributes of the instance.
         """
         self.func = func
         self.handler_class = handler_class
-
-        # Allow for both decorator styles: @wrapper or @wrapper(handler_class=...)
-        if func is not None:
-            self.__name__ = func.__name__
-            self.__doc__ = func.__doc__
+        self.inject_attrs = inject_attrs or {}
 
     def __call__(self, func: Callable | None = None) -> MethodHandlerWrapper:
-        """Support using the decorator with or without arguments."""
+        """Call the decorator with the function to wrap."""
         if func is not None:
-            # Called as @MethodHandlerWrapper
             self.func = func
-            self.__name__ = func.__name__
-            self.__doc__ = func.__doc__
             return self
-        # Called with arguments: @MethodHandlerWrapper(handler_class=...)
         return self
 
     def __get__(self, obj: Any, objtype: Any = None) -> Any:
@@ -80,8 +93,20 @@ class MethodHandlerWrapper:
         # Create a bound method wrapper
         bound_method = self.func.__get__(obj, objtype)
 
-        # Create a callable instance with the bound method
-        wrapper = self.handler_class(bound_method)
+        # Prepare additional arguments from instance attributes, if any
+        handler_kwargs = {}
+        for key, value in self.inject_attrs.items():
+            if hasattr(obj, value):
+                handler_kwargs[key] = getattr(obj, value)
+            else:
+                msg = (
+                    f"Attribute '{key}' not found in the object instance. "
+                    f"Please ensure it is set before using the decorator."
+                )
+                raise AttributeError(msg)
+
+        # Create a callable instance with the bound method and optional attributes
+        wrapper = self.handler_class(bound_method, **handler_kwargs)
         return wrapper
 
 
@@ -294,6 +319,20 @@ def future_deprecation(*args: Any, activate: bool = False, **kwargs: Any) -> Cal
     return custom_decorator
 
 
+def deprecated_namespace(func: Callable, previous_module: str) -> Callable:
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        warnings.warn(
+            f"The namespace `{previous_module}.{func.__name__}` is deprecated and will be removed in a future version. "
+            f"Please use the new namespace `{func.__module__}.{func.__name__}` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 def list_as_string(
     list_: Sequence | dict, prefix: str = "", style: str = "comma-seperated"
 ) -> str:
@@ -371,6 +410,57 @@ def check_optional_dependency(module_name: str, install_message: str) -> None:
         __import__(module_name)
     except ImportError:
         raise ImportError(install_message)
+
+
+def _convert_to_series(
+    variable: dict | Sequence | float | int, index: pd.Index
+) -> pd.Series:
+    if isinstance(variable, dict):
+        return pd.Series(variable)
+    elif not isinstance(variable, pd.Series):
+        return pd.Series(variable, index=index)
+    return variable
+
+
+def resample_timeseries(
+    df: pd.DataFrame, freq: str, numeric_columns: list[str] | None = None
+) -> pd.DataFrame:
+    """
+    Resample a DataFrame with proper handling of numeric and non-numeric columns.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to resample, must have a datetime index
+    freq : str
+        Frequency string for resampling (e.g. 'H' for hourly)
+    numeric_columns : list[str] | None
+        List of numeric column names to resample. If None, auto-detected.
+
+    Returns
+    -------
+    pd.DataFrame
+        Resampled DataFrame with numeric columns aggregated by mean
+        and non-numeric columns forward-filled
+    """
+    if not isinstance(df.index, pd.DatetimeIndex):
+        df = df.set_index(pd.to_datetime(df.index))
+
+    if numeric_columns is None:
+        numeric_columns = df.select_dtypes(include=["int64", "float64"]).columns
+
+    # Handle duplicate indices by aggregating first
+    if not df.index.is_unique:
+        numeric_df = df[numeric_columns].groupby(level=0).mean()
+        non_numeric_df = df.drop(columns=numeric_columns).groupby(level=0).first()
+        df = pd.concat([numeric_df, non_numeric_df], axis=1)[df.columns]
+
+    # Split into numeric and non-numeric columns
+    numeric_df = df[numeric_columns].resample(freq).mean()
+    non_numeric_df = df.drop(columns=numeric_columns).resample(freq).ffill()
+
+    # Combine the results
+    return pd.concat([numeric_df, non_numeric_df], axis=1)[df.columns]
 
 
 def check_pypsa_version(version_string: str) -> None:

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -316,7 +316,6 @@ def get_activity_mask(
     index : pd.Index, default None
         Subset of the component elements. If None (default) all components are returned.
     """
-
     sns_ = as_index(n, sns, "snapshots")
 
     if getattr(n, "_multi_invest", False):
@@ -413,7 +412,6 @@ def update_linkports_doc_changes(s: Any, i: int, j: str) -> Any:
     Any : Updated string or original value if not a string.
 
     """
-
     if not isinstance(s, str) or len(s) == 1:
         return s
     return s.replace(j, str(i)).replace("required", "optional")
@@ -436,7 +434,6 @@ def update_linkports_component_attrs(
         or identifiers. If None, no filtering is applied and additional link
         ports are considered for all connectors.
     """
-
     ports = additional_linkports(n, where)
     ports.sort(reverse=True)
     c = "Link"
@@ -481,3 +478,38 @@ def additional_linkports(n: Network, where: Iterable[str] | None = None) -> list
     if where is None:
         where = n.links.columns
     return [i[3:] for i in where if i.startswith("bus") and i not in ["bus0", "bus1"]]
+
+
+def bus_carrier_unit(n: Network, bus_carrier: str | Sequence[str] | None) -> str:
+    """
+    Determine the unit associated with a specific bus carrier in the network.
+
+    Parameters
+    ----------
+    n (Network): The network object containing buses and their attributes.
+    bus_carrier (str): The carrier type of the bus to query.
+
+    Returns
+    -------
+    str: The unit associated with the specified bus carrier. If no bus carrier is provided,
+         returns "carrier dependent".
+
+    Raises
+    ------
+    ValueError: If the specified bus carrier is not found in the network or if multiple units
+                are found for the specified bus carrier.
+    """
+    if bus_carrier is None:
+        return "carrier dependent"
+
+    if isinstance(bus_carrier, str):
+        bus_carrier = [bus_carrier]
+
+    not_included = set(bus_carrier) - set(n.buses.carrier.unique())
+    if not_included:
+        raise ValueError(f"Bus carriers {not_included} not in network")
+    unit = n.buses[n.buses.carrier.isin(bus_carrier)].unit.unique()
+    if len(unit) > 1:
+        logger.warning(f"Multiple units found for carrier {bus_carrier}: {unit}")
+        return "carrier dependent"
+    return unit.item()

--- a/pypsa/statistics/__init__.py
+++ b/pypsa/statistics/__init__.py
@@ -1,4 +1,4 @@
-"""Statistics Accessor."""
+"""Statistics package for PyPSA networks."""
 
 from pypsa.common import pass_empty_series_if_keyerror
 from pypsa.statistics.deprecated import (

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -528,8 +528,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
-
         >>> n.statistics.installed_capex().sort_index()
         component  carrier
         Generator  gas        2.120994e+07
@@ -749,7 +747,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.optimal_capacity()
         Series([], dtype: float64)
 
@@ -861,7 +858,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.installed_capacity().sort_index()
         component  carrier
         Generator  gas        150000.0
@@ -971,7 +967,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.expanded_capacity()
         Series([], dtype: float64)
 
@@ -1084,7 +1079,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.opex()
         Series([], dtype: float64)
 
@@ -1296,7 +1290,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.withdrawal()
         Series([], dtype: float64)
 
@@ -1396,7 +1389,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.transmission()
         Series([], dtype: float64)
 
@@ -1516,7 +1508,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.energy_balance()
         Series([], dtype: float64)
 
@@ -1644,7 +1635,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.curtailment()
         Series([], dtype: float64)
 
@@ -1751,7 +1741,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.capacity_factor()
         Series([], dtype: float64)
 
@@ -1864,7 +1853,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.revenue()
         Series([], dtype: float64)
 
@@ -1986,7 +1974,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Example
         -------
-
         >>> n.statistics.market_value()
         Series([], dtype: float64)
 

--- a/pypsa/statistics/grouping.py
+++ b/pypsa/statistics/grouping.py
@@ -364,7 +364,7 @@ new_grouper_access = {
 
 def deprecated_grouper(func: Callable) -> Callable:
     """
-    Decorator to deprecate old grouper methods with custom deprecation warning.
+    Deprecate old grouper methods with custom deprecation warning.
 
     Parameters
     ----------

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from pypsa.common import (
+    MethodHandlerWrapper,
     as_index,
     check_pypsa_version,
     deprecated_common_kwargs,
@@ -14,6 +15,118 @@ from pypsa.common import (
     list_as_string,
     rename_kwargs,
 )
+
+
+def test_decorator_with_arguments():
+    """Test the decorator when used with arguments: @MethodHandlerWrapper(handler_class=...)"""
+
+    class ResultHandler:
+        def __init__(self, method):
+            self.method = method
+
+        def __call__(self, *args, **kwargs):
+            result = self.method(*args, **kwargs)
+            return f"Processed: {result}"
+
+    class TestClass:
+        def __init__(self, value=10):
+            self.value = value
+
+        @MethodHandlerWrapper(handler_class=ResultHandler)
+        def method_with_decorator_args(self, x):
+            """Test method with decorator args"""
+            return self.value + x
+
+    test_instance = TestClass()
+    result = test_instance.method_with_decorator_args(5)
+    assert result == "Processed: 15"
+
+
+def test_decorator_without_arguments():
+    """Test the decorator when used without arguments: @MethodHandlerWrapper"""
+
+    class ResultHandler:
+        def __init__(self, method):
+            self.method = method
+
+        def __call__(self, *args, **kwargs):
+            result = self.method(*args, **kwargs)
+            return f"Processed: {result}"
+
+    wrapper = MethodHandlerWrapper(handler_class=ResultHandler)
+
+    class TestClass:
+        def __init__(self, value=10):
+            self.value = value
+
+        @wrapper
+        def method_with_simple_decorator(self, x):
+            """Test method with simple decorator"""
+            return self.value + x
+
+    test_instance = TestClass()
+    result = test_instance.method_with_simple_decorator(5)
+    assert result == "Processed: 15"
+
+
+def test_class_method_access():
+    """Test accessing the decorated method at the class level"""
+
+    class ResultHandler:
+        def __init__(self, method):
+            self.method = method
+
+        def __call__(self, *args, **kwargs):
+            result = self.method(*args, **kwargs)
+            return f"Processed: {result}"
+
+    class TestClass:
+        def __init__(self, value=10):
+            self.value = value
+
+        @MethodHandlerWrapper(handler_class=ResultHandler)
+        def method(self, x):
+            return self.value + x
+
+    # Should return the wrapper itself, not the handler instance
+    assert isinstance(TestClass.method, MethodHandlerWrapper)
+
+
+def test_docstring_preservation():
+    """Test that the decorator preserves the original method's docstring"""
+
+    class ResultHandler:
+        def __init__(self, method):
+            self.method = method
+
+        def __call__(self, *args, **kwargs):
+            return self.method(*args, **kwargs)
+
+    class TestClass:
+        @MethodHandlerWrapper(handler_class=ResultHandler)
+        def method_with_doc(self, x):
+            """This is a test docstring"""
+            return x
+
+    assert TestClass.method_with_doc.__doc__ == "This is a test docstring"
+
+
+def test_name_preservation():
+    """Test that the decorator preserves the original method's name"""
+
+    class ResultHandler:
+        def __init__(self, method):
+            self.method = method
+
+        def __call__(self, *args, **kwargs):
+            return self.method(*args, **kwargs)
+
+    class TestClass:
+        @MethodHandlerWrapper(handler_class=ResultHandler)
+        def test_method_name(self, x):
+            return x
+
+    assert TestClass.test_method_name.__name__ == "test_method_name"
 
 
 @pytest.mark.parametrize(

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -92,43 +92,6 @@ def test_class_method_access():
     assert isinstance(TestClass.method, MethodHandlerWrapper)
 
 
-def test_docstring_preservation():
-    """Test that the decorator preserves the original method's docstring"""
-
-    class ResultHandler:
-        def __init__(self, method):
-            self.method = method
-
-        def __call__(self, *args, **kwargs):
-            return self.method(*args, **kwargs)
-
-    class TestClass:
-        @MethodHandlerWrapper(handler_class=ResultHandler)
-        def method_with_doc(self, x):
-            """This is a test docstring"""
-            return x
-
-    assert TestClass.method_with_doc.__doc__ == "This is a test docstring"
-
-
-def test_name_preservation():
-    """Test that the decorator preserves the original method's name"""
-
-    class ResultHandler:
-        def __init__(self, method):
-            self.method = method
-
-        def __call__(self, *args, **kwargs):
-            return self.method(*args, **kwargs)
-
-    class TestClass:
-        @MethodHandlerWrapper(handler_class=ResultHandler)
-        def test_method_name(self, x):
-            return x
-
-    assert TestClass.test_method_name.__name__ == "test_method_name"
-
-
 @pytest.mark.parametrize(
     "attr, expected_name",
     [

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -121,6 +121,14 @@ def test_no_time_aggregation(ac_dc_network_r):
     assert isinstance(df, pd.DataFrame)
 
 
+def test_carrier_selection(ac_dc_network_r):
+    df = ac_dc_network_r.statistics(groupby=False, carrier="gas")
+    assert not df.empty
+
+    df = ac_dc_network_r.statistics(groupby=False, carrier=["gas", "wind"])
+    assert not df.empty
+
+
 def test_bus_carrier_selection(ac_dc_network_r):
     df = ac_dc_network_r.statistics(groupby=False, bus_carrier="AC")
     assert not df.empty


### PR DESCRIPTION
## Changes proposed in this Pull Request

To reduce the diff of #1156 and for easier review, as this interferes with the existing API:
- Wraps each statistic method with a handler to allow the suggested plotting syntax (`n.statistics.energy_balance.plot()`), while only extending the API and not changing it.
- Adds `carrier` argument to statistics functions

I would also like to refactor our entire accessor design. This is very different from module to module, and our `StatisticsAccessor' is not really just an accessor. But I think it's best to move this after the plotting library is merged.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
