### PR TITLE
Clean up deprecation warnings and add scheme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,9 @@ show_error_code_links = true
 # disallow_any_generics = true 
 # warn_return_any = true
 
+
+
+
 [[tool.mypy.overrides]]
 module = "pypsa.*"
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,9 +126,6 @@ show_error_code_links = true
 # disallow_any_generics = true 
 # warn_return_any = true
 
-
-
-
 [[tool.mypy.overrides]]
 module = "pypsa.*"
 disallow_untyped_defs = true

--- a/pypsa/__init__.py
+++ b/pypsa/__init__.py
@@ -41,7 +41,7 @@ def __getattr__(name: str) -> Any:
     if name in ["release_version"]:
         warnings.warn(
             "The attribute 'release_version' is deprecated and will be removed in a future version. "
-            "Use '__version_semver__' instead.",
+            "Use '__version_semver__' instead. Deprecated in version 0.35 and will be removed in version 1.0.",
             DeprecationWarning,
         )
     return __version_semver__

--- a/pypsa/common.py
+++ b/pypsa/common.py
@@ -346,7 +346,7 @@ def rename_deprecated_kwargs(
 
             message = f"`{alias}` is deprecated as an argument to `{func_name}`; use `{new}` instead."
             if deprecated_in:
-                message += f" Deprecated since version {deprecated_in}."
+                message += f" Deprecated in version {deprecated_in}."
             if removed_in:
                 message += f" Will be removed in version {removed_in}."
 

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -230,19 +230,22 @@ class Component:
         if list_name is not None or attrs is not None:
             warnings.warn(
                 "Passing 'list_name' and 'attrs' is deprecated and they will be "
-                "retrieved via the 'name' argument.",
+                "retrieved via the 'name' argument. Deprecated in version 0.31 and "
+                "will be removed in version 1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
         if ind is not None:
             warnings.warn(
-                "The 'ind' attribute is deprecated.",
+                "The 'ind' attribute is deprecated. Deprecated in version 0.31 and "
+                "will be removed in version 1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
         if investment_periods is not None:
             raise DeprecationWarning(
                 "The 'investment_periods' attribute is deprecated. Pass 'n' instead."
+                "Deprecated in version 0.31 and will be removed in version 1.0."
             )
 
         if name:

--- a/pypsa/definitions/components.py
+++ b/pypsa/definitions/components.py
@@ -65,6 +65,7 @@ class ComponentType:
     @property
     @deprecated(
         deprecated_in="0.32.0",
+        removed_in="1.0",
         details="Use the 'category' attribute instead.",
     )
     def type(self) -> str:
@@ -73,6 +74,7 @@ class ComponentType:
     @property
     @deprecated(
         deprecated_in="0.32.0",
+        removed_in="1.0",
         details="Use the 'defaults' attribute instead.",
     )
     def attrs(self) -> pd.DataFrame:

--- a/pypsa/examples.py
+++ b/pypsa/examples.py
@@ -58,7 +58,8 @@ def ac_dc_meshed(
     if update or from_master:
         warnings.warn(
             "The 'update' and 'from_master' parameters are deprecated and do not have any effect. "
-            "Example networks are always updated and retrieved for the current version.",
+            "Example networks are always updated and retrieved for the current version."
+            "Deprecated in version 0.35 and will be removed in version 1.0.",
             DeprecationWarning,
         )
     return _retrieve_if_not_local("examples/networks/ac-dc-meshed/ac-dc-meshed.nc")
@@ -85,7 +86,8 @@ def storage_hvdc(update: bool = False, from_master: bool = False) -> Network:
     if update or from_master:
         warnings.warn(
             "The 'update' and 'from_master' parameters are deprecated and do not have any effect. "
-            "Example networks are always updated and retrieved for the current version.",
+            "Example networks are always updated and retrieved for the current version."
+            "Deprecated in version 0.35 and will be removed in version 1.0.",
             DeprecationWarning,
         )
     return _retrieve_if_not_local("examples/networks/storage-hvdc/storage-hvdc.nc")
@@ -112,7 +114,8 @@ def scigrid_de(update: bool = False, from_master: bool = False) -> Network:
     if update or from_master:
         warnings.warn(
             "The 'update' and 'from_master' parameters are deprecated and do not have any effect. "
-            "Example networks are always updated and retrieved for the current version.",
+            "Example networks are always updated and retrieved for the current version."
+            "Deprecated in version 0.35 and will be removed in version 1.0.",
             DeprecationWarning,
         )
     return _retrieve_if_not_local("examples/networks/scigrid-de/scigrid-de.nc")
@@ -139,7 +142,8 @@ def model_energy(update: bool = False, from_master: bool = False) -> Network:
     if update or from_master:
         warnings.warn(
             "The 'update' and 'from_master' parameters are deprecated and do not have any effect. "
-            "Example networks are always updated and retrieved for the current version.",
+            "Example networks are always updated and retrieved for the current version."
+            "Deprecated in version 0.35 and will be removed in version 1.0.",
             DeprecationWarning,
         )
     return _retrieve_if_not_local("examples/networks/model-energy/model-energy.nc")

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -95,7 +95,6 @@ if TYPE_CHECKING:
     from scipy.sparse import spmatrix
 
 logger = logging.getLogger(__name__)
-warnings.simplefilter("always", DeprecationWarning)
 
 
 dir_name = os.path.dirname(__file__)
@@ -287,7 +286,8 @@ class Network:
             msg = (
                 "The arguments `override_components` and `override_component_attrs` "
                 "are deprecated. Please check the release notes: "
-                "https://pypsa.readthedocs.io/en/latest/references/release-notes.html#v0-33-0"
+                "https://pypsa.readthedocs.io/en/latest/references/release-notes.html#v0-33-0."
+                "Deprecated in version 0.33 and will be removed in version 1.0."
             )
             raise DeprecationWarning(msg)
 
@@ -1521,6 +1521,7 @@ class Network:
             warnings.warn(
                 "Argument 'with_time' is deprecated in 0.29 and will be "
                 "removed in a future version. Pass an empty list to 'snapshots' instead.",
+                "Deprecated in version 0.29 and will be removed in version 1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -13,7 +13,7 @@ from weakref import ref
 from deprecation import deprecated
 
 from pypsa._options import option_context
-from pypsa.common import equals, future_deprecation
+from pypsa.common import deprecated_in_next_major, equals
 from pypsa.components.abstract import Components
 from pypsa.components.common import as_components
 from pypsa.constants import DEFAULT_EPSG, DEFAULT_TIMESTAMP
@@ -237,12 +237,16 @@ class Network:
 
     # from pypsa.plot
     @deprecated(
+        deprecated_in="0.34",
+        removed_in="1.0",
         details="Use `n.plot.iplot()` as a drop-in replacement instead.",
     )
     def iplot(self, *args: Any, **kwargs: Any) -> Any:
         return iplot(self, *args, **kwargs)
 
     @deprecated(
+        deprecated_in="0.34",
+        removed_in="1.0",
         details="Use `n.plot.explore()` as a drop-in replacement instead.",
     )
     def explore(self, *args: Any, **kwargs: Any) -> Any:
@@ -528,7 +532,9 @@ class Network:
         """
         return self.components
 
-    @future_deprecation(details="Use `self.components.<component>.dynamic` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>.dynamic` instead."
+    )
     def df(self, component_name: str) -> pd.DataFrame:
         """
         Alias for :py:meth:`pypsa.Network.static`.
@@ -544,7 +550,9 @@ class Network:
         """
         return self.static(component_name)
 
-    @future_deprecation(details="Use `self.components.<component>.static` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>.static` instead."
+    )
     def static(self, component_name: str) -> pd.DataFrame:
         """
         Return the DataFrame of static components for component_name, i.e.
@@ -561,7 +569,9 @@ class Network:
         """
         return self.components[component_name].static
 
-    @future_deprecation(details="Use `self.components.<component>.dynamic` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>.dynamic` instead.",
+    )
     def pnl(self, component_name: str) -> Dict:
         """
         Alias for :py:meth:`pypsa.Network.dynamic`.
@@ -577,7 +587,9 @@ class Network:
         """
         return self.dynamic(component_name)
 
-    @future_deprecation(details="Use `self.components.<component>.dynamic` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>.dynamic` instead.",
+    )
     def dynamic(self, component_name: str) -> Dict:
         """
         Return the dictionary of DataFrames of varying components for
@@ -595,7 +607,9 @@ class Network:
         return self.components[component_name].dynamic
 
     @property
-    @future_deprecation(details="Use `self.components.<component>.defaults` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>.defaults` instead.",
+    )
     def component_attrs(self) -> pd.DataFrame:
         """
         Alias for :py:meth:`pypsa.Network.get`.
@@ -1755,11 +1769,13 @@ class Network:
             find_cycles(sub)
             sub.find_bus_controls()
 
-    @future_deprecation(details="Use `self.components.<component>` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>` instead.",
+    )
     def component(self, c_name: str) -> Component:
         return self.components[c_name]
 
-    @future_deprecation(details="Use `self.components` instead.")
+    @deprecated_in_next_major(details="Use `self.components` instead.")
     def iterate_components(
         self, components: Collection[str] | None = None, skip_empty: bool = True
     ) -> Iterator[Component]:
@@ -1873,7 +1889,9 @@ class SubNetwork:
         self.name = name
 
     @property
-    @deprecated(details="Use the `n` property instead.")
+    @deprecated(
+        deprecated_in="0.32", removed_in="1.0", details="Use the `n` property instead."
+    )
     def network(self) -> Network:
         return self._n()  # type: ignore
 
@@ -1944,93 +1962,121 @@ class SubNetwork:
         branches = self.n.passive_branches()
         return branches[branches.sub_network == self.name]
 
-    @future_deprecation(details="Use `self.components.<c_name>` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<c_name>` instead.",
+    )
     def component(self, c_name: str) -> SubNetworkComponents:
         return self.components[c_name]
 
-    @future_deprecation(details="Use `self.components.<c_name>.static` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<c_name>.static` instead.",
+    )
     def df(self, c_name: str) -> pd.DataFrame:
         return self.static(c_name)
 
-    @future_deprecation(details="Use `self.components.<c_name>.static` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<c_name>.static` instead.",
+    )
     def static(self, c_name: str) -> pd.DataFrame:
         return self.components[c_name].static
 
-    @future_deprecation(details="Use `self.components.<c_name>.dynamic` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<c_name>.dynamic` instead.",
+    )
     def pnl(self, c_name: str) -> Dict:
         return self.dynamic(c_name)
 
-    @future_deprecation(details="Use `self.components.<c_name>.dynamic` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.<c_name>.dynamic` instead.",
+    )
     def dynamic(self, c_name: str) -> Dict:
         return self.components[c_name].dynamic
 
-    @future_deprecation(details="Use `self.components.buses.static.index` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.buses.static.index` instead.",
+    )
     def buses_i(self) -> pd.Index:
         return self.components.buses.static.index
 
-    @future_deprecation(details="Use `self.components.lines.static.index` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.lines.static.index` instead.",
+    )
     def lines_i(self) -> pd.Index:
         return self.components.lines.static.index
 
-    @future_deprecation(
-        details="Use `self.components.transformers.static.index` instead."
+    @deprecated_in_next_major(
+        details="Use `self.components.transformers.static.index` instead.",
     )
     def transformers_i(self) -> pd.Index:
         return self.components.transformers.static.index
 
-    @future_deprecation(
-        details="Use `self.components.generators.static.index` instead."
+    @deprecated_in_next_major(
+        details="Use `self.components.generators.static.index` instead.",
     )
     def generators_i(self) -> pd.Index:
         return self.components.generators.static.index
 
-    @future_deprecation(details="Use `self.components.loads.static.index` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.loads.static.index` instead.",
+    )
     def loads_i(self) -> pd.Index:
         return self.components.loads.static.index
 
-    @future_deprecation(
-        details="Use `self.components.shunt_impedances.static.index` instead."
+    @deprecated_in_next_major(
+        details="Use `self.components.shunt_impedances.static.index` instead.",
     )
     def shunt_impedances_i(self) -> pd.Index:
         return self.components.shunt_impedances.static.index
 
-    @future_deprecation(
-        details="Use `self.components.storage_units.static.index` instead."
+    @deprecated_in_next_major(
+        details="Use `self.components.storage_units.static.index` instead.",
     )
     def storage_units_i(self) -> pd.Index:
         return self.components.storage_units.static.index
 
-    @future_deprecation(details="Use `self.components.stores.index.static` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.stores.index.static` instead.",
+    )
     def stores_i(self) -> pd.Index:
         return self.components.stores.static.index
 
-    @future_deprecation(details="Use `self.components.buses.static` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.buses.static` instead.",
+    )
     def buses(self) -> pd.DataFrame:
         return self.components.buses.static
 
-    @future_deprecation(details="Use `self.components.generators.static` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.generators.static` instead.",
+    )
     def generators(self) -> pd.DataFrame:
         return self.components.generators.static
 
-    @future_deprecation(details="Use `self.components.loads.static` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.loads.static` instead.",
+    )
     def loads(self) -> pd.DataFrame:
         return self.components.loads.static
 
-    @future_deprecation(
-        details="Use `self.components.shunt_impedances.static` instead."
+    @deprecated_in_next_major(
+        details="Use `self.components.shunt_impedances.static` instead.",
     )
     def shunt_impedances(self) -> pd.DataFrame:
         return self.components.shunt_impedances.static
 
-    @future_deprecation(details="Use `self.components.storage_units.static` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.storage_units.static` instead.",
+    )
     def storage_units(self) -> pd.DataFrame:
         return self.components.storage_units.static
 
-    @future_deprecation(details="Use `self.components.stores.static` instead.")
+    @deprecated_in_next_major(
+        details="Use `self.components.stores.static` instead.",
+    )
     def stores(self) -> pd.DataFrame:
         return self.components.stores.static
 
-    @future_deprecation(details="Use `self.components` instead.")
+    @deprecated_in_next_major(details="Use `self.components` instead.")
     # Deprecate: Use `self.iterate_components` instead
     def iterate_components(
         self, components: Collection[str] | None = None, skip_empty: bool = True

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -1520,7 +1520,7 @@ class Network:
         if with_time is not None:
             warnings.warn(
                 "Argument 'with_time' is deprecated in 0.29 and will be "
-                "removed in a future version. Pass an empty list to 'snapshots' instead.",
+                "removed in a future version. Pass an empty list to 'snapshots' instead."
                 "Deprecated in version 0.29 and will be removed in version 1.0.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -102,7 +102,7 @@ def discretized_capacity(
     if min_units is not None:
         raise DeprecationWarning(
             "The `min_units` parameter is deprecated and will be removed in future "
-            "versions."
+            "versions. Deprecated in version 0.32 and will be removed in version 1.0."
         )
     units = nom_opt // unit_size + (nom_opt % unit_size >= threshold * unit_size)
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1020,7 +1020,11 @@ def define_loss_constraints(
             )
 
 
-@deprecated("Use define_total_supply_constraints instead.")
+@deprecated(
+    deprecated_in="0.31.2",
+    removed_in="1.0",
+    details="Use define_total_supply_constraints instead.",
+)
 def define_generators_constraints(n: Network, sns: Sequence) -> None:
     return define_total_supply_constraints(n, sns)
 

--- a/pypsa/plot/__init__.py
+++ b/pypsa/plot/__init__.py
@@ -11,14 +11,28 @@ from pypsa.plot.maps.static import add_legend_semicircles as _add_legend_semicir
 from pypsa.plot.maps.static import plot as _plot
 
 # Create wrapped versions
-plot = deprecated_namespace(_plot, "pypsa.plot")  # noqa: F811
-iplot = deprecated_namespace(_iplot, "pypsa.plot")  # noqa: F811
-explore = deprecated_namespace(_explore, "pypsa.plot")  # noqa: F811
-add_legend_arrows = deprecated_namespace(_add_legend_arrows, "pypsa.plot")  # noqa: F811
-add_legend_circles = deprecated_namespace(_add_legend_circles, "pypsa.plot")  # noqa: F811
-add_legend_lines = deprecated_namespace(_add_legend_lines, "pypsa.plot")  # noqa: F811
-add_legend_patches = deprecated_namespace(_add_legend_patches, "pypsa.plot")  # noqa: F811
-add_legend_semicircles = deprecated_namespace(_add_legend_semicircles, "pypsa.plot")  # noqa: F811
+plot = deprecated_namespace(_plot, "pypsa.plot", deprecated_in="0.34", removed_in="1.0")  # noqa: F811
+iplot = deprecated_namespace(
+    _iplot, "pypsa.plot", deprecated_in="0.34", removed_in="1.0"
+)  # noqa: F811
+explore = deprecated_namespace(
+    _explore, "pypsa.plot", deprecated_in="0.34", removed_in="1.0"
+)  # noqa: F811
+add_legend_arrows = deprecated_namespace(
+    _add_legend_arrows, "pypsa.plot", deprecated_in="0.34", removed_in="1.0"
+)  # noqa: F811
+add_legend_circles = deprecated_namespace(
+    _add_legend_circles, "pypsa.plot", deprecated_in="0.34", removed_in="1.0"
+)  # noqa: F811
+add_legend_lines = deprecated_namespace(
+    _add_legend_lines, "pypsa.plot", deprecated_in="0.34", removed_in="1.0"
+)  # noqa: F811
+add_legend_patches = deprecated_namespace(
+    _add_legend_patches, "pypsa.plot", deprecated_in="0.34", removed_in="1.0"
+)  # noqa: F811
+add_legend_semicircles = deprecated_namespace(
+    _add_legend_semicircles, "pypsa.plot", deprecated_in="0.34", removed_in="1.0"
+)  # noqa: F811
 
 __all__ = [
     "plot",  # deprecated namespace

--- a/pypsa/plot/accessor.py
+++ b/pypsa/plot/accessor.py
@@ -26,6 +26,8 @@ class PlotAccessor:
         self.n = n  # TODO rename
 
     @deprecated(
+        deprecated_in="0.34",
+        removed_in="1.0",
         details="Use `n.plot.map()` as a drop-in replacement instead.",
     )
     @functools.wraps(plot)

--- a/pypsa/plot/maps/interactive.py
+++ b/pypsa/plot/maps/interactive.py
@@ -196,7 +196,7 @@ def iplot(
         if isinstance(line_widths.index, pd.MultiIndex):
             raise DeprecationWarning(
                 "Index of argument 'line_widths' is a Multiindex, "
-                "this is not support since pypsa v0.17. "
+                "this is not support since pypsa v0.17 and will be removed in v1.0. "
                 "Set differing widths with arguments 'line_widths', "
                 "'link_widths' and 'transformer_widths'."
             )
@@ -204,7 +204,7 @@ def iplot(
         if isinstance(line_colors.index, pd.MultiIndex):
             raise DeprecationWarning(
                 "Index of argument 'line_colors' is a Multiindex, "
-                "this is not support since pypsa v0.17. "
+                "this is not support since pypsa v0.17. and will be removed in v1.0. "
                 "Set differing colors with arguments 'line_colors', "
                 "'link_colors' and 'transformer_colors'."
             )

--- a/pypsa/plot/maps/static.py
+++ b/pypsa/plot/maps/static.py
@@ -1144,6 +1144,7 @@ class MapPlotter:
                 msg = (
                     "The `flow` argument is deprecated, use `line_flow`, `link_flow` and "
                     "`transformer_flow` instead. Multiindex Series are not supported anymore."
+                    "Deprecated in version 0.34 and will be removed in version 1.0."
                 )
                 warnings.warn(msg, DeprecationWarning, 2)
                 line_flow = flow.get("Line")
@@ -1156,7 +1157,7 @@ class MapPlotter:
         ):
             msg = (
                 "Index of argument 'line_widths' is a Multiindex, "
-                "this is not support since pypsa v0.17. "
+                "this is not support since pypsa v0.17 and will be removed in v1.0. "
                 "Set differing widths with arguments 'line_widths', "
                 "'link_widths' and 'transformer_widths'."
             )
@@ -1167,7 +1168,7 @@ class MapPlotter:
         ):
             msg = (
                 "Index of argument 'line_colors' is a Multiindex, "
-                "this is not support since pypsa v0.17. "
+                "this is not support since pypsa v0.17 and will be removed in v1.0. "
                 "Set differing colors with arguments 'line_colors', "
                 "'link_colors' and 'transformer_colors'."
             )

--- a/pypsa/plot/maps/static.py
+++ b/pypsa/plot/maps/static.py
@@ -1307,6 +1307,8 @@ class MapPlotter:
     link_norm="link_cmap_norm",
     transformer_norm="transformer_cmap_norm",
     color_geomap="geomap_colors",
+    deprecated_in="0.34",
+    removed_in="1.0",
 )
 @wraps(
     MapPlotter.draw_map,

--- a/pypsa/statistics/abstract.py
+++ b/pypsa/statistics/abstract.py
@@ -91,6 +91,8 @@ class Parameters:
         options.set_option("params.statistics.round", value)
 
     @deprecated(
+        deprecated_in="0.34",
+        removed_in="1.0",
         details="Use the 'pypsa.options' module instead. E.g. 'pypsa.options.params.statistics.drop_zero = True'.",
     )
     def set_parameters(self, **kwargs: Any) -> None:  # noqa: D102

--- a/pypsa/statistics/abstract.py
+++ b/pypsa/statistics/abstract.py
@@ -39,7 +39,8 @@ class Parameters:
     @property
     def drop_zero(self) -> bool:  # noqa: D102
         warnings.warn(
-            "Use 'pypsa.options.params.statistics.drop_zero' instead.",
+            "Use 'pypsa.options.params.statistics.drop_zero' instead."
+            "Deprecated in version 0.34 and will be removed in version 1.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -48,7 +49,8 @@ class Parameters:
     @drop_zero.setter
     def drop_zero(self, value: bool) -> None:  # noqa: D102
         warnings.warn(
-            "Use 'pypsa.options.params.statistics.drop_zero = ..' instead.",
+            "Use 'pypsa.options.params.statistics.drop_zero = ..' instead."
+            "Deprecated in version 0.34 and will be removed in version 1.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -57,7 +59,8 @@ class Parameters:
     @property
     def nice_names(self) -> bool:  # noqa: D102
         warnings.warn(
-            "Use 'pypsa.options.params.statistics.nice_names' instead.",
+            "Use 'pypsa.options.params.statistics.nice_names' instead."
+            "Deprecated in version 0.34 and will be removed in version 1.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -66,7 +69,8 @@ class Parameters:
     @nice_names.setter
     def nice_names(self, value: bool) -> None:  # noqa: D102
         warnings.warn(
-            "Use 'pypsa.options.params.statistics.nice_names = ..' instead.",
+            "Use 'pypsa.options.params.statistics.nice_names = ..' instead."
+            "Deprecated in version 0.34 and will be removed in version 1.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -75,7 +79,8 @@ class Parameters:
     @property
     def round(self) -> int:  # noqa: D102
         warnings.warn(
-            "Use 'pypsa.options.params.statistics.round' instead.",
+            "Use 'pypsa.options.params.statistics.round' instead."
+            "Deprecated in version 0.34 and will be removed in version 1.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -84,7 +89,8 @@ class Parameters:
     @round.setter
     def round(self, value: int) -> None:  # noqa: D102
         warnings.warn(
-            "Use 'pypsa.options.params.statistics.round = ..' instead.",
+            "Use 'pypsa.options.params.statistics.round = ..' instead."
+            "Deprecated in version 0.34 and will be removed in version 1.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -264,7 +270,8 @@ class AbstractStatisticsAccessor(ABC):
                         warnings.warn(
                             "Passing `groupby=None` is deprecated. Drop the "
                             "argument to get the default grouping (by carrier), which "
-                            "was also the previous default behavior.",
+                            "was also the previous default behavior. Deprecated in "
+                            "version 0.34 and will be removed in version 1.0.",
                             DeprecationWarning,
                             stacklevel=2,
                         )

--- a/pypsa/statistics/deprecated.py
+++ b/pypsa/statistics/deprecated.py
@@ -17,7 +17,11 @@ from pypsa.statistics.abstract import AbstractStatisticsAccessor
 logger = logging.getLogger(__name__)
 
 
-@deprecated("Use n.statistics._get_grouping instead.")
+@deprecated(
+    deprecated_in="0.32",
+    removed_in="1.0",
+    details="Use n.statistics._get_grouping instead.",
+)
 def get_grouping(  # noqa
     n: Network,
     c: str,
@@ -28,21 +32,33 @@ def get_grouping(  # noqa
     return n.statistics._get_grouping(n, c, groupby, port, nice_names)
 
 
-@deprecated("Use n.statistics._aggregate_timeseries instead.")
+@deprecated(
+    deprecated_in="0.32",
+    removed_in="1.0",
+    details="Use n.statistics._aggregate_timeseries instead.",
+)
 def aggregate_timeseries(  # noqa
     df: pd.DataFrame, weights: pd.Series, agg: str = "sum"
 ) -> pd.Series:
     return AbstractStatisticsAccessor._aggregate_timeseries(df, weights, agg)
 
 
-@deprecated("Use n.statistics._filter_active_assets instead.")
+@deprecated(
+    deprecated_in="0.32",
+    removed_in="1.0",
+    details="Use n.statistics._filter_active_assets instead.",
+)
 def filter_active_assets(  # noqa
     n: Network, c: str, df: pd.Series | pd.DataFrame
 ) -> pd.Series | pd.DataFrame:
     return n.statistics._filter_active_assets(n, c, df)
 
 
-@deprecated("Use n.statistics._filter_bus_carrier instead.")
+@deprecated(
+    deprecated_in="0.32",
+    removed_in="1.0",
+    details="Use n.statistics._filter_bus_carrier instead.",
+)
 def filter_bus_carrier(  # noqa
     n: Network,
     c: str,

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -1619,7 +1619,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    @deprecated_kwargs(kind="direction")
+    @deprecated_kwargs(kind="direction", deprecated_in="0.34", removed_in="1.0")
     def energy_balance(
         self,
         comps: str | Sequence[str] | None = None,
@@ -1968,7 +1968,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    @deprecated_kwargs(kind="direction")
+    @deprecated_kwargs(kind="direction", deprecated_in="0.34", removed_in="1.0")
     def revenue(
         self,
         comps: str | Sequence[str] | None = None,

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -345,7 +345,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         if aggregate_time is not None:
             warnings.warn(
                 "The parameter `aggregate_time` is deprecated for the summary function."
-                "Please use it for individual statistics instead.",
+                "Please use it for individual statistics instead. Deprecated in "
+                "version 0.34 and will be removed in version 1.0.",
                 DeprecationWarning,
             )
         funcs: list[Callable] = [

--- a/pypsa/statistics/grouping.py
+++ b/pypsa/statistics/grouping.py
@@ -407,6 +407,7 @@ def deprecated_grouper(func: Callable) -> Callable:
             f"`n.statistics.{func.__name__}` and `pypsa.statistics.{func.__name__}` "
             f"are deprecated. Use "
             f"`pypsa.statistics.groupers{new_grouper_access[func.__name__]}` instead."
+            "Deprecated in version 0.34 and will be removed in version 1.0."
         )
         warnings.warn(msg, DeprecationWarning)
         return func(*args, **kwargs)

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -7,12 +7,8 @@ import pytest
 from pypsa.common import (
     MethodHandlerWrapper,
     as_index,
-    deprecated_common_kwargs,
-    deprecated_kwargs,
     equals,
-    future_deprecation,
     list_as_string,
-    rename_kwargs,
 )
 
 
@@ -246,59 +242,6 @@ def warning_catcher():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         yield w
-
-
-def test_deprecated_kwargs(warning_catcher):
-    @deprecated_kwargs(old_arg="new_arg")
-    def test_func(new_arg):
-        return new_arg
-
-    result = test_func(old_arg="value")
-    assert result == "value"
-    assert len(warning_catcher) == 1
-    assert issubclass(warning_catcher[0].category, DeprecationWarning)
-    assert "old_arg" in str(warning_catcher[0].message)
-
-
-def test_rename_kwargs():
-    kwargs = {"old_arg": "value"}
-    aliases = {"old_arg": "new_arg"}
-    with pytest.warns(DeprecationWarning):
-        rename_kwargs("test_func", kwargs, aliases)
-    assert "new_arg" in kwargs
-    assert "old_arg" not in kwargs
-    assert kwargs["new_arg"] == "value"
-
-
-def test_deprecated_common_kwargs(warning_catcher):
-    @deprecated_common_kwargs
-    def test_func(n):
-        return n
-
-    result = test_func(network="value")
-    assert result == "value"
-    assert len(warning_catcher) == 1
-    assert issubclass(warning_catcher[0].category, DeprecationWarning)
-    assert "network" in str(warning_catcher[0].message)
-
-
-def test_future_deprecation(warning_catcher):
-    @future_deprecation(activate=False)
-    def test_func_inactive():
-        return "not deprecated"
-
-    result = test_func_inactive()
-    assert result == "not deprecated"
-    assert len(warning_catcher) == 0
-
-    @future_deprecation(activate=True)
-    def test_func_active():
-        return "deprecated"
-
-    result = test_func_active()
-    assert result == "deprecated"
-    assert len(warning_catcher) == 1
-    assert issubclass(warning_catcher[0].category, DeprecationWarning)
 
 
 def test_list_as_string():

--- a/test/test_common_deprecations.py
+++ b/test/test_common_deprecations.py
@@ -1,0 +1,210 @@
+import warnings
+from unittest.mock import patch
+
+import pytest
+
+from pypsa.common import (
+    deprecated_common_kwargs,
+    deprecated_in_next_major,
+    deprecated_kwargs,
+    deprecated_namespace,
+    rename_deprecated_kwargs,
+)
+
+
+@pytest.fixture
+def mock_version_semver():
+    with patch("pypsa.common.__version_semver__", "1.0.0"):
+        yield
+
+
+def test_rename_deprecated_kwargs_basic(mock_version_semver):
+    """Test basic functionality of rename_deprecated_kwargs."""
+    func_name = "test_func"
+    kwargs = {"old_arg": "value"}
+    aliases = {"old_arg": "new_arg"}
+    deprecated_in = "0.9.0"
+    removed_in = "1.1.0"
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        rename_deprecated_kwargs(func_name, kwargs, aliases, deprecated_in, removed_in)
+
+        # Check that a warning was raised
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "`old_arg` is deprecated as an argument to `test_func`" in str(
+            w[0].message
+        )
+        assert "Deprecated since version 0.9.0" in str(w[0].message)
+        assert "Will be removed in version 1.1.0" in str(w[0].message)
+
+    # Check that the argument was renamed
+    assert "new_arg" in kwargs
+    assert "old_arg" not in kwargs
+    assert kwargs["new_arg"] == "value"
+
+
+def test_rename_deprecated_kwargs_both_args_present(mock_version_semver):
+    """Test that an error is raised when both old and new arguments are provided."""
+    func_name = "test_func"
+    kwargs = {"old_arg": "old_value", "new_arg": "new_value"}
+    aliases = {"old_arg": "new_arg"}
+    deprecated_in = "0.9.0"
+    removed_in = "1.1.0"
+
+    with pytest.raises(DeprecationWarning) as excinfo:
+        rename_deprecated_kwargs(func_name, kwargs, aliases, deprecated_in, removed_in)
+
+    assert "received both old_arg and new_arg as arguments" in str(excinfo.value)
+
+
+def test_rename_deprecated_kwargs_no_deprecated_args(mock_version_semver):
+    """Test that no warnings are raised when no deprecated arguments are used."""
+    func_name = "test_func"
+    kwargs = {"new_arg": "value"}
+    aliases = {"old_arg": "new_arg"}
+    deprecated_in = "0.9.0"
+    removed_in = "1.1.0"
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        rename_deprecated_kwargs(func_name, kwargs, aliases, deprecated_in, removed_in)
+
+        # Check that no warnings were raised
+        assert len(w) == 0
+
+    # Check that the arguments remain unchanged
+    assert "new_arg" in kwargs
+    assert kwargs["new_arg"] == "value"
+
+
+def test_rename_deprecated_kwargs_multiple_aliases(mock_version_semver):
+    """Test handling multiple aliases at once."""
+    func_name = "test_func"
+    kwargs = {"old_arg1": "value1", "old_arg2": "value2"}
+    aliases = {"old_arg1": "new_arg1", "old_arg2": "new_arg2"}
+    deprecated_in = "0.9.0"
+    removed_in = "1.1.0"
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        rename_deprecated_kwargs(func_name, kwargs, aliases, deprecated_in, removed_in)
+
+        # Check that warnings were raised
+        assert len(w) == 2
+
+    # Check that the arguments were renamed
+    assert "new_arg1" in kwargs and "new_arg2" in kwargs
+    assert "old_arg1" not in kwargs and "old_arg2" not in kwargs
+    assert kwargs["new_arg1"] == "value1" and kwargs["new_arg2"] == "value2"
+
+
+def test_rename_deprecated_kwargs_version_error(mock_version_semver):
+    """Test that an error is raised when deprecated_in is in the future."""
+    func_name = "test_func"
+    kwargs = {"old_arg": "value"}
+    aliases = {"old_arg": "new_arg"}
+    deprecated_in = "2.0.0"  # Future version
+    removed_in = "3.0.0"
+
+    with pytest.raises(ValueError) as excinfo:
+        rename_deprecated_kwargs(func_name, kwargs, aliases, deprecated_in, removed_in)
+
+    assert (
+        "'rename_deprecated_kwargs' can only be used in a version >= deprecated_in"
+        in str(excinfo.value)
+    )
+
+
+def test_deprecated_kwargs_decorator(mock_version_semver):
+    """Test the deprecated_kwargs decorator."""
+
+    @deprecated_kwargs(deprecated_in="0.9.0", removed_in="1.1.0", old_arg="new_arg")
+    def test_func(new_arg):
+        return new_arg
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = test_func(old_arg="value")
+
+        # Check that a warning was raised
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "`old_arg` is deprecated as an argument to `test_func`" in str(
+            w[0].message
+        )
+
+    # Check that the function worked correctly
+    assert result == "value"
+
+
+def test_deprecated_common_kwargs(mock_version_semver):
+    """Test the deprecated_common_kwargs decorator."""
+
+    @deprecated_common_kwargs
+    def test_func(n):
+        return n
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = test_func(network="value")
+
+        # Check that a warning was raised
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "`network` is deprecated as an argument to `test_func`" in str(
+            w[0].message
+        )
+
+    # Check that the function worked correctly
+    assert result == "value"
+
+
+def test_deprecated_in_next_major(mock_version_semver):
+    """Test the deprecated_in_next_major decorator."""
+
+    @deprecated_in_next_major("This function will be removed in version 2.0")
+    def test_func():
+        return "value"
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = test_func()
+
+        # Check that a warning was raised
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "is deprecated as of 1.0" in str(w[0].message).lower()
+        assert "will be removed in 2.0" in str(w[0].message).lower()
+
+    # Check that the function worked correctly
+    assert result == "value"
+
+
+def test_deprecated_namespace(mock_version_semver):
+    """Test the deprecated_namespace decorator."""
+
+    def test_func():
+        return "value"
+
+    decorated_func = deprecated_namespace(
+        test_func,
+        previous_module="old.module",
+        deprecated_in="0.9.0",
+        removed_in="1.1.0",
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = decorated_func()
+
+        # Check that a warning was raised
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "old.module" in str(w[0].message)
+        assert "Deprecated since version 0.9.0" in str(w[0].message)
+        assert "Will be removed in version 1.1.0" in str(w[0].message)
+
+    # Check that the function worked correctly
+    assert result == "value"

--- a/test/test_common_deprecations.py
+++ b/test/test_common_deprecations.py
@@ -36,7 +36,7 @@ def test_rename_deprecated_kwargs_basic(mock_version_semver):
         assert "`old_arg` is deprecated as an argument to `test_func`" in str(
             w[0].message
         )
-        assert "Deprecated since version 0.9.0" in str(w[0].message)
+        assert "Deprecated in version 0.9.0" in str(w[0].message)
         assert "Will be removed in version 1.1.0" in str(w[0].message)
 
     # Check that the argument was renamed


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Adds `deprecated_in` and `removed_in` to any deprecation warning and enforces them from now
  - `deprecated_in` is from when the warning is shown. Can be added in any version.
  - `removed_in` is from when the feature etc. is removed. Only allowed for next major version, e.g `1.0`, `2.0`
- The decorator `deprecated_in_next_major` can be used to mark future deprecations (e.g. `deprecated_in="1.0"` and `removed_in="2.0"`). No warning will show up until 1.0.

## Checklist
- [x] Unit tests for new features were added (if applicable).
- [x] I consent to the release of this PR's code under the MIT license.
