### PR TITLE
Fix: dynamic expressions for assigned model with subset of snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ dev
 .venv
 .aider*
 uv.lock
+.github/copilot-instructions.md

--- a/test/test_optimization_expressions.py
+++ b/test/test_optimization_expressions.py
@@ -34,6 +34,15 @@ def prepared_network(ac_dc_network):
     return n
 
 
+@pytest.fixture
+def prepared_network_with_snapshot_subset(ac_dc_network):
+    n = ac_dc_network.copy()
+    n.optimize.create_model(snapshots=n.snapshots[:2])
+    n.lines["carrier"] = n.lines.bus0.map(n.buses.carrier)
+    n.generators.loc[n.generators.index[0], "p_nom_extendable"] = False
+    return n
+
+
 # Test one static function for each groupby option and other options
 @pytest.mark.parametrize("groupby", GROUPER_PARAMETERS)
 def test_expressions_capacity(prepared_network, groupby):
@@ -83,6 +92,36 @@ def test_expressions_energy_balance(prepared_network, groupby, aggregate_time):
     )
     assert isinstance(expr, LinearExpression)
     assert expr.size > 0
+
+
+@pytest.mark.parametrize("aggregate_time", AGGREGRATE_TIME_PARAMETERS)
+@pytest.mark.parametrize("groupby", GROUPER_PARAMETERS)
+def test_expressions_energy_balance_with_snapshot_subset(
+    prepared_network_with_snapshot_subset, groupby, aggregate_time
+):
+    n = prepared_network_with_snapshot_subset
+    expr = n.optimize.expressions.energy_balance(
+        groupby=groupby, aggregate_time=aggregate_time
+    )
+    assert isinstance(expr, LinearExpression)
+    assert expr.size > 0
+
+
+def test_other_dynamic_expressions_with_snapshot_subset(
+    prepared_network_with_snapshot_subset,
+):
+    n = prepared_network_with_snapshot_subset
+    for expr_str in [
+        "opex",
+        "curtailment",
+        "operation",
+        "supply",
+        "withdrawal",
+        "transmission",
+    ]:
+        expr = getattr(n.optimize.expressions, expr_str)()
+        assert isinstance(expr, LinearExpression)
+        assert expr.size > 0
 
 
 @pytest.mark.parametrize("kwargs", KWARGS_PARAMETERS)


### PR DESCRIPTION
When trying to formulate dynamic expressions with the optimization module (energy_balance, opex, etc) on a network with a subset of snapshots in the model, we ran into errors. This fixes it.    


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] I consent to the release of this PR's code under the MIT license.
