### PR TITLE
fix: iplot area with facet_col/row

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -35,6 +35,8 @@ Bug Fixes
 * Fixed unaligned statistics index names when ``groupby=False``
   (https://github.com/PyPSA/PyPSA/pull/1205)
   
+* Fixed interactive area plots in stacked more with `facet_row` and `facet_col`. 
+
 
 `v0.34.1 <https://github.com/PyPSA/PyPSA/releases/tag/v0.34.1>`__ (7th April 2025)
 =======================================================================================

--- a/pypsa/plot/statistics/charts.py
+++ b/pypsa/plot/statistics/charts.py
@@ -450,7 +450,7 @@ class ChartGenerator(PlotsGenerator, ABC):
                 ldata[x], categories=ldata[x].unique(), ordered=True
             )
         if y != "value" and ldata[y].dtype.name == "object":
-            ldata[y] = pd.Categorical(
+            ldata.loc[:, y] = pd.Categorical(
                 ldata[y], categories=ldata[y].unique(), ordered=True
             )
 
@@ -560,6 +560,11 @@ class ChartGenerator(PlotsGenerator, ABC):
                 artificial_zeros = pd.DataFrame(
                     {x: ldata[x].iloc[-1], y: np.nan, color: unique_colors}
                 )
+                if facet_col:
+                    artificial_zeros[facet_col] = ldata[facet_col].iloc[-1]
+                if facet_row:
+                    artificial_zeros[facet_row] = ldata[facet_row].iloc[-1]
+
                 artificials = px.area(
                     artificial_zeros,
                     **kwargs,

--- a/test/test_plot_statistics_interactive.py
+++ b/test/test_plot_statistics_interactive.py
@@ -46,6 +46,20 @@ def test_iplot_with_colors(ac_dc_network_r):
     )
 
 
+def test_iplot_with_facet_col(ac_dc_network_r):
+    """Test creating a plot with colors from carriers."""
+    n = ac_dc_network_r
+    fig = n.statistics.installed_capacity.iplot.bar(facet_col="carrier")
+    assert isinstance(fig, go.Figure)
+
+
+def test_iplot_with_facet_row(ac_dc_network_r):
+    """Test creating a plot with colors from carriers."""
+    n = ac_dc_network_r
+    fig = n.statistics.installed_capacity.iplot.bar(facet_row="carrier")
+    assert isinstance(fig, go.Figure)
+
+
 def test_iplot_different_statistics(ac_dc_network_r):
     """Test creating plots with different statistics."""
     n = ac_dc_network_r


### PR DESCRIPTION
Small fix for area plots with facet row and col in stacked mode. before the artificial data that we have to insert did not have the full set of needed columns. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
