### PR TITLE
feat: option to change components api

### DIFF
--- a/pypsa/_options.py
+++ b/pypsa/_options.py
@@ -224,6 +224,9 @@ class OptionsNode:
         >>> pypsa.options.describe_options()
         PyPSA Options
         =============
+        api.legacy_components:
+            Default: True
+            Description: WARNING: Experimental feature. Not all PyPSA functionality is supported yet. Use legacy components API for backwards compatibility to PyPSA versions prior to 1.0.0. It is still recommended to use the new API and not to rely on the legacy API. This option will be removed with PyPSA 2.0.0.
         params.statistics.drop_zero:
             Default: True
             Description: Default value for the 'drop_zero' parameter in statistics module.
@@ -235,7 +238,7 @@ class OptionsNode:
             Description: Default value for the 'round' parameter in statistics module.
         warnings.components_store_iter:
             Default: True
-            Description: Some Description
+            Description: If False, suppresses the deprecatio warning when iterating over components.
 
         """
         if not prefix:
@@ -266,6 +269,9 @@ class OptionsNode:
         >>> pypsa.options.describe() # doctest: +ELLIPSIS
         PyPSA Options
         =============
+        api.legacy_components:
+            Default: True
+            Description: WARNING: Experimental feature. Not all PyPSA functionality is supported yet. Use legacy components API for backwards compatibility to PyPSA versions prior to 1.0.0. It is still recommended to use the new API and not to rely on the legacy API. This option will be removed with PyPSA 2.0.0.
         params.statistics.drop_zero:
             Default: True
             Description: Default value for the 'drop_zero' parameter in statistics module.
@@ -277,7 +283,7 @@ class OptionsNode:
             Description: Default value for the 'round' parameter in statistics module.
         warnings.components_store_iter:
             Default: True
-            Description: Some Description
+            Description: If False, suppresses the deprecatio warning when iterating over components.
 
         """
         self.describe_options()
@@ -325,8 +331,22 @@ def option_context(*args: Any) -> Generator[None, None, None]:
 # Setup default options
 # =====================
 
+# API
+options._add_option(
+    "api.legacy_components",
+    True,
+    "WARNING: Experimental feature. Not all PyPSA functionality is supported yet. "
+    "Use legacy components API for backwards compatibility to PyPSA versions prior to "
+    "1.0.0. It is still recommended to use the new API and not to rely on the legacy "
+    "API. This option will be removed with PyPSA 2.0.0.",
+)
+
 # Warnings category
-options._add_option("warnings.components_store_iter", True, "Some Description")
+options._add_option(
+    "warnings.components_store_iter",
+    True,
+    "If False, suppresses the deprecatio warning when iterating over components. ",
+)
 
 # Parameters category
 options._add_option(

--- a/pypsa/components/abstract.py
+++ b/pypsa/components/abstract.py
@@ -15,13 +15,14 @@ if TYPE_CHECKING:
 
     from pypsa import Network
     from pypsa.components.types import ComponentType
+    from pypsa.definitions.structures import Dict
 
 
 class _ComponentsABC(ABC):
     ctype: ComponentType
     n: Network | None
     static: pd.DataFrame
-    dynamic: dict
+    dynamic: Dict
 
     @property
     @abstractmethod

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -68,7 +68,7 @@ class ComponentsData:
     ctype: ComponentType
     n: Network | None
     static: pd.DataFrame
-    dynamic: dict
+    dynamic: Dict
 
 
 class Components(

--- a/pypsa/components/transform.py
+++ b/pypsa/components/transform.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
     import pandas as pd
 
+    from pypsa.definitions.structures import Dict
+
 logger = logging.getLogger(__name__)
 
 
@@ -28,7 +30,7 @@ class _ComponentsTransform:
     """
 
     static: pd.DataFrame
-    dynamic: dict[str, pd.DataFrame]
+    dynamic: Dict
     attached: Any
     n_save: Any
     name: Any

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -1732,7 +1732,7 @@ def _import_components_from_df(
     for attr in [attr for attr in df if attr.startswith("bus")]:
         # allow empty buses for multi-ports
         port = int(attr[-1]) if attr[-1].isdigit() else 0
-        mask = ~df[attr].isin(n.components.buses.static.index)  # type: ignore
+        mask = ~df[attr].isin(n.components.buses.static.index)
         if port > 1:
             mask &= df[attr].ne("")
         missing = df.index[mask]

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -1732,7 +1732,7 @@ def _import_components_from_df(
     for attr in [attr for attr in df if attr.startswith("bus")]:
         # allow empty buses for multi-ports
         port = int(attr[-1]) if attr[-1].isdigit() else 0
-        mask = ~df[attr].isin(n.buses.index)  # type: ignore
+        mask = ~df[attr].isin(n.components.buses.static.index)  # type: ignore
         if port > 1:
             mask &= df[attr].ne("")
         missing = df.index[mask]
@@ -1772,7 +1772,7 @@ def _import_components_from_df(
     new_static = _sort_attrs(new_static, attrs.index, axis=1)
 
     new_static.index.name = cls_name
-    setattr(n, n.components[cls_name]["list_name"], new_static)
+    n.components[cls_name].static = new_static
 
     # Now deal with time-dependent properties
 
@@ -1789,7 +1789,7 @@ def _import_components_from_df(
             new_components = df.index.difference(duplicated_components)
             dynamic[k].loc[:, new_components] = df.loc[new_components, k].values
 
-    setattr(n, n.components[cls_name]["list_name"] + "_t", dynamic)
+    n.components[cls_name].dynamic = dynamic
 
 
 def _import_series_from_df(

--- a/pypsa/network/abstract.py
+++ b/pypsa/network/abstract.py
@@ -26,4 +26,5 @@ class _NetworkABC(ABC):
     static: pd.DataFrame
     dynamic: Callable
     components: ComponentsStore
+    c: ComponentsStore
     _import_series_from_df: Callable

--- a/pypsa/network/components.py
+++ b/pypsa/network/components.py
@@ -17,34 +17,22 @@ pypsa.network.index
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pypsa.network.abstract import _NetworkABC
 
 if TYPE_CHECKING:
-    from pypsa.components._types import (
-        Buses,
-        Carriers,
-        Generators,
-        GlobalConstraints,
-        Lines,
-        LineTypes,
-        Links,
-        Loads,
-        Shapes,
-        ShuntImpedances,
-        StorageUnits,
-        Stores,
-        SubNetworks,
-        Transformers,
-        TransformerTypes,
-    )
+    import pandas as pd
+
+    from pypsa.definitions.structures import Dict
+
 from pypsa._options import options
 
 logger = logging.getLogger(__name__)
 
 # TODO Change to UserWarning when they are all resolved and raised
-
+# TODO Change types back to class with release. With legacy API type hints
+# will be unsupported.
 
 _STATIC_SETTER_WARNING = (
     "You are overwriting the network components with a new object. This is "
@@ -73,7 +61,7 @@ class _NetworkComponents(_NetworkABC):
     """
 
     @property
-    def sub_networks(self) -> SubNetworks:
+    def sub_networks(self) -> Any:
         return (
             self.c.sub_networks.static
             if options.api.legacy_components
@@ -81,71 +69,71 @@ class _NetworkComponents(_NetworkABC):
         )
 
     @sub_networks.setter
-    def sub_networks(self, value: SubNetworks) -> None:
+    def sub_networks(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.sub_networks.static = value
 
     @property
-    def sub_networks_t(self) -> None:
+    def sub_networks_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("sub_networks"))
         return self.c.sub_networks.dynamic
 
     @sub_networks_t.setter
-    def sub_networks_t(self, value: None) -> None:
+    def sub_networks_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("sub_networks"))
         self.c.sub_networks.dynamic = value
 
     @property
-    def buses(self) -> Buses:
+    def buses(self) -> Any:
         return self.c.buses.static if options.api.legacy_components else self.c.buses
 
     @buses.setter
-    def buses(self, value: Buses) -> None:
+    def buses(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.buses.static = value
 
     @property
-    def buses_t(self) -> None:
+    def buses_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("buses"))
         return self.c.buses.dynamic
 
     @buses_t.setter
-    def buses_t(self, value: None) -> None:
+    def buses_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("buses"))
         self.c.buses.dynamic = value
 
     @property
