### PR TITLE
fix unaligned statistics index names and better `equals()`

### DIFF
--- a/pypsa/components/abstract.py
+++ b/pypsa/components/abstract.py
@@ -230,9 +230,9 @@ class Components(ComponentsData, ABC):
             Check for equality of two networks.
 
         """
-        return self.equals(other, log_difference=False)
+        return self.equals(other)
 
-    def equals(self, other: Any, log_difference: bool = False) -> bool:
+    def equals(self, other: Any, log_mode: str = "silent") -> bool:
         """
         Check if two Components are equal.
 
@@ -243,9 +243,16 @@ class Components(ComponentsData, ABC):
         ----------
         other : Any
             The other network to compare with.
-        log_difference: bool, default=False
-            If True, logs the difference between two objects (logging level INFO). This
-            is useful for debugging purposes.
+        log_mode: str, default="silent"
+            Controls how differences are reported:
+            - 'silent': No logging, just returns True/False
+            - 'verbose': Prints differences but doesn't raise errors
+            - 'strict': Raises ValueError on first difference
+
+        Raises
+        ------
+        ValueError
+            If log_mode is 'strict' and components are not equal.
 
         Returns
         -------
@@ -265,9 +272,9 @@ class Components(ComponentsData, ABC):
 
         """
         return (
-            equals(self.ctype, other.ctype, log_difference=log_difference)
-            and equals(self.static, other.static, log_difference=log_difference)
-            and equals(self.dynamic, other.dynamic, log_difference=log_difference)
+            equals(self.ctype, other.ctype, log_mode=log_mode, path="c.ctype")
+            and equals(self.static, other.static, log_mode=log_mode, path="c.static")
+            and equals(self.dynamic, other.dynamic, log_mode=log_mode, path="c.dynamic")
         )
 
     @staticmethod

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -385,9 +385,9 @@ class Network:
         --------
         pypsa.Network.equals : Check for equality of two networks.
         """
-        return self.equals(other, log_difference=False)
+        return self.equals(other)
 
