### PR TITLE
refactor: change class method import structure (`Components`)

### DIFF
--- a/pypsa/components/__init__.py
+++ b/pypsa/components/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from pypsa.components.abstract import Components
-from pypsa.components.components import Component, Generators, GenericComponents
+from pypsa.components.components import Component, Generators, GenericComponents, Lines
 
 
 def __getattr__(name: str) -> Any:
@@ -21,4 +21,5 @@ __all__ = [
     "Components",
     "GenericComponents",
     "Generators",
+    "Lines",
 ]

--- a/pypsa/components/abstract.py
+++ b/pypsa/components/abstract.py
@@ -19,7 +19,7 @@ import pandas as pd
 from pyproj import CRS
 
 from pypsa.common import equals
-from pypsa.components.descriptors import get_active_assets
+from pypsa.components.descriptors import ComponentsDescriptors
 from pypsa.constants import DEFAULT_EPSG, DEFAULT_TIMESTAMP
 from pypsa.definitions.components import ComponentType
 from pypsa.definitions.structures import Dict
@@ -61,7 +61,7 @@ class ComponentsData:
     dynamic: dict
 
 
-class Components(ComponentsData, ABC):
+class Components(ComponentsData, ABC, ComponentsDescriptors):
     """
     Components base class.
 
@@ -72,17 +72,11 @@ class Components(ComponentsData, ABC):
     Components inherits from it, adds logic and methods, but does not store any data
     itself.
 
-    .. warning::
+    !!! warning
         This class is under ongoing development and will be subject to changes.
         It is not recommended to use this class outside of PyPSA.
 
     """