-    def carriers(self) -> Carriers:
+    def carriers(self) -> Any:
         return (
             self.c.carriers.static if options.api.legacy_components else self.c.carriers
         )
 
     @carriers.setter
-    def carriers(self, value: Carriers) -> None:
+    def carriers(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.carriers.static = value
 
     @property
-    def carriers_t(self) -> None:
+    def carriers_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("carriers"))
         return self.c.carriers.dynamic
 
     @carriers_t.setter
-    def carriers_t(self, value: None) -> None:
+    def carriers_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("carriers"))
         self.c.carriers.dynamic = value
 
     @property
-    def global_constraints(self) -> GlobalConstraints:
+    def global_constraints(self) -> Any:
         return (
             self.c.global_constraints.static
             if options.api.legacy_components
@@ -153,13 +141,13 @@ class _NetworkComponents(_NetworkABC):
         )
 
     @global_constraints.setter
-    def global_constraints(self, value: GlobalConstraints) -> None:
+    def global_constraints(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.global_constraints.static = value
 
     @property
-    def global_constraints_t(self) -> None:
+    def global_constraints_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(
                 _DYNAMIC_GETTER_WARNING.format("global_constraints")
@@ -167,7 +155,7 @@ class _NetworkComponents(_NetworkABC):
         return self.c.global_constraints.dynamic
 
     @global_constraints_t.setter
-    def global_constraints_t(self, value: None) -> None:
+    def global_constraints_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(
                 _DYNAMIC_SETTER_WARNING.format("global_constraints")
@@ -175,29 +163,29 @@ class _NetworkComponents(_NetworkABC):
         self.c.global_constraints.dynamic = value
 
     @property
-    def lines(self) -> Lines:
+    def lines(self) -> Any:
         return self.c.lines.static if options.api.legacy_components else self.c.lines
 
     @lines.setter
-    def lines(self, value: Lines) -> None:
+    def lines(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.lines.static = value
 
     @property
-    def lines_t(self) -> None:
+    def lines_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("lines"))
         return self.c.lines.dynamic
 
     @lines_t.setter
-    def lines_t(self, value: None) -> None:
+    def lines_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("lines"))
         self.c.lines.dynamic = value
 
     @property
-    def line_types(self) -> LineTypes:
+    def line_types(self) -> Any:
         return (
             self.c.line_types.static
             if options.api.legacy_components
@@ -205,25 +193,25 @@ class _NetworkComponents(_NetworkABC):
         )
 
     @line_types.setter
-    def line_types(self, value: LineTypes) -> None:
+    def line_types(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.line_types.static = value
 
     @property
-    def line_types_t(self) -> None:
+    def line_types_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("line_types"))
         return self.c.line_types.dynamic
 
     @line_types_t.setter
-    def line_types_t(self, value: None) -> None:
+    def line_types_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("line_types"))
         self.c.line_types.dynamic = value
 
     @property
-    def transformers(self) -> Transformers:
+    def transformers(self) -> Any:
         return (
             self.c.transformers.static
             if options.api.legacy_components
@@ -231,25 +219,25 @@ class _NetworkComponents(_NetworkABC):
         )
 
     @transformers.setter
-    def transformers(self, value: Transformers) -> None:
+    def transformers(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.transformers.static = value
 
     @property
-    def transformers_t(self) -> None:
+    def transformers_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("transformers"))
         return self.c.transformers.dynamic
 
     @transformers_t.setter
-    def transformers_t(self, value: None) -> None:
+    def transformers_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("transformers"))
         self.c.transformers.dynamic = value
 
     @property
