### PR TITLE
fix: ensure consistent circle sizing in add_legend_semicircles() method

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -47,6 +47,11 @@ Minor improvements
 
 * Ensuring that the created lp/mps file is deterministic by sorting the strongly meshed buses. (https://github.com/PyPSA/PyPSA/pull/1174)
 
+Bug fixes
+---------
+
+* Fixed ``pypsa.plot.add_legend_semicircles()`` circle sizing to be consistent with ``n.plot(bus_sizes=..., bus_split_circles=True)`` argument.
+
 `v0.33.2 <https://github.com/PyPSA/PyPSA/releases/tag/v0.33.2>`__ (12th March 2025)
 =======================================================================================
 

--- a/pypsa/plot.py
+++ b/pypsa/plot.py
@@ -780,7 +780,7 @@ def add_legend_semicircles(
         area_correction = projected_area_factor(ax, srid) ** 2
         sizes = [s * area_correction for s in sizes]
 
-    radius = [np.sign(s) * np.abs(s) ** 0.5 for s in sizes]
+    radius = [np.sign(s) * np.abs(s * 2) ** 0.5 for s in sizes]
     handles = [
         Wedge((0, -r / 2), r=r, theta1=0, theta2=180, **patch_kw) for r in radius
     ]


### PR DESCRIPTION
Closes #1031.

## Changes proposed in this Pull Request

**MWE**

Example is set up so that blue and orange semi-circles should have the same size.

```py
import pypsa
import matplotlib.pyplot as plt
from pypsa.plot import add_legend_semicircles
import cartopy.crs as ccrs

n = pypsa.examples.ac_dc_meshed()
n.loads["carrier"] = "electricity"
n.add("Carrier", "electricity", color='orange')

bus_sizes = n.loads_t.p_set.sum().T.groupby([n.loads.bus, n.loads.carrier]).count() * 2
crs = ccrs.PlateCarree()
fig, ax = plt.subplots(figsize=(8, 8), subplot_kw={"projection": crs})
n.plot(ax=ax, bus_sizes=bus_sizes, bus_split_circles=True, margin=0.25)
add_legend_semicircles(ax, 2, "", legend_kw=dict(frameon=False, loc="center"))
```

**Before**

![image](https://github.com/user-attachments/assets/6b8cf85f-6091-46b2-b316-cf1c60315204)

**After**

![image](https://github.com/user-attachments/assets/6c35fefe-9073-4667-bc37-acb0bca0e75f)


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