-    def equals(self, other: Any, log_difference: bool = False) -> bool:
+    def equals(self, other: Any, log_mode: str = "silent") -> bool:
         """
         Check for equality of two networks.
 
@@ -395,9 +395,16 @@ class Network:
         ----------
         other : Any
             The other network to compare with.
-        log_difference: bool, default=False
-            If True, logs the difference between two objects (logging level INFO). This
-            is useful for debugging purposes.
+        log_mode: str, default="silent"
+            Controls how differences are reported:
+            - 'silent': No logging, just returns True/False
+            - 'verbose': Prints differences but doesn't raise errors
+            - 'strict': Raises ValueError on first difference
+
+        Raises
+        ------
+        ValueError
+            If log_mode is 'strict' and components are not equal.
 
         Returns
         -------
@@ -430,11 +437,12 @@ class Network:
                     value,
                     other.__dict__[key],
                     ignored_classes=ignore,
-                    log_difference=log_difference,
+                    log_mode=log_mode,
+                    path="n." + key,
                 ):
                     logger.warning("Mismatch in attribute: %s", key)
                     not_equal = True
-                    if not log_difference:
+                    if not log_mode:
                         break
         else:
             logger.warning(

--- a/pypsa/plot/maps/interactive.py
+++ b/pypsa/plot/maps/interactive.py
@@ -194,7 +194,7 @@ def iplot(
     # Plot branches:
     if isinstance(line_widths, pd.Series):
         if isinstance(line_widths.index, pd.MultiIndex):
-            raise TypeError(
+            raise DeprecationWarning(
                 "Index of argument 'line_widths' is a Multiindex, "
                 "this is not support since pypsa v0.17. "
                 "Set differing widths with arguments 'line_widths', "
@@ -202,7 +202,7 @@ def iplot(
             )
     if isinstance(line_colors, pd.Series):
         if isinstance(line_colors.index, pd.MultiIndex):
-            raise TypeError(
+            raise DeprecationWarning(
                 "Index of argument 'line_colors' is a Multiindex, "
                 "this is not support since pypsa v0.17. "
                 "Set differing colors with arguments 'line_colors', "

--- a/pypsa/plot/maps/static.py
+++ b/pypsa/plot/maps/static.py
@@ -1160,7 +1160,7 @@ class MapPlotter:
                 "Set differing widths with arguments 'line_widths', "
                 "'link_widths' and 'transformer_widths'."
             )
-            raise TypeError(msg)
+            raise DeprecationWarning(msg)
 
         if isinstance(line_colors, pd.Series) and isinstance(
             line_colors.index, pd.MultiIndex
@@ -1171,7 +1171,7 @@ class MapPlotter:
                 "Set differing colors with arguments 'line_colors', "
                 "'link_colors' and 'transformer_colors'."
             )
-            raise TypeError(msg)
+            raise DeprecationWarning(msg)
 
         # Check for ValueErrors
         if geomap:

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -225,8 +225,18 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         first_key = next(iter(d))
         if is_one_component:
             return d[first_key]
-        index_names = ["component"] + d[first_key].index.names
-        df = pd.concat(d, names=index_names)
+        index_names = [x.index.names for x in d.values()]
+        # If index names are the same, use them
+        if all(x == index_names[0] for x in index_names):
+            col_names = ["component"] + index_names[0]
+        # Otherwise, use default column names
+        elif all(len(x) == 1 for x in index_names):
+            col_names = ["component", "name"]
+        else:
+            msg = "Multi-indexed data must have the same index names."
+            raise AssertionError(msg)
+
+        df = pd.concat(d, names=col_names)
         return df
 
     def _apply_option_kwargs(

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -157,8 +157,17 @@ def test_equals(a, b, expected):
     ],
 )
 def test_equals_logs(a, b, caplog):
-    assert equals(a, b, log_difference=True) is False
+    assert equals(a, b, log_mode="silent") is False
+    assert caplog.text == ""
+
+    assert equals(a, b, log_mode="verbose") is False
     assert caplog.text != ""
+
+    with pytest.raises(ValueError):
+        equals(a, b, log_mode="strict")
+
+    with pytest.raises(ValueError):
+        equals(a, b, log_mode="invalid")
 
 
 def test_equals_ignored_classes():
@@ -172,8 +181,8 @@ def test_equals_ignored_classes():
 
 
 def test_equals_type_mismatch():
-    with pytest.raises(AssertionError):
-        equals(1, "1")
+    with pytest.raises(ValueError):
+        equals(1, "1", log_mode="strict")
 
 
 @pytest.fixture

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -366,21 +366,21 @@ def test_io_equality(ac_dc_network, tmp_path):
     n = ac_dc_network
     n.export_to_netcdf(tmp_path / "network.nc")
     n2 = pypsa.Network(tmp_path / "network.nc")
-    assert n.equals(n2, log_difference=True)
+    assert n.equals(n2, log_mode="strict")
 
     n.export_to_csv_folder(tmp_path / "network")
     n3 = pypsa.Network(tmp_path / "network")
-    assert n.equals(n3, log_difference=True)
+    assert n.equals(n3, log_mode="strict")
 
     if excel_installed:
         n.export_to_excel(tmp_path / "network.xlsx")
         n4 = pypsa.Network(tmp_path / "network.xlsx")
-        assert n.equals(n4, log_difference=True)
+        assert n.equals(n4, log_mode="strict")
 
     if tables_installed:
         n.export_to_hdf5(tmp_path / "network.h5")
         n5 = pypsa.Network(tmp_path / "network.h5")
-        assert n.equals(n5, log_difference=True)
+        assert n.equals(n5, log_mode="strict")
 
 
 @pytest.mark.parametrize("use_pandapower_index", [True, False])

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -344,7 +344,7 @@ def test_equality_behavior(all_networks):
     for n in all_networks:
         deep_copy = copy.deepcopy(n)
         assert n is not deep_copy
-        assert n.equals(deep_copy, log_difference=True)
+        assert n.equals(deep_copy, log_mode="strict")
 
         assert n == deep_copy
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
**Better `.equals()`**
log_mode (silent, verbose and strict) and more helpful logs

**Fix index issue in statistics**
When `groupby=False` the column names have not been aligned, which lead to issues in #1183

``` python
n = pypsa.examples.ac_dc_meshed()
n.optimize()
n.statistics.capex(groupby=False)
```
Previously:
``` bash
component  Link             
Line       0                    9.912913e+01
           1                    1.998738e+02
...
```
Now:
``` bash
component  name             
Line       0                    9.912913e+01
           1                    1.998738e+02
...
```

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
