### PR TITLE
add warnings for consistent legend sizes in combined geographical plots

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -47,6 +47,8 @@ Minor improvements
 
 * Ensuring that the created lp/mps file is deterministic by sorting the strongly meshed buses. (https://github.com/PyPSA/PyPSA/pull/1174)
 
+* Added warning for consistent legend circle and semicirle sizes when combining plots on a geographical axis.
+
 `v0.33.2 <https://github.com/PyPSA/PyPSA/releases/tag/v0.33.2>`__ (12th March 2025)
 =======================================================================================
 

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -10,6 +10,7 @@ Functions for plotting networks.
 from __future__ import annotations
 
 import logging
+import warnings
 
 import geopandas as gpd
 import matplotlib.colors as mcolors
@@ -717,6 +718,11 @@ def add_legend_circles(
     """
     Add a legend for reference circles.
 
+    .. warning::
+        When combining ``n.plot()`` with other plots on a geographical axis,
+        ensure ``n.plot()`` is called first or the final axis extent is set initially
+        (``ax.set_extent(boundaries, crs=crs)``) for consistent legend circle sizes.
+
     Parameters
     ----------
     ax : matplotlib ax
@@ -741,6 +747,12 @@ def add_legend_circles(
         raise ValueError(msg)
 
     if hasattr(ax, "projection"):
+        warnings.warn(
+            "When combining n.plot() with other plots on a geographical axis, "
+            "ensure n.plot() is called first or the final axis extent is set initially "
+            "(ax.set_extent(boundaries, crs=crs)) for consistent legend circle sizes.",
+            UserWarning,
+        )
         area_correction = projected_area_factor(ax, srid) ** 2
         sizes = [s * area_correction for s in sizes]
 
@@ -758,6 +770,11 @@ def add_legend_semicircles(
 ):
     """
     Add a legend for reference semi-circles.
+
+    .. warning::
+        When combining ``n.plot()`` with other plots on a geographical axis,
+        ensure ``n.plot()`` is called first or the final axis extent is set initially
+        (``ax.set_extent(boundaries, crs=crs)``) for consistent legend semicircle sizes.
 
     Parameters
     ----------
@@ -777,6 +794,12 @@ def add_legend_semicircles(
     assert len(sizes) == len(labels), "Sizes and labels must have the same length."
 
     if hasattr(ax, "projection"):
+        warnings.warn(
+            "When combining n.plot() with other plots on a geographical axis, "
+            "ensure n.plot() is called first or the final axis extent is set initially "
+            "(ax.set_extent(boundaries, crs=crs)) for consistent legend semicircle sizes.",
+            UserWarning,
+        )
         area_correction = projected_area_factor(ax, srid) ** 2
         sizes = [s * area_correction for s in sizes]
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

There are some interactions with combined PyPSA and Geopandas plots on a single geographical axis. Depending on the order of execution, the legend circle sizes are correct or incorrext (`add_legend_circles()` and `add_legend_semicircles()`).

The problem is the changing extent of the plot, which is changed here:

https://github.com/PyPSA/pypsa/blob/fneum/legend-circle-sizes/pypsa/plot.py#L242-L243

and accessed here to calculate in `projected_area_factor()`.

https://github.com/PyPSA/pypsa/blob/df3beba8b8aec071fcbe61800d6358552d76eba6/pypsa/plot.py#L534

I have no idea how to properly it (apart from running `n.plot()` first), but a first measure would be to warn about what the right order of execution would be.

**MWE**

```py
import pypsa
import matplotlib.pyplot as plt
from pypsa.plot import add_legend_circles, add_legend_semicircles
import cartopy.crs as ccrs
import geopandas as gpd

n = pypsa.examples.ac_dc_meshed()
gdf = gpd.read_file(fn)

# a) works as intended

crs = ccrs.PlateCarree()
fig, ax = plt.subplots(figsize=(8, 8), subplot_kw={"projection": crs})
n.plot(ax=ax, bus_sizes=2, margin=0.8)
add_legend_circles(ax, 2, "", legend_kw=dict(frameon=False, loc="center"))
add_legend_semicircles(ax, 2, "", legend_kw=dict(frameon=False, loc="lower center"))
gdf.to_crs(crs.proj4_init).plot(ax=ax, color="none")

# b) wrong marker size

crs = ccrs.PlateCarree()
fig, ax = plt.subplots(figsize=(8, 8), subplot_kw={"projection": crs})
gdf.to_crs(crs.proj4_init).plot(ax=ax, color="none")
n.plot(ax=ax, bus_sizes=2, margin=0.8)
add_legend_circles(ax, 2, "", legend_kw=dict(frameon=False, loc="center"))
add_legend_semicircles(ax, 2, "", legend_kw=dict(frameon=False, loc="lower center"))
```

**Output of a)**

![image](https://github.com/user-attachments/assets/511c6e80-9085-43eb-9906-c92aac729f38)

**Output of b)**

![image](https://github.com/user-attachments/assets/92163815-4960-4996-a5f9-5b0ea5584140)


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
