### PR TITLE
Patch for committable error in multi-investment

### DIFF
--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -226,7 +226,11 @@ def define_operational_constraints_for_committables(
         lhs = -status.loc[:, min_up_time_i] + merge(expr, dim=com_i.name)
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-up-time", mask=DataArray(active[min_up_time_i]).sel(snapshot=sns[1:]),
+            lhs,
+            "<=",
+            0,
+            name=f"{c}-com-up-time",
+            mask=DataArray(active[min_up_time_i]).sel(snapshot=sns[1:]),
         )
 
     # min down time
@@ -299,7 +303,11 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-p-before", mask=active_ce,
+            lhs,
+            "<=",
+            0,
+            name=f"{c}-com-p-before",
+            mask=active_ce,
         )
 
         # dispatch limit for partly start up/shut down for t
@@ -310,7 +318,11 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-p-current", mask=active_ce,
+            lhs,
+            "<=",
+            0,
+            name=f"{c}-com-p-current",
+            mask=active_ce,
         )
 
         # ramp up if committable is only partly active and some capacity is starting up
@@ -323,7 +335,11 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-start-up", mask=active_ce,
+            lhs,
+            "<=",
+            0,
+            name=f"{c}-com-partly-start-up",
+            mask=active_ce,
         )
 
         # ramp down if committable is only partly active and some capacity is shutting up
@@ -336,7 +352,11 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-shut-down", mask=active_ce,
+            lhs,
+            "<=",
+            0,
+            name=f"{c}-com-partly-shut-down",
+            mask=active_ce,
         )
 
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -226,7 +226,7 @@ def define_operational_constraints_for_committables(
         lhs = -status.loc[:, min_up_time_i] + merge(expr, dim=com_i.name)
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-up-time", mask=active[min_up_time_i].iloc[1:]
+            lhs, "<=", 0, name=f"{c}-com-up-time", mask=DataArray(active[min_up_time_i]).isel(snapshot=slice(1, None)),
         )
 
     # min down time
@@ -243,7 +243,7 @@ def define_operational_constraints_for_committables(
             "<=",
             1,
             name=f"{c}-com-down-time",
-            mask=active[min_down_time_i].iloc[1:],
+            mask=DataArray(active[min_down_time_i]).isel(snapshot=slice(1, None)),
         )
     # up time before
     timesteps = pd.DataFrame([range(1, len(sns) + 1)] * len(com_i), com_i, sns).T
@@ -299,7 +299,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-p-before", mask=active_ce.iloc[1:]
+            lhs, "<=", 0, name=f"{c}-com-p-before", mask= DataArray(active_ce).isel(snapshot=slice(1, None)),
         )
 
         # dispatch limit for partly start up/shut down for t
@@ -310,7 +310,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-p-current", mask=active_ce.iloc[1:]
+            lhs, "<=", 0, name=f"{c}-com-p-current", mask=DataArray(active_ce).isel(snapshot=slice(1, None)),
         )
 
         # ramp up if committable is only partly active and some capacity is starting up
@@ -323,7 +323,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-start-up", mask=active_ce.iloc[1:]
+            lhs, "<=", 0, name=f"{c}-com-partly-start-up", mask=DataArray(active_ce).isel(snapshot=slice(1, None)),
         )
 
         # ramp down if committable is only partly active and some capacity is shutting up
@@ -336,7 +336,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-shut-down", mask=active_ce.iloc[1:]
+            lhs, "<=", 0, name=f"{c}-com-partly-shut-down", mask=DataArray(active_ce).isel(snapshot=slice(1, None)),
         )
 
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -226,7 +226,7 @@ def define_operational_constraints_for_committables(
         lhs = -status.loc[:, min_up_time_i] + merge(expr, dim=com_i.name)
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-up-time", mask=DataArray(active[min_up_time_i]).isel(snapshot=slice(1, None)),
+            lhs, "<=", 0, name=f"{c}-com-up-time", mask=DataArray(active[min_up_time_i]).sel(snapshot=sns[1:]),
         )
 
     # min down time
@@ -243,7 +243,7 @@ def define_operational_constraints_for_committables(
             "<=",
             1,
             name=f"{c}-com-down-time",
-            mask=DataArray(active[min_down_time_i]).isel(snapshot=slice(1, None)),
+            mask=DataArray(active[min_down_time_i]).sel(snapshot=sns[1:]),
         )
     # up time before
     timesteps = pd.DataFrame([range(1, len(sns) + 1)] * len(com_i), com_i, sns).T
@@ -282,7 +282,7 @@ def define_operational_constraints_for_committables(
         p_ce = p.loc[:, cost_equal]
         start_up_ce = start_up.loc[:, cost_equal]
         status_ce = status.loc[:, cost_equal]
-        active_ce = active.loc[:, cost_equal]
+        active_ce = DataArray(active.loc[:, cost_equal]).sel(snapshot=sns[1:])
 
         # parameters
         upper_p_ce = upper_p.loc[:, cost_equal]
@@ -299,7 +299,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-p-before", mask= DataArray(active_ce).isel(snapshot=slice(1, None)),
+            lhs, "<=", 0, name=f"{c}-com-p-before", mask=active_ce,
         )
 
         # dispatch limit for partly start up/shut down for t
@@ -310,7 +310,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-p-current", mask=DataArray(active_ce).isel(snapshot=slice(1, None)),
+            lhs, "<=", 0, name=f"{c}-com-p-current", mask=active_ce,
         )
 
         # ramp up if committable is only partly active and some capacity is starting up
@@ -323,7 +323,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-start-up", mask=DataArray(active_ce).isel(snapshot=slice(1, None)),
+            lhs, "<=", 0, name=f"{c}-com-partly-start-up", mask=active_ce,
         )
 
         # ramp down if committable is only partly active and some capacity is shutting up
@@ -336,7 +336,7 @@ def define_operational_constraints_for_committables(
         )
         lhs = lhs.sel(snapshot=sns[1:])
         n.model.add_constraints(
-            lhs, "<=", 0, name=f"{c}-com-partly-shut-down", mask=DataArray(active_ce).isel(snapshot=slice(1, None)),
+            lhs, "<=", 0, name=f"{c}-com-partly-shut-down", mask=active_ce,
         )
 
 


### PR DESCRIPTION
Closes # 1180.

## Changes proposed in this Pull Request
When the active mask is a multi-index, calling active.iloc[1:] results in the index name "snapshot" being dropped. This PR first converts the mask to a DataArray and then selects the relevant snapshots for committable generators.


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