-    def transformer_types(self) -> TransformerTypes:
+    def transformer_types(self) -> Any:
         return (
             self.c.transformer_types.static
             if options.api.legacy_components
@@ -257,13 +245,13 @@ class _NetworkComponents(_NetworkABC):
         )
 
     @transformer_types.setter
-    def transformer_types(self, value: TransformerTypes) -> None:
+    def transformer_types(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.transformer_types.static = value
 
     @property
-    def transformer_types_t(self) -> None:
+    def transformer_types_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(
                 _DYNAMIC_GETTER_WARNING.format("transformer_types")
@@ -271,7 +259,7 @@ class _NetworkComponents(_NetworkABC):
         return self.c.transformer_types.dynamic
 
     @transformer_types_t.setter
-    def transformer_types_t(self, value: None) -> None:
+    def transformer_types_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(
                 _DYNAMIC_SETTER_WARNING.format("transformer_types")
@@ -279,51 +267,51 @@ class _NetworkComponents(_NetworkABC):
         self.c.transformer_types.dynamic = value
 
     @property
-    def links(self) -> Links:
+    def links(self) -> Any:
         return self.c.links.static if options.api.legacy_components else self.c.links
 
     @links.setter
-    def links(self, value: Links) -> None:
+    def links(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.links.static = value
 
     @property
-    def links_t(self) -> None:
+    def links_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("links"))
         return self.c.links.dynamic
 
     @links_t.setter
-    def links_t(self, value: None) -> None:
+    def links_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("links"))
         self.c.links.dynamic = value
 
     @property
-    def loads(self) -> Loads:
+    def loads(self) -> Any:
         return self.c.loads.static if options.api.legacy_components else self.c.loads
 
     @loads.setter
-    def loads(self, value: Loads) -> None:
+    def loads(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.loads.static = value
 
     @property
-    def loads_t(self) -> None:
+    def loads_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("loads"))
         return self.c.loads.dynamic
 
     @loads_t.setter
-    def loads_t(self, value: None) -> None:
+    def loads_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("loads"))
         self.c.loads.dynamic = value
 
     @property
-    def generators(self) -> Generators:
+    def generators(self) -> Any:
         return (
             self.c.generators.static
             if options.api.legacy_components
@@ -331,25 +319,25 @@ class _NetworkComponents(_NetworkABC):
         )
 
     @generators.setter
-    def generators(self, value: Generators) -> None:
+    def generators(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.generators.static = value
 
     @property
-    def generators_t(self) -> None:
+    def generators_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("generators"))
         return self.c.generators.dynamic
 
     @generators_t.setter
-    def generators_t(self, value: None) -> None:
+    def generators_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("generators"))
         self.c.generators.dynamic = value
 
     @property
-    def storage_units(self) -> StorageUnits:
+    def storage_units(self) -> Any:
         return (
             self.c.storage_units.static
             if options.api.legacy_components
@@ -357,47 +345,47 @@ class _NetworkComponents(_NetworkABC):
         )
 
     @storage_units.setter
-    def storage_units(self, value: StorageUnits) -> None:
+    def storage_units(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.storage_units.static = value
 
     @property
-    def storage_units_t(self) -> None:
+    def storage_units_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("storage_units"))
         return self.c.storage_units.dynamic
 
     @storage_units_t.setter
-    def storage_units_t(self, value: None) -> None:
+    def storage_units_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("storage_units"))
         self.c.storage_units.dynamic = value
 
     @property
-    def stores(self) -> Stores:
+    def stores(self) -> Any:
         return self.c.stores.static if options.api.legacy_components else self.c.stores
 
     @stores.setter
-    def stores(self, value: Stores) -> None:
+    def stores(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.stores.static = value
 
     @property
-    def stores_t(self) -> None:
+    def stores_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("stores"))
         return self.c.stores.dynamic
 
     @stores_t.setter
-    def stores_t(self, value: None) -> None:
+    def stores_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("stores"))
         self.c.stores.dynamic = value
 
     @property
-    def shunt_impedances(self) -> ShuntImpedances:
+    def shunt_impedances(self) -> Any:
         return (
             self.c.shunt_impedances.static
             if options.api.legacy_components
@@ -405,41 +393,41 @@ class _NetworkComponents(_NetworkABC):
         )
 
     @shunt_impedances.setter
-    def shunt_impedances(self, value: ShuntImpedances) -> None:
+    def shunt_impedances(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.shunt_impedances.static = value
 
     @property
-    def shunt_impedances_t(self) -> None:
+    def shunt_impedances_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("shunt_impedances"))
         return self.c.shunt_impedances.dynamic
 
     @shunt_impedances_t.setter
