### PR TITLE
Add filter function for buses

### DIFF
--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -50,8 +50,11 @@ def get_weightings(n: Network, c: str) -> pd.Series:
         return n.snapshot_weightings["objective"]
 
 
-def filter_carriers(n: pypsa.Network, bus_carrier="AC", comps=["Generator", "Link"])->list:
-    """filter carriers for links that attach to a bus of the target carrier
+def filter_carriers(
+    n: pypsa.Network, bus_carrier="AC", comps=["Generator", "Link"]
+) -> list:
+    """
+    Filter carriers for links that attach to a bus of the target carrier
 
     Args:
         n (pypsa.Network): the pypsa network object
@@ -62,19 +65,24 @@ def filter_carriers(n: pypsa.Network, bus_carrier="AC", comps=["Generator", "Lin
         attached_carriers = filter_carriers(n, "AC")
         ds = n.statistics.capacity_factor(groupby=["carrier"]).dropna()
         ds.loc[ds.index.get_level_values(1).isin(attached_carriers)]
-        
+
     Returns:
         list: list of carriers that are attached to the bus carrier
+
     """
     carriers = []
     for c in comps:
         comp = n.static(c)
         ports = [c for c in comp.columns if c.startswith("bus")]
-        comp_df = comp[ports+["carrier"]]
-        is_attached = comp_df[ports].apply(lambda x: x.map(n.buses.carrier)==bus_carrier).T.any()
+        comp_df = comp[ports + ["carrier"]]
+        is_attached = (
+            comp_df[ports]
+            .apply(lambda x: x.map(n.buses.carrier) == bus_carrier)
+            .T.any()
+        )
         carriers += comp_df.loc[is_attached].carrier.unique().tolist()
 
-    if not bus_carrier in carriers:
+    if bus_carrier not in carriers:
         carriers += [bus_carrier]
     return carriers
 


### PR DESCRIPTION
Problem statement:
- hard to get links attached to a bus carrier (may be less true for latest pypsa version)
- `n.statistics.some_op(bus_carrier="AC")` often fails. If `at_port=False` then the `bus1` will not be checked. If at True then results will not be correct.

Closes # (if applicable).

## Changes proposed in this Pull Request
Add a convenience function for filtering carriers attached to buses. Useful for links and statistics -> bus_carrier in  often fails if at_port is false but gives weird results if at_port is True

Happy to make efforts to integrate better (release_notes, unit_tests) if the idea is deemed worth it.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).: NA feature is not integrated in main
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
