### PR TITLE
feat: add `n.equals`

### DIFF
--- a/doc/api/networks.rst
+++ b/doc/api/networks.rst
@@ -29,6 +29,7 @@ General methods
     ~pypsa.Network.remove
     ~pypsa.Network.mremove
     ~pypsa.Network.copy
+    ~pypsa.Network.equals
     ~pypsa.Network.branches
     ~pypsa.Network.passive_branches
     ~pypsa.Network.controllable_branches

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -23,6 +23,10 @@ Upcoming Release
   The new modularized maps module allows for more flexibility and easier
   maintenance. 
 
+* New method `n.equals() <pypsa.Network.equals>` to compare two networks for equality. 
+  This is similar to the equality operator `==` but allows for more flexibility in the
+  comparison which is useful for testing and debugging.
+
 `v0.34.0 <https://github.com/PyPSA/PyPSA/releases/tag/v0.34.0>`__ (25th March 2025)
 =======================================================================================
 

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -26,6 +26,7 @@ Upcoming Release
 * New method `n.equals() <pypsa.Network.equals>` to compare two networks for equality. 
   This is similar to the equality operator `==` but allows for more flexibility in the
   comparison which is useful for testing and debugging.
+  (https://github.com/PyPSA/PyPSA/pull/1194)
 
 `v0.34.0 <https://github.com/PyPSA/PyPSA/releases/tag/v0.34.0>`__ (25th March 2025)
 =======================================================================================

--- a/pypsa/components/abstract.py
+++ b/pypsa/components/abstract.py
@@ -224,11 +224,50 @@ class Components(ComponentsData, ABC):
         bool
             True if components are equal, otherwise False.
 
+        See Also
+        --------
+        pypsa.components.abstract.Components.equals :
+            Check for equality of two networks.
+
+        """
+        return self.equals(other, log_difference=False)
+
+    def equals(self, other: Any, log_difference: bool = False) -> bool:
+        """
+        Check if two Components are equal.
+
+        Does not check the attached Network, but only component specific data. Therefore
+        two components can be equal even if they are attached to different networks.
+
+        Parameters
+        ----------
+        other : Any
+            The other network to compare with.
+        log_difference: bool, default=False
+            If True, logs the difference between two objects (logging level INFO). This
+            is useful for debugging purposes.
+
+        Returns
+        -------
+        bool
+            True if components are equal, otherwise False.
+
+        Examples
+        --------
+        >>> n1 = pypsa.Network()
+        >>> n2 = pypsa.Network()
+        >>> n1.add("Bus", "bus1")
+        Index(['bus1'], dtype='object')
+        >>> n2.add("Bus", "bus1")
+        Index(['bus1'], dtype='object')
+        >>> n1.buses.equals(n2.buses)
+        True
+
         """
         return (
-            equals(self.ctype, other.ctype)
-            and equals(self.static, other.static)
-            and equals(self.dynamic, other.dynamic)
+            equals(self.ctype, other.ctype, log_difference=log_difference)
+            and equals(self.static, other.static, log_difference=log_difference)
+            and equals(self.dynamic, other.dynamic, log_difference=log_difference)
         )
 
     @staticmethod

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -368,19 +368,73 @@ class Network:
         self.merge(other)
 
     def __eq__(self, other: Any) -> bool:
-        """Check for equality of two networks."""
+        """
+        Check for equality of two networks.
+
+        Parameters
+        ----------
+        other : Any
+            The other network to compare with.
+
+        Returns
+        -------
+        bool
+            True if the networks are equal, False otherwise.
+
+        See Also
+        --------
+        pypsa.Network.equals : Check for equality of two networks.
+        """
+        return self.equals(other, log_difference=False)
+
+    def equals(self, other: Any, log_difference: bool = False) -> bool:
+        """
+        Check for equality of two networks.
+
+        Parameters
+        ----------
+        other : Any
+            The other network to compare with.
+        log_difference: bool, default=False
+            If True, logs the difference between two objects (logging level INFO). This
+            is useful for debugging purposes.
+
+        Returns
+        -------
+        bool
+            True if the networks are equal, False otherwise.
+
+        Examples
+        --------
+        >>> n1 = pypsa.Network()
+        >>> n2 = pypsa.Network()
+        >>> n1.add("Bus", "bus1")
+        Index(['bus1'], dtype='object')
+        >>> n2.add("Bus", "bus2")
+        Index(['bus2'], dtype='object')
+        >>> n1.equals(n2)
+        False
+
+        """
         ignore = [
             OptimizationAccessor,
             ClusteringAccessor,
             StatisticsAccessor,
             PlotAccessor,
         ]
-
+        not_equal = False
         if isinstance(other, self.__class__):
             for key, value in self.__dict__.items():
-                if not equals(value, other.__dict__[key], ignored_classes=ignore):
+                if not equals(
+                    value,
+                    other.__dict__[key],
+                    ignored_classes=ignore,
+                    log_difference=log_difference,
+                ):
                     logger.warning("Mismatch in attribute: %s", key)
-                    return False
+                    not_equal = True
+                    if not log_difference:
+                        break
         else:
             logger.warning(
                 "Can only compare two pypsa.Network objects with each other. Got %s.",
@@ -388,7 +442,8 @@ class Network:
             )
 
             return False
-        return True
+
+        return not not_equal
 
     # ----------------
     # Initialization

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -138,6 +138,7 @@ def test_as_index(ac_dc_network_mi, attr, expected_name):
         (np.array([1, 2, 3]), np.array([1, 2, 3]), True),
         (np.array([1, 2, 3]), np.array([1, 2, 4]), False),
         (pd.DataFrame({"A": [1, 2]}), pd.DataFrame({"A": [1, 2]}), True),
+        (pd.DataFrame({"A": [1, 2]}), pd.DataFrame({"A": [1, 4]}), False),
         ({"a": 1, "b": 2}, {"a": 1, "b": 3}, False),
         ([1, 2, 3], [1, 2, 3], True),
         (np.nan, np.nan, True),
@@ -147,11 +148,18 @@ def test_equals(a, b, expected):
     assert equals(a, b) == expected
 
 
-def test_equals_logs(caplog):
-    a = pd.DataFrame({"A": [1, 2]})
-    b = pd.DataFrame({"A": [1, 1]})
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        (1, 2),
+        ("a", "b"),
+        (np.array([1, 2, 3]), np.array([1, 2, 4])),
+        (pd.DataFrame({"A": [1, 3]}), pd.DataFrame({"A": [1, 2]})),
+    ],
+)
+def test_equals_logs(a, b, caplog):
     assert equals(a, b, log_difference=True) is False
-    assert "pandas objects diff" in caplog.text
+    assert caplog.text != ""
 
 
 def test_equals_ignored_classes():

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -147,6 +147,13 @@ def test_equals(a, b, expected):
     assert equals(a, b) == expected
 
 
+def test_equals_logs(caplog):
+    a = pd.DataFrame({"A": [1, 2]})
+    b = pd.DataFrame({"A": [1, 1]})
+    assert equals(a, b, log_difference=True) is False
+    assert "pandas objects diff" in caplog.text
+
+
 def test_equals_ignored_classes():
     class IgnoredClass:
         def __init__(self, value=1):

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -343,8 +343,10 @@ def test_equality_behavior(all_networks):
     """
     for n in all_networks:
         deep_copy = copy.deepcopy(n)
-        assert n == deep_copy
         assert n is not deep_copy
+        assert n.equals(deep_copy, log_difference=True)
+
+        assert n == deep_copy
 
         # TODO: Could add more property based tests here (hypothesis)
         deep_copy.name = "new_name"


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
New method `n.equals()` to compare two networks for equality. This is similar to the equality operator `==` but allows for more flexibility in the comparison which is useful for testing and debugging.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