-    def shunt_impedances_t(self, value: None) -> None:
+    def shunt_impedances_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("shunt_impedances"))
         self.c.shunt_impedances.dynamic = value
 
     @property
-    def shapes(self) -> Shapes:
+    def shapes(self) -> Any:
         return self.c.shapes.static if options.api.legacy_components else self.c.shapes
 
     @shapes.setter
-    def shapes(self, value: Shapes) -> None:
+    def shapes(self, value: pd.DataFrame) -> None:
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.shapes.static = value
 
     @property
-    def shapes_t(self) -> None:
+    def shapes_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("shapes"))
         return self.c.shapes.dynamic
 
     @shapes_t.setter
-    def shapes_t(self, value: None) -> None:
+    def shapes_t(self, value: Dict) -> None:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("shapes"))
         self.c.shapes.dynamic = value

--- a/pypsa/network/components.py
+++ b/pypsa/network/components.py
@@ -66,13 +66,12 @@ class _NetworkComponents(_NetworkABC):
     @sub_networks.setter
     def sub_networks(self, value: SubNetworks) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `sub_networks` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
+            msg = (
+                "You are overwriting the network components with a new object. This is "
+                "not supported, since it may lead to unexpected behavior. See #TODO. "
+                "for more information."
             )
+            raise ValueError(msg)
         self.c.sub_networks.static = value
 
     @property
@@ -85,6 +84,17 @@ class _NetworkComponents(_NetworkABC):
             )
             raise DeprecationWarning(msg)
         return self.c.sub_networks.dynamic
+
+    @sub_networks_t.setter
+    def sub_networks_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. `n.sub_networks_t` is deprecated and "
+                "cannot be set."
+            )
+            raise ValueError(msg)
+        self.c.sub_networks.dynamic = value
 
     @property
     def buses(self) -> Buses:

--- a/pypsa/network/components.py
+++ b/pypsa/network/components.py
@@ -17,7 +17,6 @@ pypsa.network.index
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import TYPE_CHECKING
 
 from pypsa.network.abstract import _NetworkABC
@@ -45,7 +44,25 @@ from pypsa._options import options
 logger = logging.getLogger(__name__)
 
 # TODO Change to UserWarning when they are all resolved and raised
-# TODO Handle setters
+
+
+_STATIC_SETTER_WARNING = (
+    "You are overwriting the network components with a new object. This is "
+    "not supported, since it may lead to unexpected behavior. See #TODO. "
+    "for more information."
+)
+
+_DYNAMIC_GETTER_WARNING = (
+    "With PyPSA 1.0, the API for how to access components data has changed. "
+    "See #TODO for more information. Use `n.{0}.dynamic` as a "
+    "drop-in replacement for `n.{0}_t`."
+)
+
+_DYNAMIC_SETTER_WARNING = (
+    "With PyPSA 1.0, the API for how to access components data has changed. "
+    "See #TODO for more information. `n.{0}_t` is deprecated and "
+    "cannot be set."
+)
 
 
 class _NetworkComponents(_NetworkABC):
@@ -66,34 +83,19 @@ class _NetworkComponents(_NetworkABC):
     @sub_networks.setter
     def sub_networks(self, value: SubNetworks) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "You are overwriting the network components with a new object. This is "
-                "not supported, since it may lead to unexpected behavior. See #TODO. "
-                "for more information."
-            )
-            raise ValueError(msg)
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.sub_networks.static = value
 
     @property
     def sub_networks_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.sub_networks.dynamic` as a "
-                "drop-in replacement for `n.sub_networks_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("sub_networks"))
         return self.c.sub_networks.dynamic
 
     @sub_networks_t.setter
     def sub_networks_t(self, value: None) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. `n.sub_networks_t` is deprecated and "
-                "cannot be set."
-            )
-            raise ValueError(msg)
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("sub_networks"))
         self.c.sub_networks.dynamic = value
 
     @property
@@ -103,25 +105,20 @@ class _NetworkComponents(_NetworkABC):
     @buses.setter
     def buses(self, value: Buses) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `buses` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.buses.static = value
 
     @property
     def buses_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.buses.dynamic` as a "
-                "drop-in replacement for `n.buses_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("buses"))
         return self.c.buses.dynamic
+
+    @buses_t.setter
+    def buses_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("buses"))
+        self.c.buses.dynamic = value
 
     @property
     def carriers(self) -> Carriers:
@@ -132,25 +129,20 @@ class _NetworkComponents(_NetworkABC):
     @carriers.setter
     def carriers(self, value: Carriers) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `carriers` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.carriers.static = value
 
     @property
     def carriers_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.carriers.dynamic` as a "
-                "drop-in replacement for `n.carrier_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("carriers"))
         return self.c.carriers.dynamic
+
+    @carriers_t.setter
+    def carriers_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("carriers"))
+        self.c.carriers.dynamic = value
 
     @property
     def global_constraints(self) -> GlobalConstraints:
@@ -163,25 +155,24 @@ class _NetworkComponents(_NetworkABC):
     @global_constraints.setter
     def global_constraints(self, value: GlobalConstraints) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `global_constraints` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.global_constraints.static = value
 
     @property
     def global_constraints_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.global_constraints.dynamic` as a "
-                "drop-in replacement for `n.global_constraint_t`."
+            raise DeprecationWarning(
+                _DYNAMIC_GETTER_WARNING.format("global_constraints")
             )
-            raise DeprecationWarning(msg)
         return self.c.global_constraints.dynamic
+
+    @global_constraints_t.setter
+    def global_constraints_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(
+                _DYNAMIC_SETTER_WARNING.format("global_constraints")
+            )
+        self.c.global_constraints.dynamic = value
 
     @property
     def lines(self) -> Lines:
@@ -190,25 +181,20 @@ class _NetworkComponents(_NetworkABC):
     @lines.setter
     def lines(self, value: Lines) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `lines` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.lines.static = value
 
     @property
     def lines_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.lines.dynamic` as a "
-                "drop-in replacement for `n.lines_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("lines"))
         return self.c.lines.dynamic
+
+    @lines_t.setter
+    def lines_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("lines"))
+        self.c.lines.dynamic = value
 
     @property
     def line_types(self) -> LineTypes:
@@ -221,25 +207,20 @@ class _NetworkComponents(_NetworkABC):
     @line_types.setter
     def line_types(self, value: LineTypes) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `line_types` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.line_types.static = value
 
     @property
     def line_types_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.line_types.dynamic` as a "
-                "drop-in replacement for `n.line_types_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("line_types"))
         return self.c.line_types.dynamic
+
+    @line_types_t.setter
+    def line_types_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("line_types"))
+        self.c.line_types.dynamic = value
 
     @property
     def transformers(self) -> Transformers:
@@ -252,25 +233,20 @@ class _NetworkComponents(_NetworkABC):
     @transformers.setter
     def transformers(self, value: Transformers) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `transformers` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.transformers.static = value
 
     @property
     def transformers_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.transformers.dynamic` as a "
-                "drop-in replacement for `n.transformers_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("transformers"))
         return self.c.transformers.dynamic
+
+    @transformers_t.setter
+    def transformers_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("transformers"))
+        self.c.transformers.dynamic = value
 
     @property
     def transformer_types(self) -> TransformerTypes:
@@ -283,25 +259,24 @@ class _NetworkComponents(_NetworkABC):
     @transformer_types.setter
     def transformer_types(self, value: TransformerTypes) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `transformer_types` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.transformer_types.static = value
 
     @property
     def transformer_types_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.transformer_types.dynamic` as a "
-                "drop-in replacement for `n.transformer_types_t`."
+            raise DeprecationWarning(
+                _DYNAMIC_GETTER_WARNING.format("transformer_types")
             )
-            raise DeprecationWarning(msg)
         return self.c.transformer_types.dynamic
+
+    @transformer_types_t.setter
+    def transformer_types_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(
+                _DYNAMIC_SETTER_WARNING.format("transformer_types")
+            )
+        self.c.transformer_types.dynamic = value
 
     @property
     def links(self) -> Links:
@@ -310,25 +285,20 @@ class _NetworkComponents(_NetworkABC):
     @links.setter
     def links(self, value: Links) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `links` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.links.static = value
 
     @property
     def links_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.links.dynamic` as a "
-                "drop-in replacement for `n.links_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("links"))
         return self.c.links.dynamic
+
+    @links_t.setter
+    def links_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("links"))
+        self.c.links.dynamic = value
 
     @property
     def loads(self) -> Loads:
@@ -337,25 +307,20 @@ class _NetworkComponents(_NetworkABC):
     @loads.setter
     def loads(self, value: Loads) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `loads` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.loads.static = value
 
     @property
     def loads_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.loads.dynamic` as a "
-                "drop-in replacement for `n.loads_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("loads"))
         return self.c.loads.dynamic
+
+    @loads_t.setter
+    def loads_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("loads"))
+        self.c.loads.dynamic = value
 
     @property
     def generators(self) -> Generators:
@@ -368,25 +333,20 @@ class _NetworkComponents(_NetworkABC):
     @generators.setter
     def generators(self, value: Generators) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `generators` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.generators.static = value
 
     @property
     def generators_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.generators.dynamic` as a "
-                "drop-in replacement for `n.generators_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("generators"))
         return self.c.generators.dynamic
+
+    @generators_t.setter
+    def generators_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("generators"))
+        self.c.generators.dynamic = value
 
     @property
     def storage_units(self) -> StorageUnits:
@@ -399,25 +359,20 @@ class _NetworkComponents(_NetworkABC):
     @storage_units.setter
     def storage_units(self, value: StorageUnits) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `storage_units` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.storage_units.static = value
 
     @property
     def storage_units_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.storage_units.dynamic` as a "
-                "drop-in replacement for `n.storage_units_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("storage_units"))
         return self.c.storage_units.dynamic
+
+    @storage_units_t.setter
+    def storage_units_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("storage_units"))
+        self.c.storage_units.dynamic = value
 
     @property
     def stores(self) -> Stores:
@@ -426,25 +381,20 @@ class _NetworkComponents(_NetworkABC):
     @stores.setter
     def stores(self, value: Stores) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `stores` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.stores.static = value
 
     @property
     def stores_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.stores.dynamic` as a "
-                "drop-in replacement for `n.stores_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("stores"))
         return self.c.stores.dynamic
+
+    @stores_t.setter
+    def stores_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("stores"))
+        self.c.stores.dynamic = value
 
     @property
     def shunt_impedances(self) -> ShuntImpedances:
@@ -457,25 +407,20 @@ class _NetworkComponents(_NetworkABC):
     @shunt_impedances.setter
     def shunt_impedances(self, value: ShuntImpedances) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `shunt_impedances` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.shunt_impedances.static = value
 
     @property
     def shunt_impedances_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.shunt_impedances.dynamic` as a "
-                "drop-in replacement for `n.shunt_impedances_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("shunt_impedances"))
         return self.c.shunt_impedances.dynamic
+
+    @shunt_impedances_t.setter
+    def shunt_impedances_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("shunt_impedances"))
+        self.c.shunt_impedances.dynamic = value
 
     @property
     def shapes(self) -> Shapes:
@@ -484,22 +429,17 @@ class _NetworkComponents(_NetworkABC):
     @shapes.setter
     def shapes(self, value: Shapes) -> None:
         if not options.api.legacy_components:
-            warnings.warn(
-                "You are setting the `shapes` attribute directly. This is not "
-                "recommended, since it may lead to unexpected behavior. See #TODO for "
-                "more information.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.shapes.static = value
 
     @property
     def shapes_t(self) -> None:
         if not options.api.legacy_components:
-            msg = (
-                "With PyPSA 1.0, the API for how to access components data has changed. "
-                "See #TODO for more information. Use `n.shapes.dynamic` as a "
-                "drop-in replacement for `n.shapes_t`."
-            )
-            raise DeprecationWarning(msg)
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("shapes"))
         return self.c.shapes.dynamic
+
+    @shapes_t.setter
+    def shapes_t(self, value: None) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("shapes"))
+        self.c.shapes.dynamic = value