-
-    # Methods
-    # -------
-
-    # from pypsa.components.descriptors
-    get_active_assets = get_active_assets
 
     def __init__(
         self,
@@ -665,6 +659,9 @@ class Components(ComponentsData, ABC):
         except KeyError:
             msg = f"Component type '{self.ctype.name}' has no nominal attribute."
             raise AttributeError(msg)
+
+    # Methods
+    # -------
 
     # TODO move
     def rename_component_names(self, **kwargs: str) -> None:

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -42,25 +42,7 @@ class GenericComponents(Components):
 
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """
-        Initialize generic components class.
-
-        See :class:`pypsa.components.abstract.Components` for more information.
-
-        Parameters
-        ----------
-        args : Any
-            Arguments of base class.
-        kwargs : Any
-            Keyword arguments of base class.
-
-        Returns
-        -------
-        None
-
-        """
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class Generators(Components):

--- a/pypsa/components/descriptors.py
+++ b/pypsa/components/descriptors.py
@@ -1,61 +1,79 @@
 """
-Abstract components module.
+Components descriptor module.
 
-Contains classes and logic relevant to all component types in PyPSA.
+Contains single helper class (ComponentsDescriptors) which is used to inherit
+to Components class. Should not be used directly.
 """
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import Any
 
 import numpy as np
 import pandas as pd
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:
-    from pypsa import Components
+
+def get_component_type(*args: Any, **kwargs: Any) -> Any:  # noqa: D103
+    msg = (
+        "pypsa.components.descriptors.get_component_type is deprecated. "
+        "Use c.get_component_type instead."
+        "Deprecated in version 0.35 and will be removed in version 1.0."
+    )
+    raise DeprecationWarning(msg)
 
 
-def get_active_assets(
-    c: Components,
-    investment_period: int | str | Sequence | None = None,
-) -> pd.Series:
+class ComponentsDescriptors:
     """
-    Get active components mask of componen type in investment period(s).
+    Helper class for components descriptors methods.
 
-    A component is considered active when:
-    - it's active attribute is True
-    - it's build year + lifetime is smaller than the investment period (if given)
-
-    Parameters
-    ----------
-    c : pypsa.Components
-        Components instance.
-    investment_period : int, str, Sequence
-        Investment period(s) to check for active within build year and lifetime. If
-        none only the active attribute is considered and build year and lifetime are
-        ignored. If multiple periods are given the mask is True if component is
-        active in any of the given periods.
-
-    Returns
-    -------
-    pd.Series
-        Boolean mask for active components
-
+    Class only inherits to Components and should not be used directly.
     """
-    if investment_period is None:
-        return c.static.active
-    if not {"build_year", "lifetime"}.issubset(c.static):
-        return c.static.active
 
-    # Logical OR of active assets in all investment periods and
-    # logical AND with active attribute
-    active = {}
-    for period in np.atleast_1d(investment_period):
-        if period not in c.n_save.investment_periods:
-            raise ValueError("Investment period not in `n.investment_periods`")
-        active[period] = c.static.eval("build_year <= @period < build_year + lifetime")
-    return pd.DataFrame(active).any(axis=1) & c.static.active
+    static: pd.DataFrame
+    n_save: Any
+
+    def get_active_assets(
+        self,
+        investment_period: int | str | Sequence | None = None,
+    ) -> pd.Series:
+        """
+        Get active components mask of componen type in investment period(s).
+
+        A component is considered active when:
+
+        - it's active attribute is True
+        - it's build year + lifetime is smaller than the investment period (if given)
+
+        Parameters
+        ----------
+        investment_period : int, str, Sequence
+            Investment period(s) to check for active within build year and lifetime. If
+            none only the active attribute is considered and build year and lifetime are
+            ignored. If multiple periods are given the mask is True if component is
+            active in any of the given periods.
+
+        Returns
+        -------
+        pd.Series
+            Boolean mask for active components
+
+        """
+        if investment_period is None:
+            return self.static.active
+        if not {"build_year", "lifetime"}.issubset(self.static):
+            return self.static.active
+
+        # Logical OR of active assets in all investment periods and
+        # logical AND with active attribute
+        active = {}
+        for period in np.atleast_1d(investment_period):
+            if period not in self.n_save.investment_periods:
+                raise ValueError("Investment period not in `n.investment_periods`")
+            active[period] = self.static.eval(
+                "build_year <= @period < build_year + lifetime"
+            )
+        return pd.DataFrame(active).any(axis=1) & self.static.active

--- a/pypsa/components/descriptors.py
+++ b/pypsa/components/descriptors.py
@@ -8,32 +8,47 @@ to Components class. Should not be used directly.
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
 
+if TYPE_CHECKING:
+    from pypsa import Components
 logger = logging.getLogger(__name__)
 
 
-def get_active_assets(*args: Any, **kwargs: Any) -> Any:
+def get_active_assets(c: Components, *args: Any, **kwargs: Any) -> Any:
     """
     Deprecated function to get active assets. Use `c.get_active_assets`.
 
     Examples
     --------
     >>> import pytest
-    >>> with pytest.raises(DeprecationWarning):
-    ...     get_active_assets()
+    >>> with pytest.warns(DeprecationWarning):
+    ...     get_active_assets(c)
+    Generator
+    Manchester Wind    True
+    Manchester Gas     True
+    Norway Wind        True
+    Norway Gas         True
+    Frankfurt Wind     True
+    Frankfurt Gas      True
+    Name: active, dtype: bool
 
     """
-    msg = (
-        "pypsa.components.descriptors.get_active_assets is deprecated. "
-        "Use c.get_active_assets instead."
-        "Deprecated in version 0.35 and will be removed in version 1.0."
+    warnings.warn(
+        (
+            "pypsa.components.descriptors.get_active_assets is deprecated. "
+            "Use c.get_active_assets instead."
+            "Deprecated in version 0.35 and will be removed in version 1.0."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
     )
-    raise DeprecationWarning(msg)
+    return c.get_active_assets(*args, **kwargs)
 
 
 class ComponentsDescriptors:

--- a/pypsa/components/descriptors.py
+++ b/pypsa/components/descriptors.py
@@ -17,10 +17,20 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def get_component_type(*args: Any, **kwargs: Any) -> Any:  # noqa: D103
+def get_active_assets(*args: Any, **kwargs: Any) -> Any:
+    """
+    Deprecated function to get active assets. Use `c.get_active_assets`.
+
+    Examples
+    --------
+    >>> import pytest
+    >>> with pytest.raises(DeprecationWarning):
+    ...     get_active_assets()
+
+    """
     msg = (
-        "pypsa.components.descriptors.get_component_type is deprecated. "
-        "Use c.get_component_type instead."
+        "pypsa.components.descriptors.get_active_assets is deprecated. "
+        "Use c.get_active_assets instead."
         "Deprecated in version 0.35 and will be removed in version 1.0."
     )
     raise DeprecationWarning(msg)

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -26,6 +26,7 @@ doctest_globals = {
     "pandas": pd,
     "pypsa": pypsa,
     "n": pypsa.examples.ac_dc_meshed(),
+    "c": pypsa.examples.ac_dc_meshed().components.generators,
 }
 
 modules = [


### PR DESCRIPTION
## Changes proposed in this Pull Request
Use parent classes instead of the current function import. This will improve structure and readability, be more python-like, and make the API reference easier to generate. API will not change at all.

E.g.
``` python
class NetworkDescriptors:

   def x():
       ...
```
and 
``` python
class Network(NetworkDescriptors):
    ..
```
vs
``` python
from descriptors import x
...

class Network
  x = x
```

## Checklist

- [ ] Unit tests for new features were added (if applicable).
- [x] I consent to the release of this PR's code under the MIT license.