--- a/pypsa/network/components.py
+++ b/pypsa/network/components.py
@@ -1,0 +1,495 @@
+"""
+Network components module.
+
+Contains single helper class (_NetworkComponents) which is used to inherit
+to Network class. Should not be used directly.
+
+Adds all properties and access methods to the Components of a network. `n.components`
+is already defined during the Network initialization and here just the access properties
+are set.
+
+Also See
+--------
+pypsa.network.index
+
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import TYPE_CHECKING
+
+from pypsa.network.abstract import _NetworkABC
+
+if TYPE_CHECKING:
+    from pypsa.components._types import (
+        Buses,
+        Carriers,
+        Generators,
+        GlobalConstraints,
+        Lines,
+        LineTypes,
+        Links,
+        Loads,
+        Shapes,
+        ShuntImpedances,
+        StorageUnits,
+        Stores,
+        SubNetworks,
+        Transformers,
+        TransformerTypes,
+    )
+from pypsa._options import options
+
+logger = logging.getLogger(__name__)
+
+# TODO Change to UserWarning when they are all resolved and raised
+# TODO Handle setters
+
+
+class _NetworkComponents(_NetworkABC):
+    """
+    Helper class for components array methods.
+
+    Class only inherits to Components and should not be used directly.
+    """
+
+    @property
+    def sub_networks(self) -> SubNetworks:
+        return (
+            self.c.sub_networks.static
+            if options.api.legacy_components
+            else self.c.subnetworks
+        )
+
+    @sub_networks.setter
+    def sub_networks(self, value: SubNetworks) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `sub_networks` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.sub_networks.static = value
+
+    @property
+    def sub_networks_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.sub_networks.dynamic` as a "
+                "drop-in replacement for `n.sub_networks_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.sub_networks.dynamic
+
+    @property
+    def buses(self) -> Buses:
+        return self.c.buses.static if options.api.legacy_components else self.c.buses
+
+    @buses.setter
+    def buses(self, value: Buses) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `buses` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.buses.static = value
+
+    @property
+    def buses_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.buses.dynamic` as a "
+                "drop-in replacement for `n.buses_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.buses.dynamic
+
+    @property
+    def carriers(self) -> Carriers:
+        return (
+            self.c.carriers.static if options.api.legacy_components else self.c.carriers
+        )
+
+    @carriers.setter
+    def carriers(self, value: Carriers) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `carriers` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.carriers.static = value
+
+    @property
+    def carriers_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.carriers.dynamic` as a "
+                "drop-in replacement for `n.carrier_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.carriers.dynamic
+
+    @property
+    def global_constraints(self) -> GlobalConstraints:
+        return (
+            self.c.global_constraints.static
+            if options.api.legacy_components
+            else self.c.global_constraints
+        )
+
+    @global_constraints.setter
+    def global_constraints(self, value: GlobalConstraints) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `global_constraints` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.global_constraints.static = value
+
+    @property
+    def global_constraints_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.global_constraints.dynamic` as a "
+                "drop-in replacement for `n.global_constraint_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.global_constraints.dynamic
+
+    @property
+    def lines(self) -> Lines:
+        return self.c.lines.static if options.api.legacy_components else self.c.lines
+
+    @lines.setter
+    def lines(self, value: Lines) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `lines` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.lines.static = value
+
+    @property
+    def lines_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.lines.dynamic` as a "
+                "drop-in replacement for `n.lines_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.lines.dynamic
+
+    @property
+    def line_types(self) -> LineTypes:
+        return (
+            self.c.line_types.static
+            if options.api.legacy_components
+            else self.c.line_types
+        )
+
+    @line_types.setter
+    def line_types(self, value: LineTypes) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `line_types` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.line_types.static = value
+
+    @property
+    def line_types_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.line_types.dynamic` as a "
+                "drop-in replacement for `n.line_types_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.line_types.dynamic
+
+    @property
+    def transformers(self) -> Transformers:
+        return (
+            self.c.transformers.static
+            if options.api.legacy_components
+            else self.c.transformers
+        )
+
+    @transformers.setter
+    def transformers(self, value: Transformers) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `transformers` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.transformers.static = value
+
+    @property
+    def transformers_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.transformers.dynamic` as a "
+                "drop-in replacement for `n.transformers_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.transformers.dynamic
+
+    @property
+    def transformer_types(self) -> TransformerTypes:
+        return (
+            self.c.transformer_types.static
+            if options.api.legacy_components
+            else self.c.transformer_types
+        )
+
+    @transformer_types.setter
+    def transformer_types(self, value: TransformerTypes) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `transformer_types` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.transformer_types.static = value
+
+    @property
+    def transformer_types_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.transformer_types.dynamic` as a "
+                "drop-in replacement for `n.transformer_types_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.transformer_types.dynamic
+
+    @property
+    def links(self) -> Links:
+        return self.c.links.static if options.api.legacy_components else self.c.links
+
+    @links.setter
+    def links(self, value: Links) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `links` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.links.static = value
+
+    @property
+    def links_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.links.dynamic` as a "
+                "drop-in replacement for `n.links_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.links.dynamic
+
+    @property
+    def loads(self) -> Loads:
+        return self.c.loads.static if options.api.legacy_components else self.c.loads
+
+    @loads.setter
+    def loads(self, value: Loads) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `loads` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.loads.static = value
+
+    @property
+    def loads_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.loads.dynamic` as a "
+                "drop-in replacement for `n.loads_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.loads.dynamic
+
+    @property
+    def generators(self) -> Generators:
+        return (
+            self.c.generators.static
+            if options.api.legacy_components
+            else self.c.generators
+        )
+
+    @generators.setter
+    def generators(self, value: Generators) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `generators` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.generators.static = value
+
+    @property
+    def generators_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.generators.dynamic` as a "
+                "drop-in replacement for `n.generators_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.generators.dynamic
+
+    @property
+    def storage_units(self) -> StorageUnits:
+        return (
+            self.c.storage_units.static
+            if options.api.legacy_components
+            else self.c.storage_units
+        )
+
+    @storage_units.setter
+    def storage_units(self, value: StorageUnits) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `storage_units` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.storage_units.static = value
+
+    @property
+    def storage_units_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.storage_units.dynamic` as a "
+                "drop-in replacement for `n.storage_units_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.storage_units.dynamic
+
+    @property
+    def stores(self) -> Stores:
+        return self.c.stores.static if options.api.legacy_components else self.c.stores
+
+    @stores.setter
+    def stores(self, value: Stores) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `stores` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.stores.static = value
+
+    @property
+    def stores_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.stores.dynamic` as a "
+                "drop-in replacement for `n.stores_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.stores.dynamic
+
+    @property
+    def shunt_impedances(self) -> ShuntImpedances:
+        return (
+            self.c.shunt_impedances.static
+            if options.api.legacy_components
+            else self.c.shunt_impedances
+        )
+
+    @shunt_impedances.setter
+    def shunt_impedances(self, value: ShuntImpedances) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `shunt_impedances` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.shunt_impedances.static = value
+
+    @property
+    def shunt_impedances_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.shunt_impedances.dynamic` as a "
+                "drop-in replacement for `n.shunt_impedances_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.shunt_impedances.dynamic
+
+    @property
+    def shapes(self) -> Shapes:
+        return self.c.shapes.static if options.api.legacy_components else self.c.shapes
+
+    @shapes.setter
+    def shapes(self, value: Shapes) -> None:
+        if not options.api.legacy_components:
+            warnings.warn(
+                "You are setting the `shapes` attribute directly. This is not "
+                "recommended, since it may lead to unexpected behavior. See #TODO for "
+                "more information.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.c.shapes.static = value
+
+    @property
+    def shapes_t(self) -> None:
+        if not options.api.legacy_components:
+            msg = (
+                "With PyPSA 1.0, the API for how to access components data has changed. "
+                "See #TODO for more information. Use `n.shapes.dynamic` as a "
+                "drop-in replacement for `n.shapes_t`."
+            )
+            raise DeprecationWarning(msg)
+        return self.c.shapes.dynamic

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -531,6 +531,11 @@ class Network(_NetworkTransform, _NetworkIndex, _NetworkComponents):
         """
         return self.components
 
+    # TODO Disallow setter
+    @c.setter
+    def c(self, value: ComponentsStore) -> None:
+        self.components = value
+
     @deprecated_in_next_major(
         details="Use `self.components.<component>.dynamic` instead."
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,6 +9,29 @@ from shapely.geometry import Polygon
 import pypsa
 from pypsa.constants import DEFAULT_EPSG
 
+COMPONENT_NAMES = [
+    "sub_networks",
+    "buses",
+    "carriers",
+    "global_constraints",
+    "lines",
+    "line_types",
+    "transformers",
+    "transformer_types",
+    "links",
+    "loads",
+    "generators",
+    "storage_units",
+    "stores",
+    "shunt_impedances",
+    "shapes",
+]
+
+
+@pytest.fixture(params=COMPONENT_NAMES)
+def component_name(request):
+    return request.param
+
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -508,8 +508,6 @@ def test_api_components_legacy(legacy_components):
     """
     Test the API of the components module.
     """
-    import pypsa
-
     with pypsa.option_context("api.legacy_components", legacy_components):
         n = pypsa.examples.ac_dc_meshed()
 
@@ -530,3 +528,28 @@ def test_api_components_legacy(legacy_components):
             assert n.generators is n.components.generators
             with pytest.raises(DeprecationWarning):
                 assert n.generators_t is n.components.generators.dynamic
+
+
+@pytest.mark.parametrize("legacy_components", [True, False])
+def test_api_legacy_components(component_name, legacy_components):
+    """
+    Test the API of the components module.
+    """
+
+    with pypsa.option_context("api.legacy_components", legacy_components):
+        n = pypsa.examples.ac_dc_meshed()
+        if legacy_components:
+            assert n.static(component_name) is n.c[component_name].static
+            assert n.dynamic(component_name) is n.c[component_name].dynamic
+
+            setattr(n, component_name, "test")
+            assert n.static(component_name) == "test"
+            setattr(n, f"{component_name}_t", "test")
+            assert n.dynamic(component_name) == "test"
+        else:
+            assert n.static(component_name) is n.c[component_name].static
+            assert n.dynamic(component_name) is n.c[component_name].dynamic
+            with pytest.raises(AttributeError):
+                setattr(n, component_name, "test")
+            with pytest.raises(DeprecationWarning):
+                setattr(n, f"{component_name}_t", "test")

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -501,3 +501,32 @@ def test_components_repr(ac_dc_network):
     n = pypsa.Network()
     assert repr(n).startswith("Empty Unnamed PyPSA Network")
     assert len(repr(n)) > len(str(n))
+
+
+@pytest.mark.parametrize("legacy_components", [True, False])
+def test_api_components_legacy(legacy_components):
+    """
+    Test the API of the components module.
+    """
+    import pypsa
+
+    with pypsa.option_context("api.legacy_components", legacy_components):
+        n = pypsa.examples.ac_dc_meshed()
+
+        if legacy_components:
+            assert n.buses is n.components.buses.static
+            assert n.buses_t is n.components.buses.dynamic
+            assert n.lines is n.components.lines.static
+            assert n.lines_t is n.components.lines.dynamic
+            assert n.generators is n.components.generators.static
+            assert n.generators_t is n.components.generators.dynamic
+        else:
+            assert n.buses is n.components.buses
+            with pytest.raises(DeprecationWarning):
+                assert n.buses_t is n.components.buses.dynamic
+            assert n.lines is n.components.lines
+            with pytest.raises(DeprecationWarning):
+                assert n.lines_t is n.components.lines.dynamic
+            assert n.generators is n.components.generators
+            with pytest.raises(DeprecationWarning):
+                assert n.generators_t is n.components.generators.dynamic


### PR DESCRIPTION
Closes #936 

## Changes proposed in this Pull Request
- Adds the option to turn on the proposed new API for `1.0`. 
- With `1.0`, I would switch the default with a link to a migration guide, but the option also allows for backwards compatibility without migration with `1.x`
- Also adds a bit of quality of life for docs, code completion etc.

When setting
``` python
pypsa.options.api.legacy_components = True
```
`n.generators`  (and `_t`) will yield the same as right now
``` python
>>> n.generators
                        bus control type    p_nom  p_nom_mod  p_nom_extendable  p_nom_min  p_nom_max  p_min_pu  p_max_pu  p_set  e_sum_min  ...  shut_down_cost  stand_by_cost  min_up_time min_down_time  up_time_before  down_time_before  ramp_limit_up  ramp_limit_down  ramp_limit_start_up  ramp_limit_shut_down  weight  p_nom_opt
Generator                                                                                                                                   ...                                                                                                                                                                                          
Manchester Wind  Manchester      PQ          80.0        0.0              True      100.0        inf       0.0       1.0    0.0       -inf  ...             0.0            0.0            0             0               1                 0            NaN              NaN                  1.0                   1.0     1.0        0.0
Manchester Gas   Manchester      PQ       50000.0        0.0              True        0.0        inf       0.0       1.0    0.0       -inf  ...             0.0            0.0            0             0               1                 0            NaN              NaN                  1.0                   1.0     1.0        0.0
Norway Wind          Norway      PQ         100.0        0.0              True      100.0        inf       0.0       1.0    0.0       -inf  ...             0.0            0.0            0             0               1                 0            NaN              NaN                  1.0                   1.0     1.0        0.0
Norway Gas           Norway      PQ       20000.0        0.0              True        0.0        inf       0.0       1.0    0.0       -inf  ...             0.0            0.0            0             0               1                 0            NaN              NaN                  1.0                   1.0     1.0        0.0
Frankfurt Wind    Frankfurt      PQ         110.0        0.0              True      100.0        inf       0.0       1.0    0.0       -inf  ...             0.0            0.0            0             0               1                 0            NaN              NaN                  1.0                   1.0     1.0        0.0
Frankfurt Gas     Frankfurt      PQ       80000.0        0.0              True        0.0        inf       0.0       1.0    0.0       -inf  ...             0.0            0.0            0             0               1                 0            NaN              NaN                  1.0                   1.0     1.0        0.0

[6 rows x 37 columns]
```

With
``` python
pypsa.options.api.legacy_components = False
```
you get the components class from `n.components.<components_name>` (where it sits right now). And then `n.generators.static` etc. to yield the same informations

``` python
>>> n.generators
'Generator' Components
----------------------
Attached to PyPSA Network 'AC-DC'
Components: 6
```

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] ~~A note for the release notes `doc/release_notes.rst` of the upcoming release is included.~~
- [x] I consent to the release of this PR's code under the MIT license.
