### PR TITLE
deprecate/ refactor `descriptors.py` and more docstrings

### DIFF
--- a/pypsa/_options.py
+++ b/pypsa/_options.py
@@ -260,10 +260,6 @@ class OptionsNode:
 
         This is a convenience method to call describe_options() without a prefix.
 
-        Returns
-        -------
-        None
-
         Examples
         --------
         >>> pypsa.options.describe() # doctest: +ELLIPSIS
@@ -303,9 +299,6 @@ def option_context(*args: Any) -> Generator[None, None, None]:
         Must be passed in pairs of option_name and value.
         Option_name must be in the format "category.option_name" or "category.subcategory.option_name"
 
-    Returns
-    -------
-    None
 
     """
     if len(args) % 2 != 0:

--- a/pypsa/common.py
+++ b/pypsa/common.py
@@ -20,7 +20,7 @@ from pypsa.version import __version_semver__
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from pypsa.networks import Network
+    from pypsa.typing import NetworkType
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +153,7 @@ class MethodHandlerWrapper:
 
 
 def as_index(
-    n: Network, values: Any, network_attribute: str, force_subset: bool = True
+    n: NetworkType, values: Any, network_attribute: str, force_subset: bool = True
 ) -> pd.Index:
     """
     Returns a pd.Index object from a list-like or scalar object.
@@ -719,3 +719,13 @@ def resample_timeseries(
 
     # Combine the results
     return pd.concat([numeric_df, non_numeric_df], axis=1)[df.columns]
+
+
+def expand_series(ser: pd.Series, columns: Sequence[str]) -> pd.DataFrame:
+    """
+    Helper function to quickly expand a series to a dataframe.
+
+    Columns are the given series and every single column being the equal to
+    the given series.
+    """
+    return ser.to_frame(columns[0]).reindex(columns=columns).ffill(axis=1)

--- a/pypsa/components/__init__.py
+++ b/pypsa/components/__init__.py
@@ -15,6 +15,7 @@ from pypsa.components._types import (
     ShuntImpedances,
     StorageUnits,
     Stores,
+    SubNetworks,
     Transformers,
     TransformerTypes,
 )
@@ -44,6 +45,7 @@ __all__ = [
     "Links",
     "Loads",
     "Shapes",
+    "SubNetworks",
     "ShuntImpedances",
     "StorageUnits",
     "Stores",

--- a/pypsa/components/_types/_patch.py
+++ b/pypsa/components/_types/_patch.py
@@ -21,7 +21,7 @@ def create_docstring_parameters(component_name: str) -> str:
         "    Component attributes to add. See Additinal Parameters for list of default"
         "    attributes but any attribute could be added.\n"
         "\n"
-        "Additional Parameters\n"
+        "Other Parameters\n"
         "---------------------\n"
     )
     ct = get_component_type(component_name)

--- a/pypsa/components/_types/links.py
+++ b/pypsa/components/_types/links.py
@@ -46,3 +46,31 @@ class Links(Components):
             overwrite=overwrite,
             **kwargs,
         )
+
+    @property
+    def additional_ports(self) -> list[str]:
+        """
+        Identify additional link ports (bus connections) beyond predefined ones.
+
+        Parameters
+        ----------
+        n : pypsa.Network
+            Network instance.
+        where : iterable of strings, default None
+            Subset of columns to consider. Takes link columns by default.
+
+        Returns
+        -------
+        list of strings
+            List of additional link ports. E.g. ["2", "3"] for bus2, bus3.
+
+        Also see
+        ---------
+        pypsa.Components.ports
+
+        """
+        return [
+            i[3:]
+            for i in self.static.columns
+            if i.startswith("bus") and i not in ["bus0", "bus1"]
+        ]

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -49,19 +49,33 @@ class ComponentsData:
     """
     Dataclass for Components.
 
-    Dataclass to store all data of a Components object and used to separate data from
-    logic.
+    This class is used to store all data of a Components object. Other classes inherit
+    from this class to implement logic and methods, but do not store any data next
+    to the data in here.
+
+    All attributes can therefore also be accessed directly from
+    any [`Components`][pypsa.components.Components] object (which defines all
+    attributes and properties which are available for all component types) as well as
+    in specific type classes as [`Generators`][pypsa.components.Generators] (which
+    define logic and methods specific to the component type).
+
+    User Guide
+    ----------
+    Check out the corresponding user guide: [:material-bookshelf: Components](/user-guide/components)
 
     Attributes
     ----------
     ctype : ComponentType
-        Component type information containing all default values and attributes.
+        Component type information containing all default values and attributes. #TODO
     n : Network | None
-        Network object to which the component might be attached.
+        Network to which the component might be attached.
     static : pd.DataFrame
-        Static data of components.
+        Static data of components as a pandas DataFrame. Columns are the attributes
+        and the index is the component name.
     dynamic : dict
-        Dynamic data of components.
+        Dynamic (time-varying) data of components as a dict-like object of pandas
+        DataFrames. Keys of the dict are the attribute names and each value is a pandas
+        DataFrame with snapshots as index and the component names as columns.
 
     """
 
@@ -675,10 +689,6 @@ class SubNetworkComponents:
             Custom getter function to delegate attribute access to the wrapped data
             object and allow for custom attribute handling.
 
-        Returns
-        -------
-        None
-
         """
         self._wrapped_data = wrapped_data
         self._wrapper_func = wrapped_get
@@ -711,10 +721,6 @@ class SubNetworkComponents:
         value : Any
             Attribute value to set.
 
-        Returns
-        -------
-        None
-
         Raises
         ------
         AttributeError
@@ -735,10 +741,6 @@ class SubNetworkComponents:
         ----------
         name : str
             Attribute name to delete.
-
-        Returns
-        -------
-        None
 
         Raises
         ------

--- a/pypsa/components/descriptors.py
+++ b/pypsa/components/descriptors.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pandas as pd
 
+from pypsa.common import as_index
 from pypsa.components.abstract import _ComponentsABC
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,45 @@ class _ComponentsDescriptors(_ComponentsABC):
     Class only inherits to Components and should not be used directly.
     """
 
+    @property
+    def _operational_attrs(self) -> dict[str, str]:
+        """
+        Get operational attributes of component for optimization.
+
+        Provides a dictionary of attribute patterns used in optimization constraints,
+        based on the component type. This makes constraint formulation more modular
+        by avoiding hardcoded attribute names.
+
+        Returns
+        -------
+        dict[str, str]
+            Dictionary of operational attribute names
+
+        """
+        # TODO: refactor component attrs store
+
+        base = {
+            "Generator": "p",
+            "Line": "s",
+            "Link": "p",
+            "Load": "p",
+            "StorageUnit": "p",
+            "Store": "e",
+            "Transformer": "s",
+        }[self.name]
+
+        return {
+            "base": base,
+            "nom": f"{base}_nom",
+            "nom_extendable": f"{base}_nom_extendable",
+            "nom_min": f"{base}_nom_min",
+            "nom_max": f"{base}_nom_max",
+            "nom_set": f"{base}_nom_set",
+            "min_pu": f"{base}_min_pu",
+            "max_pu": f"{base}_max_pu",
+            "set": f"{base}_set",
+        }
+
     def get_active_assets(
         self,
         investment_period: int | str | Sequence | None = None,
@@ -106,3 +146,107 @@ class _ComponentsDescriptors(_ComponentsABC):
                 "build_year <= @period < build_year + lifetime"
             )
         return pd.DataFrame(active).any(axis=1) & self.static.active
+
+    def get_activity_mask(
+        self,
+        sns: Sequence | None = None,
+        index: pd.Index | None = None,
+    ) -> pd.DataFrame:
+        """
+        Get active components mask indexed by snapshots.
+
+        Wrapper around the
+        `:py:meth:`pypsa.descriptors.components.Componenet.get_active_assets` method.
+        Get's the boolean mask for active components, but indexed by snapshots and
+        components instead of just components.
+
+        Parameters
+        ----------
+        n : pypsa.Network
+            Network instance
+        c : string
+            Component name
+        sns : pandas.Index, default None
+            Set of snapshots for the mask. If None (default) all snapshots are returned.
+        index : pd.Index, default None
+            Subset of the component elements. If None (default) all components are returned.
+
+        """
+        sns_ = as_index(self.n_save, sns, "snapshots")
+
+        if getattr(self.n_save, "_multi_invest", False):
+            active_assets_per_period = {
+                period: self.get_active_assets(period)
+                for period in self.investment_periods
+            }
+            mask = (
+                pd.concat(active_assets_per_period, axis=1)
+                .T.reindex(self.snapshots, level=0)
+                .loc[sns_]
+            )
+        else:
+            active_assets = self.get_active_assets()
+            mask = pd.DataFrame(
+                np.tile(active_assets, (len(sns_), 1)),
+                index=sns_,
+                columns=active_assets.index,
+            )
+
+        if index is not None:
+            mask = mask.reindex(columns=index)
+
+        return mask
+
+    @property
+    def extendables(self) -> pd.Index:
+        """
+        Get the index of extendable components of this component type.
+
+        Returns
+        -------
+        pd.Index
+            Index of extendable components.
+
+        """
+        extendable_col = self._operational_attrs["nom_extendable"]
+        if extendable_col not in self.static.columns:
+            return self.static.iloc[:0].index
+
+        idx = self.static.loc[self.static[extendable_col]].index
+
+        return idx.rename(f"{self.name}-ext")
+
+    @property
+    def fixed(self) -> pd.Index:
+        """
+        Get the index of non-extendable components of this component type.
+
+        Returns
+        -------
+        pd.Index
+            Index of non-extendable components.
+
+        """
+        extendable_col = self._operational_attrs["nom_extendable"]
+        if extendable_col not in self.static.columns:
+            return self.static.iloc[:0].index
+
+        idx = self.static.loc[~self.static[extendable_col]].index
+        return idx.rename(f"{self.name}-fix")
+
+    @property
+    def committables(self) -> pd.Index:
+        """
+        Get the index of committable components of this component type.
+
+        Returns
+        -------
+        pd.Index
+            Index of committable components.
+
+        """
+        if "committable" not in self.static:
+            return self.static.iloc[:0].index
+
+        idx = self.static.loc[self.static["committable"]].index
+        return idx.rename(f"{self.name}-com")

--- a/pypsa/components/index.py
+++ b/pypsa/components/index.py
@@ -63,13 +63,3 @@ class _ComponentsIndex(_ComponentsABC):
     def has_periods(self) -> bool:
         """Investment periods of the network."""
         return self.n_save.has_periods
-
-    @property
-    def scenarios(self) -> pd.Index:
-        """Scenarios of networks."""
-        return self.n_save.scenarios
-
-    @property
-    def has_scenarios(self) -> bool:
-        """Boolean indicating if the network has scenarios defined."""
-        return len(self.scenarios) > 0

--- a/pypsa/components/transform.py
+++ b/pypsa/components/transform.py
@@ -64,9 +64,6 @@ class _ComponentsTransform:
 
         Parameters
         ----------
-        class_name : str
-            Component class name in ("Bus", "Generator", "Load", "StorageUnit",
-            "Store", "ShuntImpedance", "Line", "Transformer", "Link").
         name : str or int or list of str or list of int
             Component name(s)
         suffix : str, default ""
@@ -166,10 +163,6 @@ class _ComponentsTransform:
         ----------
         **kwargs
             Mapping of old names to new names.
-
-        Returns
-        -------
-        None
 
         Examples
         --------

--- a/pypsa/components/types.py
+++ b/pypsa/components/types.py
@@ -57,9 +57,6 @@ def add_component_type(
     standard_types_df : pandas.DataFrame, optional
         Standard types of the component type.
 
-    Returns
-    -------
-    None
 
     Examples
     --------

--- a/pypsa/consistency.py
+++ b/pypsa/consistency.py
@@ -486,9 +486,7 @@ def check_generators(component: Components, strict: bool = False) -> None:
     strict : bool, optional
         If True, raise an error instead of logging a warning.
 
-    Returns
-    -------
-    None
+
 
     See Also
     --------
@@ -775,10 +773,6 @@ def consistency_check(
         of strings with the names of the checks to be strict about. If 'all' is passed,
         all checks will be strict. The default is no strict checks.
 
-    Returns
-    -------
-    None
-
     Raises
     ------
     ConsistencyError : If any of the checks fail and strict mode is activated.
@@ -891,9 +885,6 @@ def plotting_consistency_check(n: Network, strict: Sequence | None = None) -> No
         of strings with the names of the checks to be strict about. If 'all' is passed,
         all checks will be strict. The default is no strict checks.
 
-    Returns
-    -------
-    None
 
     See Also
     --------

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -3,24 +3,31 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections import OrderedDict
-from itertools import product, repeat
+from itertools import product
 from typing import TYPE_CHECKING, Any
 
 import networkx as nx
-import numpy as np
 import pandas as pd
+from deprecation import deprecated
 
-from pypsa.common import as_index, deprecated_common_kwargs
+from pypsa.common import deprecated_common_kwargs, deprecated_in_next_major
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Sequence
 
     from pypsa import Network, SubNetwork
+    from pypsa.typing import NetworkType
 
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    deprecated_in="0.35",
+    removed_in="1.0",
+    details="Use `pypsa.graph.OrderedGraph` instead.",
+)
 class OrderedGraph(nx.MultiGraph):
     """Ordered graph."""
 
@@ -28,6 +35,7 @@ class OrderedGraph(nx.MultiGraph):
     adjlist_dict_factory = OrderedDict
 
 
+@deprecated_in_next_major(details="Use `n.get_switchable_as_dense` instead.")
 @deprecated_common_kwargs
 def get_switchable_as_dense(
     n: Network,
@@ -39,53 +47,15 @@ def get_switchable_as_dense(
     """
     Return a Dataframe for a time-varying component attribute .
 
-    Values for all non-time-varying components are filled in with the default
-    values for the attribute.
-
-    Parameters
-    ----------
-    n : pypsa.Network
-        Network instance.
-    component : string
-        Component object name, e.g. 'Generator' or 'Link'
-    attr : string
-        Attribute name
-    snapshots : pandas.Index
-        Restrict to these snapshots rather than n.snapshots.
-    inds : pandas.Index
-        Restrict to these components rather than n.components.index
-
-    Returns
-    -------
-    pandas.DataFrame
-
-    Examples
-    --------
-    >>> get_switchable_as_dense(n, 'Generator', 'p_max_pu', n.snapshots[:2]) # doctest: +SKIP
-    Generator            Manchester Wind  Manchester Gas  Norway Wind  Norway Gas  Frankfurt Wind  Frankfurt Gas
-    snapshot
-    2015-01-01 00:00:00         0.930020             1.0     0.974583         1.0        0.559078            1.0
-    2015-01-01 01:00:00         0.485748             1.0     0.481290         1.0        0.752910            1.0
+    Deprecation
+    ------------
+    Use `n.get_switchable_as_dense` instead.
 
     """
-    sns = as_index(n, snapshots, "snapshots")
-
-    static = n.static(component)[attr]
-    empty = pd.DataFrame(index=sns)
-    dynamic = n.dynamic(component).get(attr, empty).loc[sns]
-
-    index = static.index
-    if inds is not None:
-        index = index.intersection(inds)
-
-    diff = index.difference(dynamic.columns)
-    static_to_dynamic = pd.DataFrame({**static[diff]}, index=sns)
-    res = pd.concat([dynamic, static_to_dynamic], axis=1, names=sns.names)[index]
-    res.index.name = sns.name
-    res.columns.name = component
-    return res
+    return n.get_switchable_as_dense(component, attr, snapshots, inds)
 
 
+@deprecated_in_next_major(details="Use `n.get_switchable_as_iter` instead.")
 @deprecated_common_kwargs
 def get_switchable_as_iter(
     n: Network,
@@ -97,102 +67,32 @@ def get_switchable_as_iter(
     """
     Return an iterator over snapshots for a time-varying component attribute.
 
-    Values for all non-time-varying components are filled in with the default
-    values for the attribute.
-
-    Parameters
-    ----------
-    n : pypsa.Network
-        Network instance.
-    component : string
-        Component object name, e.g. 'Generator' or 'Link'
-    attr : string
-        Attribute name
-    snapshots : pandas.Index
-        Restrict to these snapshots rather than n.snapshots.
-    inds : pandas.Index
-        Restrict to these items rather than all of n.{generators, ..}.index
-
-    Returns
-    -------
-    pandas.DataFrame
-
-    Examples
-    --------
-    >>> get_switchable_as_iter(n, 'Generator', 'p_max_pu', n.snapshots[:2]) # doctest: +ELLIPSIS
-    <generator object get_switchable_as_iter...
+    Deprecation
+    ------------
+    Use `n.get_switchable_as_iter` instead.
 
     """
-    static = n.static(component)
-    dynamic = n.dynamic(component)
-
-    index = static.index
-    varying_i = dynamic[attr].columns
-    fixed_i = static.index.difference(varying_i)
-
-    if inds is not None:
-        inds = pd.Index(inds)
-        index = inds.intersection(index)
-        varying_i = inds.intersection(varying_i)
-        fixed_i = inds.intersection(fixed_i)
-
-    # Short-circuit only fixed
-    if len(varying_i) == 0:
-        return repeat(static.loc[fixed_i, attr], len(snapshots))
-
-    def is_same_indices(i1: pd.Index, i2: pd.Index) -> bool:
-        return len(i1) == len(i2) and (i1 == i2).all()
-
-    if is_same_indices(fixed_i.append(varying_i), index):
-
-        def reindex_maybe(s: pd.Series | pd.DataFrame) -> pd.Series | pd.DataFrame:
-            return s
-
-    else:
-
-        def reindex_maybe(s: pd.Series | pd.DataFrame) -> pd.Series | pd.DataFrame:
-            return s.reindex(index)
-
-    return (
-        reindex_maybe(
-            static.loc[fixed_i, attr].append(dynamic[attr].loc[sn, varying_i])
-        )
-        for sn in snapshots
-    )
+    return n.get_switchable_as_iter(component, attr, snapshots, inds)
 
 
+@deprecated(
+    deprecated_in="0.35",
+    removed_in="1.0",
+    details="Use `pypsa.pf.allocate_series_dataframes` instead.",
+)
 @deprecated_common_kwargs
 def allocate_series_dataframes(n: Network, series: dict) -> None:
-    """
-    Populate time-varying outputs with default values.
+    """Populate time-varying outputs with default values."""
+    from pypsa.pf import allocate_series_dataframes as allocate_series_dataframes_pf
 
-    Parameters
-    ----------
-    n : pypsa.Network
-        Network instance.
-    series : dict
-        Dictionary of components and their attributes to populate (see example)
-
-    Returns
-    -------
-    None
-
-    Examples
-    --------
-    >>> allocate_series_dataframes(n, {'Generator': ['p'], 'Load': ['p']})
-
-    """
-    for component, attributes in series.items():
-        static = n.static(component)
-        dynamic = n.dynamic(component)
-
-        for attr in attributes:
-            dynamic[attr] = dynamic[attr].reindex(
-                columns=static.index,
-                fill_value=n.components[component]["attrs"].at[attr, "default"],
-            )
+    allocate_series_dataframes_pf(n, series)
 
 
+@deprecated(
+    deprecated_in="0.35",
+    removed_in="1.0",
+    details="Will be removed in the next major release.",
+)
 @deprecated_common_kwargs
 def free_output_series_dataframes(
     n: Network, components: Collection[str] | None = None
@@ -219,6 +119,11 @@ def free_output_series_dataframes(
             dynamic[attr] = pd.DataFrame(index=n.snapshots, columns=[])
 
 
+@deprecated(
+    deprecated_in="0.35",
+    removed_in="1.0",
+    details="Use `pypsa.pf.zsum` instead.",
+)
 def zsum(s: pd.Series, *args: Any, **kwargs: Any) -> Any:
     """
     Custom zsum function.
@@ -243,6 +148,11 @@ nominal_attrs = {
 }
 
 
+@deprecated(
+    deprecated_in="0.35",
+    removed_in="1.0",
+    details="Use `pypsa.common.expand_series` instead.",
+)
 def expand_series(ser: pd.Series, columns: Sequence[str]) -> pd.DataFrame:
     """
     Helper function to quickly expand a series to a dataframe.
@@ -253,39 +163,37 @@ def expand_series(ser: pd.Series, columns: Sequence[str]) -> pd.DataFrame:
     return ser.to_frame(columns[0]).reindex(columns=columns).ffill(axis=1)
 
 
+@deprecated_in_next_major(details="Use `n.components[c].extendables` instead.")
 def get_extendable_i(n: Network, c: str) -> pd.Index:
-    """
-    Getter function.
-
-    Get the index of extendable elements of a given component.
-    """
-    idx = n.static(c)[lambda ds: ds[nominal_attrs[c] + "_extendable"]].index
-    return idx.rename(f"{c}-ext")
+    """Get the index of extendable elements of a given component."""
+    return n.components[c].extendables
 
 
+@deprecated_in_next_major(details="Use `n.components[c].fixed` instead.")
 def get_non_extendable_i(n: Network, c: str) -> pd.Index:
     """
     Getter function.
 
     Get the index of non-extendable elements of a given component.
+
+    Deprecated: Use n.components[c].self.fixed instead.
     """
-    idx = n.static(c)[lambda ds: ~ds[nominal_attrs[c] + "_extendable"]].index
-    return idx.rename(f"{c}-fix")
+    return n.components[c].fixed
 
 
+@deprecated_in_next_major(details="Use `n.components[c].committables` instead.")
 def get_committable_i(n: Network, c: str) -> pd.Index:
     """
     Getter function.
 
     Get the index of commitable elements of a given component.
+
+    Deprecated: Use n.components[c].get_committable_i() instead.
     """
-    if "committable" not in n.static(c):
-        idx = pd.Index([])
-    else:
-        idx = n.static(c)[lambda ds: ds["committable"]].index
-    return idx.rename(f"{c}-com")
+    return n.components[c].committables
 
 
+@deprecated_in_next_major(details="Use `n.components[c].get_active_assets` instead.")
 def get_active_assets(
     n: Network | SubNetwork,
     c: str,
@@ -314,6 +222,7 @@ def get_active_assets(
     return n.component(c).get_active_assets(investment_period=investment_period)
 
 
+@deprecated_in_next_major(details="Use `n.components[c].get_activity_mask` instead.")
 @deprecated_common_kwargs
 def get_activity_mask(
     n: Network,
@@ -341,31 +250,10 @@ def get_activity_mask(
         Subset of the component elements. If None (default) all components are returned.
 
     """
-    sns_ = as_index(n, sns, "snapshots")
-
-    if getattr(n, "_multi_invest", False):
-        active_assets_per_period = {
-            period: get_active_assets(n, c, period) for period in n.investment_periods
-        }
-        mask = (
-            pd.concat(active_assets_per_period, axis=1)
-            .T.reindex(n.snapshots, level=0)
-            .loc[sns_]
-        )
-    else:
-        active_assets = get_active_assets(n, c)
-        mask = pd.DataFrame(
-            np.tile(active_assets, (len(sns_), 1)),
-            index=sns_,
-            columns=active_assets.index,
-        )
-
-    if index is not None:
-        mask = mask.reindex(columns=index)
-
-    return mask
+    return n.components[c].get_activity_mask(sns, index)
 
 
+@deprecated_in_next_major(details="Deprecate with new-opt.")
 @deprecated_common_kwargs
 def get_bounds_pu(
     n: Network,
@@ -408,6 +296,8 @@ def get_bounds_pu(
         if attr == "p_store":
             max_pu = -get_switchable_as_dense(n, c, min_pu_str, sns)
         if attr == "state_of_charge":
+            from pypsa.common import expand_series
+
             max_pu = expand_series(n.static(c).max_hours, sns).T
             min_pu = pd.DataFrame(0, *max_pu.axes)
     else:
@@ -418,7 +308,7 @@ def get_bounds_pu(
     return min_pu.reindex(columns=index), max_pu.reindex(columns=index)
 
 
-def update_linkports_doc_changes(s: Any, i: int, j: str) -> Any:
+def _update_linkports_doc_changes(s: Any, i: int, j: str) -> Any:
     """
     Update components documentation for link ports.
 
@@ -445,6 +335,85 @@ def update_linkports_doc_changes(s: Any, i: int, j: str) -> Any:
     return s.replace(j, str(i)).replace("required", "optional")
 
 
+@deprecated(
+    deprecated_in="0.35",
+    removed_in="1.0",
+    details="Will be removed in the next major release.",
+)
+def update_linkports_doc_changes(s: Any, i: int, j: str) -> Any:
+    """
+    Update components documentation for link ports.
+
+    Multi-linkports require the following changes:
+    1. Replaces every occurrence of the substring `j` with `i`.
+    2. Make attribute required
+
+    Parameters
+    ----------
+    s : An
+        String to update.
+    i : int
+        Integer to replace `j` with.
+    j : string
+        Substring to replace.
+
+    Returns
+    -------
+    Any : Updated string or original value if not a string.
+
+    """
+    return _update_linkports_doc_changes(s, i, j)
+
+
+def _update_linkports_component_attrs(
+    n: NetworkType, where: Iterable[str] | None = None
+) -> None:
+    """
+    Update the Link components attributes to add the additional ports.
+
+    Parameters
+    ----------
+    n : Network
+        Network instance to which additional ports will be added.
+    where : Iterable[str] or None, optional
+        Filters for specific subsets of data by providing an iterable of tags
+        or identifiers. If None, no filtering is applied and additional link
+        ports are considered for all connectors.
+
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        ports = additional_linkports(n, where)
+    ports.sort(reverse=True)
+    c = "Link"
+
+    for i, attr in product(ports, ["bus", "efficiency", "p"]):
+        target = f"{attr}{i}"
+        if target in n.components[c]["attrs"].index:
+            continue
+        j = "1" if attr != "efficiency" else ""
+        base_attr = attr + j
+        base_attr_index = n.components[c]["attrs"].index.get_loc(base_attr)
+        n.components[c]["attrs"].index.insert(base_attr_index + 1, target)
+        n.components[c]["attrs"].loc[target] = (
+            n.components[c]["attrs"]
+            .loc[attr + j]
+            .apply(_update_linkports_doc_changes, args=("1", i))
+        )
+        # Also update container for varying attributes
+        if attr in ["efficiency", "p"] and target not in n.dynamic(c):
+            df = pd.DataFrame(index=n.snapshots, columns=[], dtype=float)
+            df.columns.name = c
+            n.dynamic(c)[target] = df
+        elif attr == "bus" and target not in n.static(c).columns:
+            n.static(c)[target] = n.components[c]["attrs"].loc[target, "default"]
+
+
+@deprecated(
+    deprecated_in="0.35",
+    removed_in="1.0",
+    details="Will be removed in the next major release.",
+)
 @deprecated_common_kwargs
 def update_linkports_component_attrs(
     n: Network, where: Iterable[str] | None = None
@@ -462,32 +431,14 @@ def update_linkports_component_attrs(
         ports are considered for all connectors.
 
     """
-    ports = additional_linkports(n, where)
-    ports.sort(reverse=True)
-    c = "Link"
-
-    for i, attr in product(ports, ["bus", "efficiency", "p"]):
-        target = f"{attr}{i}"
-        if target in n.components[c]["attrs"].index:
-            continue
-        j = "1" if attr != "efficiency" else ""
-        base_attr = attr + j
-        base_attr_index = n.components[c]["attrs"].index.get_loc(base_attr)
-        n.components[c]["attrs"].index.insert(base_attr_index + 1, target)
-        n.components[c]["attrs"].loc[target] = (
-            n.components[c]["attrs"]
-            .loc[attr + j]
-            .apply(update_linkports_doc_changes, args=("1", i))
-        )
-        # Also update container for varying attributes
-        if attr in ["efficiency", "p"] and target not in n.dynamic(c):
-            df = pd.DataFrame(index=n.snapshots, columns=[], dtype=float)
-            df.columns.name = c
-            n.dynamic(c)[target] = df
-        elif attr == "bus" and target not in n.static(c).columns:
-            n.static(c)[target] = n.components[c]["attrs"].loc[target, "default"]
+    _update_linkports_component_attrs(n, where)
 
 
+@deprecated(
+    deprecated_in="0.35",
+    removed_in="1.0",
+    details="Use `n.components.links.additional_ports` instead. Passing `where` will be deprecated.",
+)
 def additional_linkports(n: Network, where: Iterable[str] | None = None) -> list[str]:
     """
     Identify additional link ports (bus connections) beyond predefined ones.
@@ -510,40 +461,11 @@ def additional_linkports(n: Network, where: Iterable[str] | None = None) -> list
     return [i[3:] for i in where if i.startswith("bus") and i not in ["bus0", "bus1"]]
 
 
+@deprecated(
+    deprecated_in="0.35",
+    removed_in="1.0",
+    details="Use `n.bus_carrier_unit` instead.",
+)
 def bus_carrier_unit(n: Network, bus_carrier: str | Sequence[str] | None) -> str:
-    """
-    Determine the unit associated with a specific bus carrier in the network.
-
-    Parameters
-    ----------
-    n : Network
-        The network object containing buses and their attributes.
-    bus_carrier : str | Sequence[str] | None
-        The carrier type of the bus to query.
-
-    Returns
-    -------
-    str: The unit associated with the specified bus carrier. If no bus carrier is provided,
-         returns "carrier dependent".
-
-    Raises
-    ------
-    ValueError: If the specified bus carrier is not found in the network or if multiple units
-                are found for the specified bus carrier.
-
-    """
-    if bus_carrier is None:
-        return "carrier dependent"
-
-    if isinstance(bus_carrier, str):
-        bus_carrier = [bus_carrier]
-
-    not_included = set(bus_carrier) - set(n.buses.carrier.unique())
-    if not_included:
-        msg = f"Bus carriers {not_included} not in network"
-        raise ValueError(msg)
-    unit = n.buses[n.buses.carrier.isin(bus_carrier)].unit.unique()
-    if len(unit) > 1:
-        logger.warning("Multiple units found for carrier %s: %s", bus_carrier, unit)
-        return "carrier dependent"
-    return unit.item()
+    """Determine the unit associated with a specific bus carrier in the network."""
+    return n.bus_carrier_unit(bus_carrier)

--- a/pypsa/examples.py
+++ b/pypsa/examples.py
@@ -43,13 +43,32 @@ def ac_dc_meshed(
     remove_link_p_set : bool, optional
         Whether to remove the link `p_set` attribute from the links.
 
-    .. deprecated:: 0.35.0
-          `from_master` and `update` are deprecated and do not have any effect.
-
+    Deprecation
+    ------------
+    [:material-tag-outline: v0.35.0](/release-notes/#v0.35.0): Parameters
+    `from_master`, `update`, and `remove_link_p_set` are deprecated and do not have
+    any effect. Networks are always updated and retrieved for the current version.
 
     Returns
     -------
     pypsa.Network
+        AC-DC meshed network.
+
+    Examples
+    --------
+    >>> n = pypsa.examples.ac_dc_meshed()
+    >>> n
+    PyPSA Network 'AC-DC'
+    ---------------------
+    Components:
+     - Bus: 9
+     - Carrier: 6
+     - Generator: 6
+     - GlobalConstraint: 1
+     - Line: 7
+     - Link: 4
+     - Load: 6
+    Snapshots: 10
 
     """
     if update or from_master or remove_link_p_set:
@@ -66,7 +85,7 @@ def ac_dc_meshed(
 
 def storage_hvdc(update: bool = False, from_master: bool = False) -> Network:
     """
-    Load the storage network example of pypsa stored in the PyPSA repository.
+    Load the storage network example of PyPSA.
 
     Parameters
     ----------
@@ -75,12 +94,33 @@ def storage_hvdc(update: bool = False, from_master: bool = False) -> Network:
     from_master : bool, optional
         Whether to retrieve from the master branch of the pypsa repository.
 
-    .. deprecated:: 0.35.0
-          `from_master` and `update` are deprecated and do not have any effect.
+    Deprecation
+    -----------
+    [:material-tag-outline: v0.35.0](/release-notes/#v0.35.0): Parameters
+    `from_master` and `update` are deprecated and do not have any effect. Networks
+    are always updated and retrieved for the current version.
 
     Returns
     -------
     pypsa.Network
+        Storage network example network.
+
+    Examples
+    --------
+    >>> n = pypsa.examples.storage_hvdc()
+    >>> n
+    PyPSA Network 'Test 6 bus'
+    --------------------------
+    Components:
+     - Bus: 6
+     - Carrier: 3
+     - Generator: 12
+     - GlobalConstraint: 1
+     - Line: 6
+     - Link: 2
+     - Load: 6
+     - StorageUnit: 6
+    Snapshots: 12
 
     """
     if update or from_master:
@@ -96,7 +136,7 @@ def storage_hvdc(update: bool = False, from_master: bool = False) -> Network:
 
 def scigrid_de(update: bool = False, from_master: bool = False) -> Network:
     """
-    Load the SciGrid network example of pypsa stored in the PyPSA repository.
+    Load the SciGrid network example of PyPSA.
 
     Parameters
     ----------
@@ -105,12 +145,32 @@ def scigrid_de(update: bool = False, from_master: bool = False) -> Network:
     from_master : bool, optional
         Whether to retrieve from the master branch of the pypsa repository.
 
-    .. deprecated:: 0.35.0
-          `from_master` and `update` are deprecated and do not have any effect.
+    Deprecation
+    -----------
+    [:material-tag-outline: v0.35.0](/release-notes/#v0.35.0): Parameters
+    `from_master` and `update` are deprecated and do not have any effect. Networks
+    are always updated and retrieved for the current version.
 
     Returns
     -------
     pypsa.Network
+        SciGrid network example network.
+
+    Examples
+    --------
+    >>> n = pypsa.examples.scigrid_de()
+    >>> n
+    PyPSA Network 'scigrid-de'
+    --------------------------
+    Components:
+     - Bus: 585
+     - Carrier: 17
+     - Generator: 1423
+     - Line: 852
+     - Load: 489
+     - StorageUnit: 38
+     - Transformer: 96
+    Snapshots: 24
 
     """
     if update or from_master:
@@ -128,6 +188,8 @@ def model_energy(update: bool = False, from_master: bool = False) -> Network:
     """
     Load the single-node capacity expansion model in style of model.energy.
 
+    Check out the [model.energy website](https://model.energy/) for more information.
+
     Parameters
     ----------
     update : bool, optional
@@ -135,12 +197,36 @@ def model_energy(update: bool = False, from_master: bool = False) -> Network:
     from_master : bool, optional
         Whether to retrieve from the master branch of the pypsa repository.
 
-    .. deprecated:: 0.35.0
-          `from_master` and `update` are deprecated and do not have any effect.
+    Deprecation
+    -----------
+    [:material-tag-outline: v0.35.0](/release-notes/#v0.35.0): Parameters
+    `from_master` and `update` are deprecated and do not have any effect. Networks
+    are always updated and retrieved for the current version.
 
     Returns
     -------
     pypsa.Network
+        Single-node capacity expansion model in style of model.energy.
+
+    Examples
+    --------
+    >>> n = pypsa.examples.model_energy()
+    >>> n
+    Unnamed PyPSA Network
+    ---------------------
+    Components:
+     - Bus: 2
+     - Carrier: 9
+     - Generator: 3
+     - Link: 2
+     - Load: 1
+     - StorageUnit: 1
+     - Store: 1
+    Snapshots: 2920
+
+    References
+    ----------
+    [^1]: See https://model.energy/
 
     """
     if update or from_master:

--- a/pypsa/graph.py
+++ b/pypsa/graph.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from typing import TYPE_CHECKING
 
+import networkx as nx
 import numpy as np
 import scipy as sp
 
 from pypsa.common import deprecated_common_kwargs
-from pypsa.descriptors import OrderedGraph
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable
@@ -16,6 +17,13 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from pypsa import Network, SubNetwork
+
+
+class OrderedGraph(nx.MultiGraph):
+    """Ordered graph."""
+
+    node_dict_factory = OrderedDict
+    adjlist_dict_factory = OrderedDict
 
 
 @deprecated_common_kwargs

--- a/pypsa/io.py
+++ b/pypsa/io.py
@@ -22,7 +22,7 @@ from pyproj import CRS
 from typing_extensions import Self
 
 from pypsa.common import check_optional_dependency, deprecated_common_kwargs
-from pypsa.descriptors import update_linkports_component_attrs
+from pypsa.descriptors import _update_linkports_component_attrs
 
 try:
     from cloudpathlib import AnyPath as Path
@@ -1546,7 +1546,7 @@ def _import_from_importer(
             continue
 
         if component == "Link":
-            update_linkports_component_attrs(n, where=df)
+            _update_linkports_component_attrs(n, where=df)
 
         n.add(component, df.index, **df)
 
@@ -1698,7 +1698,7 @@ def _import_components_from_df(
     non_static_attrs = attrs[~attrs.static]
 
     if cls_name == "Link":
-        update_linkports_component_attrs(n, where=df)
+        _update_linkports_component_attrs(n, where=df)
 
     # Clean dataframe and ensure correct types
     df = pd.DataFrame(df)

--- a/pypsa/network/abstract.py
+++ b/pypsa/network/abstract.py
@@ -7,7 +7,7 @@ Only defines a base class for all Network helper classes which inherit to
 
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -22,9 +22,25 @@ class _NetworkABC(ABC):
     snapshots: pd.Index | pd.MultiIndex
     _snapshot_weightings: pd.DataFrame
     _investment_period_weightings: pd.DataFrame
-    all_components: set[str]
     static: pd.DataFrame
     dynamic: Callable
-    components: ComponentsStore
-    c: ComponentsStore
     _import_series_from_df: Callable
+    add: Callable
+
+    @property
+    @abstractmethod
+    def all_components(self) -> set[str]:
+        """Read only placeholder."""
+        ...
+
+    @property
+    @abstractmethod
+    def components(self) -> ComponentsStore:
+        """Read only placeholder."""
+        ...
+
+    @property
+    @abstractmethod
+    def c(self) -> ComponentsStore:
+        """Read only placeholder."""
+        ...

--- a/pypsa/network/components.py
+++ b/pypsa/network/components.py
@@ -10,7 +10,7 @@ are set.
 
 Also See
 --------
-pypsa.network.index
+pypsa.components.index
 
 """
 
@@ -19,12 +19,22 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from pypsa._options import option_context
+from pypsa.common import deprecated_in_next_major
+from pypsa.components.legacy import Component
+from pypsa.components.store import ComponentsStore
+from pypsa.components.types import (
+    component_types_df,
+)
+from pypsa.components.types import (
+    get as get_component_type,
+)
+from pypsa.definitions.structures import Dict
 from pypsa.network.abstract import _NetworkABC
 
 if TYPE_CHECKING:
     import pandas as pd
 
-    from pypsa.definitions.structures import Dict
 
 from pypsa._options import options
 
@@ -57,8 +67,80 @@ class _NetworkComponents(_NetworkABC):
     """
     Helper class for components array methods.
 
-    Class only inherits to Components and should not be used directly.
+    Class only inherits to [Network][pypsa.Network] and should not be used
+    directly. All attributes and methods can be used within any Network instance.
     """
+
+    def __init__(self) -> None:
+        self._components: ComponentsStore | None = None
+
+    def _read_in_default_standard_types(self) -> None:
+        """Read in the default standard types from the data folder."""
+        for std_type in self.standard_type_components:
+            self.add(
+                std_type,
+                self.components[std_type].ctype.standard_types.index,
+                **self.components[std_type].ctype.standard_types,
+            )
+
+    @property
+    def components(self) -> ComponentsStore:
+        """
+        Network components store.
+
+        Access all components of the network via `n.components.<component>`.
+
+        Examples
+        --------
+        >>> n.components # doctest: +ELLIPSIS
+        PyPSA Components Store
+        ======================
+        - 0 'SubNetwork' Components
+        - 9 'Bus' Components
+        ...
+
+        Access a single component:
+        >>> n.components.generators
+        'Generator' Components
+        ----------------------
+        Attached to PyPSA Network 'AC-DC'
+        Components: 6
+
+        Which is the same reference when accessing the component directly:
+        >>> n.generators # doctest: +SKIP
+        #TODO
+        >>> n.generators is n.components.generators.static # TODO
+        True
+
+        Returns
+        -------
+        ComponentsStore
+
+        """
+        if self._components is None:
+            components = component_types_df.index.to_list()
+
+            self._components = ComponentsStore()
+            for c_name in components:
+                ctype = get_component_type(c_name)
+
+                self._components[ctype.list_name] = Component(ctype=ctype, n=self)
+        return self._components
+
+    @property
+    def c(self) -> ComponentsStore:
+        """
+        Network components store.
+
+        Access all components of the network via `n.c.<component>`. Alias for
+        [`n.components`][pypsa.Network.components].
+
+        Returns
+        -------
+        ComponentsStore
+
+        """
+        return self.components
 
     @property
     def sub_networks(self) -> Any:
@@ -75,18 +157,6 @@ class _NetworkComponents(_NetworkABC):
         self.c.sub_networks.static = value
 
     @property
-    def sub_networks_t(self) -> Dict:
-        if not options.api.legacy_components:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("sub_networks"))
-        return self.c.sub_networks.dynamic
-
-    @sub_networks_t.setter
-    def sub_networks_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("sub_networks"))
-        self.c.sub_networks.dynamic = value
-
-    @property
     def buses(self) -> Any:
         return self.c.buses.static if options.api.legacy_components else self.c.buses
 
@@ -95,18 +165,6 @@ class _NetworkComponents(_NetworkABC):
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.buses.static = value
-
-    @property
-    def buses_t(self) -> Dict:
-        if not options.api.legacy_components:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("buses"))
-        return self.c.buses.dynamic
-
-    @buses_t.setter
-    def buses_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("buses"))
-        self.c.buses.dynamic = value
 
     @property
     def carriers(self) -> Any:
@@ -121,18 +179,6 @@ class _NetworkComponents(_NetworkABC):
         self.c.carriers.static = value
 
     @property
-    def carriers_t(self) -> Dict:
-        if not options.api.legacy_components:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("carriers"))
-        return self.c.carriers.dynamic
-
-    @carriers_t.setter
-    def carriers_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("carriers"))
-        self.c.carriers.dynamic = value
-
-    @property
     def global_constraints(self) -> Any:
         return (
             self.c.global_constraints.static
@@ -145,6 +191,176 @@ class _NetworkComponents(_NetworkABC):
         if not options.api.legacy_components:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.global_constraints.static = value
+
+    @property
+    def lines(self) -> Any:
+        return self.c.lines.static if options.api.legacy_components else self.c.lines
+
+    @lines.setter
+    def lines(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.lines.static = value
+
+    @property
+    def line_types(self) -> Any:
+        return (
+            self.c.line_types.static
+            if options.api.legacy_components
+            else self.c.line_types
+        )
+
+    @line_types.setter
+    def line_types(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.line_types.static = value
+
+    @property
+    def transformers(self) -> Any:
+        return (
+            self.c.transformers.static
+            if options.api.legacy_components
+            else self.c.transformers
+        )
+
+    @transformers.setter
+    def transformers(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.transformers.static = value
+
+    @property
+    def transformer_types(self) -> Any:
+        return (
+            self.c.transformer_types.static
+            if options.api.legacy_components
+            else self.c.transformer_types
+        )
+
+    @transformer_types.setter
+    def transformer_types(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.transformer_types.static = value
+
+    @property
+    def links(self) -> Any:
+        return self.c.links.static if options.api.legacy_components else self.c.links
+
+    @links.setter
+    def links(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.links.static = value
+
+    @property
+    def loads(self) -> Any:
+        return self.c.loads.static if options.api.legacy_components else self.c.loads
+
+    @loads.setter
+    def loads(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.loads.static = value
+
+    @property
+    def generators(self) -> Any:
+        return (
+            self.c.generators.static
+            if options.api.legacy_components
+            else self.c.generators
+        )
+
+    @generators.setter
+    def generators(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.generators.static = value
+
+    @property
+    def storage_units(self) -> Any:
+        return (
+            self.c.storage_units.static
+            if options.api.legacy_components
+            else self.c.storage_units
+        )
+
+    @storage_units.setter
+    def storage_units(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.storage_units.static = value
+
+    @property
+    def stores(self) -> Any:
+        return self.c.stores.static if options.api.legacy_components else self.c.stores
+
+    @stores.setter
+    def stores(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.stores.static = value
+
+    @property
+    def shunt_impedances(self) -> Any:
+        return (
+            self.c.shunt_impedances.static
+            if options.api.legacy_components
+            else self.c.shunt_impedances
+        )
+
+    @shunt_impedances.setter
+    def shunt_impedances(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.shunt_impedances.static = value
+
+    @property
+    def shapes(self) -> Any:
+        return self.c.shapes.static if options.api.legacy_components else self.c.shapes
+
+    @shapes.setter
+    def shapes(self, value: pd.DataFrame) -> None:
+        if not options.api.legacy_components:
+            raise AttributeError(_STATIC_SETTER_WARNING)
+        self.c.shapes.static = value
+
+    @property
+    def sub_networks_t(self) -> Dict:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("sub_networks"))
+        return self.c.sub_networks.dynamic
+
+    @sub_networks_t.setter
+    def sub_networks_t(self, value: Dict) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("sub_networks"))
+        self.c.sub_networks.dynamic = value
+
+    @property
+    def buses_t(self) -> Dict:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("buses"))
+        return self.c.buses.dynamic
+
+    @buses_t.setter
+    def buses_t(self, value: Dict) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("buses"))
+        self.c.buses.dynamic = value
+
+    @property
+    def carriers_t(self) -> Dict:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("carriers"))
+        return self.c.carriers.dynamic
+
+    @carriers_t.setter
+    def carriers_t(self, value: Dict) -> None:
+        if not options.api.legacy_components:
+            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("carriers"))
+        self.c.carriers.dynamic = value
 
     @property
     def global_constraints_t(self) -> Dict:
@@ -163,16 +379,6 @@ class _NetworkComponents(_NetworkABC):
         self.c.global_constraints.dynamic = value
 
     @property
-    def lines(self) -> Any:
-        return self.c.lines.static if options.api.legacy_components else self.c.lines
-
-    @lines.setter
-    def lines(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.lines.static = value
-
-    @property
     def lines_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("lines"))
@@ -183,20 +389,6 @@ class _NetworkComponents(_NetworkABC):
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("lines"))
         self.c.lines.dynamic = value
-
-    @property
-    def line_types(self) -> Any:
-        return (
-            self.c.line_types.static
-            if options.api.legacy_components
-            else self.c.line_types
-        )
-
-    @line_types.setter
-    def line_types(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.line_types.static = value
 
     @property
     def line_types_t(self) -> Dict:
@@ -211,20 +403,6 @@ class _NetworkComponents(_NetworkABC):
         self.c.line_types.dynamic = value
 
     @property
-    def transformers(self) -> Any:
-        return (
-            self.c.transformers.static
-            if options.api.legacy_components
-            else self.c.transformers
-        )
-
-    @transformers.setter
-    def transformers(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.transformers.static = value
-
-    @property
     def transformers_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("transformers"))
@@ -235,20 +413,6 @@ class _NetworkComponents(_NetworkABC):
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("transformers"))
         self.c.transformers.dynamic = value
-
-    @property
-    def transformer_types(self) -> Any:
-        return (
-            self.c.transformer_types.static
-            if options.api.legacy_components
-            else self.c.transformer_types
-        )
-
-    @transformer_types.setter
-    def transformer_types(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.transformer_types.static = value
 
     @property
     def transformer_types_t(self) -> Dict:
@@ -267,16 +431,6 @@ class _NetworkComponents(_NetworkABC):
         self.c.transformer_types.dynamic = value
 
     @property
-    def links(self) -> Any:
-        return self.c.links.static if options.api.legacy_components else self.c.links
-
-    @links.setter
-    def links(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.links.static = value
-
-    @property
     def links_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("links"))
@@ -287,16 +441,6 @@ class _NetworkComponents(_NetworkABC):
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("links"))
         self.c.links.dynamic = value
-
-    @property
-    def loads(self) -> Any:
-        return self.c.loads.static if options.api.legacy_components else self.c.loads
-
-    @loads.setter
-    def loads(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.loads.static = value
 
     @property
     def loads_t(self) -> Dict:
@@ -311,20 +455,6 @@ class _NetworkComponents(_NetworkABC):
         self.c.loads.dynamic = value
 
     @property
-    def generators(self) -> Any:
-        return (
-            self.c.generators.static
-            if options.api.legacy_components
-            else self.c.generators
-        )
-
-    @generators.setter
-    def generators(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.generators.static = value
-
-    @property
     def generators_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("generators"))
@@ -335,20 +465,6 @@ class _NetworkComponents(_NetworkABC):
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("generators"))
         self.c.generators.dynamic = value
-
-    @property
-    def storage_units(self) -> Any:
-        return (
-            self.c.storage_units.static
-            if options.api.legacy_components
-            else self.c.storage_units
-        )
-
-    @storage_units.setter
-    def storage_units(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.storage_units.static = value
 
     @property
     def storage_units_t(self) -> Dict:
@@ -363,16 +479,6 @@ class _NetworkComponents(_NetworkABC):
         self.c.storage_units.dynamic = value
 
     @property
-    def stores(self) -> Any:
-        return self.c.stores.static if options.api.legacy_components else self.c.stores
-
-    @stores.setter
-    def stores(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.stores.static = value
-
-    @property
     def stores_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("stores"))
@@ -383,20 +489,6 @@ class _NetworkComponents(_NetworkABC):
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("stores"))
         self.c.stores.dynamic = value
-
-    @property
-    def shunt_impedances(self) -> Any:
-        return (
-            self.c.shunt_impedances.static
-            if options.api.legacy_components
-            else self.c.shunt_impedances
-        )
-
-    @shunt_impedances.setter
-    def shunt_impedances(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.shunt_impedances.static = value
 
     @property
     def shunt_impedances_t(self) -> Dict:
@@ -411,16 +503,6 @@ class _NetworkComponents(_NetworkABC):
         self.c.shunt_impedances.dynamic = value
 
     @property
-    def shapes(self) -> Any:
-        return self.c.shapes.static if options.api.legacy_components else self.c.shapes
-
-    @shapes.setter
-    def shapes(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
-            raise AttributeError(_STATIC_SETTER_WARNING)
-        self.c.shapes.static = value
-
-    @property
     def shapes_t(self) -> Dict:
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("shapes"))
@@ -431,3 +513,279 @@ class _NetworkComponents(_NetworkABC):
         if not options.api.legacy_components:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("shapes"))
         self.c.shapes.dynamic = value
+
+    @property
+    def controllable_branch_components(self) -> set[str]:
+        """
+        Controllable branch components of the network as set of strings.
+
+        Examples
+        --------
+        >>> sorted(n.controllable_branch_components)
+        ['Link']
+
+        """
+        return {"Link"}
+
+    @property
+    def controllable_one_port_components(self) -> set[str]:
+        """
+        Controllable one port components of the network as set of strings.
+
+        Examples
+        --------
+        >>> sorted(n.controllable_one_port_components)
+        ['Generator', 'Load', 'StorageUnit', 'Store']
+
+        """
+        return {"StorageUnit", "Store", "Generator", "Load"}
+
+    @property
+    def passive_branch_components(self) -> set[str]:
+        """
+        Passive branch components of the network as set of strings.
+
+        Examples
+        --------
+        >>> sorted(n.passive_branch_components)
+        ['Line', 'Transformer']
+
+        """
+        return {"Transformer", "Line"}
+
+    @property
+    def passive_one_port_components(self) -> set[str]:
+        """
+        Passive one port components of the network as set of strings.
+
+        Examples
+        --------
+        >>> sorted(n.passive_one_port_components)
+        ['ShuntImpedance']
+
+        """
+        return {"ShuntImpedance"}
+
+    @property
+    def standard_type_components(self) -> set[str]:
+        """
+        Standard type components of the network as set of strings.
+
+        Examples
+        --------
+        >>> sorted(n.standard_type_components)
+        ['LineType', 'TransformerType']
+
+        """
+        return {"LineType", "TransformerType"}
+
+    @property
+    def one_port_components(self) -> set[str]:
+        """
+        One port components of the network as set of strings.
+
+        Examples
+        --------
+        >>> sorted(n.one_port_components)
+        ['Generator', 'Load', 'ShuntImpedance', 'StorageUnit', 'Store']
+
+        """
+        return self.passive_one_port_components | self.controllable_one_port_components
+
+    @property
+    def branch_components(self) -> set[str]:
+        """
+        Branch components of the network as set of strings.
+
+        Examples
+        --------
+        >>> sorted(n.branch_components)
+        ['Line', 'Link', 'Transformer']
+
+        """
+        return self.passive_branch_components | self.controllable_branch_components
+
+    @property
+    def all_components(self) -> set[str]:
+        """
+        All components of the network as set of strings.
+
+        Examples
+        --------
+        >>> sorted(n.all_components)
+        ['Bus', 'Carrier', 'Generator', 'GlobalConstraint', 'Line', 'LineType', 'Link', 'Load', 'Shape', 'ShuntImpedance', 'StorageUnit', 'Store', 'SubNetwork', 'Transformer', 'TransformerType']
+
+        """
+        return {
+            "Carrier",
+            "Line",
+            "Transformer",
+            "Shape",
+            "Generator",
+            "StorageUnit",
+            "Store",
+            "ShuntImpedance",
+            "Link",
+            "GlobalConstraint",
+            "SubNetwork",
+            "TransformerType",
+            "LineType",
+            "Bus",
+            "Load",
+        }
+
+    @property
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>.defaults` instead.",
+    )
+    def component_attrs(self) -> pd.DataFrame:
+        """
+        Component attributes.
+
+        Deprecation
+        -----------
+        Deprecated in [:material-tag-outline: v1.0](/release-notes/#v1.0.0) and will be
+        removed in v2.0:
+
+        Use the [Components Class][pypsa.Components] to access components attributes.
+        As a drop in replacement you can use either
+        [`n.components[<component>].defaults`][pypsa.Components.defaults] or
+        `n.components.<component>.defaults`. You can also use the alias [
+        `n.c`][pypsa.Network.c] for [`n.components`][pypsa.Network.components].
+
+        Parameters
+        ----------
+        component_name : string
+
+        Returns
+        -------
+        pandas.DataFrame
+            Component attributes informations.
+
+        """
+        with option_context("warnings.components_store_iter", False):
+            return Dict({value.name: value.defaults for value in self.components})
+
+    @deprecated_in_next_major(
+        details="Use `self.components[<component>].static` instead."
+    )
+    def df(self, component_name: str) -> pd.DataFrame:
+        """
+        Alias for [`n.static`][pypsa.Network.static].
+
+        Deprecation
+        -----------
+        Deprecated in [:material-tag-outline: v1.0](/release-notes/#v1.0.0) and will be
+        removed in v2.0:
+
+        Use the [Components Class][pypsa.Components] to access components attributes.
+        As a drop in replacement you can use either
+        [`n.components[<component>].static`][pypsa.Components.static] or
+        `n.components.<component>.static`. You can also use the alias [
+        `n.c`][pypsa.Network.c] for [`n.components`][pypsa.Network.components].
+
+        Parameters
+        ----------
+        component_name : string
+            Name of the component.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Static data of the component.
+
+        """
+        return self.static(component_name)
+
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>.static` instead."
+    )
+    def static(self, component_name: str) -> pd.DataFrame:
+        """
+        Return the DataFrame of static components for component_name.
+
+        Deprecation
+        -----------
+        Deprecated in [:material-tag-outline: v1.0](/release-notes/#v1.0.0) and will be
+        removed in v2.0:
+
+        Use the [Components Class][pypsa.Components] to access components attributes.
+        As a drop in replacement you can use either
+        [`n.components[<component>].static`][pypsa.Components.static] or
+        `n.components.<component>.static`. You can also use the alias [
+        `n.c`][pypsa.Network.c] for [`n.components`][pypsa.Network.components].
+
+        Parameters
+        ----------
+        component_name : string
+            Name of the component.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Static data of the component.
+
+        """
+        return self.components[component_name].static
+
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>.dynamic` instead.",
+    )
+    def pnl(self, component_name: str) -> Dict:
+        """
+        Alias for [`n.dynamic`][pypsa.Network.dynamic].
+
+        Deprecation
+        -----------
+        Deprecated in [:material-tag-outline: v1.0](/release-notes/#v1.0.0) and will be
+        removed in v2.0:
+
+        Use the [Components Class][pypsa.Components] to access components attributes.
+        As a drop in replacement you can use either
+        [`n.components[<component>].dynamic`][pypsa.Components.dynamic] or
+        `n.components.<component>.dynamic`. You can also use the alias [
+        `n.c`][pypsa.Network.c] for [`n.components`][pypsa.Network.components].
+
+        Parameters
+        ----------
+        component_name : string
+            Name of the component.
+
+        Returns
+        -------
+        dict of pandas.DataFrame
+            Dynamic data of the component.
+
+        """
+        return self.dynamic(component_name)
+
+    @deprecated_in_next_major(
+        details="Use `self.components.<component>.dynamic` instead.",
+    )
+    def dynamic(self, component_name: str) -> Dict:
+        """
+        Return the dictionary of DataFrames of varying components.
+
+        Deprecation
+        -----------
+        Deprecated in [:material-tag-outline: v1.0](/release-notes/#v1.0.0) and will be
+        removed in v2.0:
+
+        Use the [Components Class][pypsa.Components] to access components attributes.
+        As a drop in replacement you can use either
+        [`n.components[<component>].dynamic`][pypsa.Components.dynamic] or
+        `n.components.<component>.dynamic`. You can also use the alias [
+        `n.c`][pypsa.Network.c] for [`n.components`][pypsa.Network.components].
+
+        Parameters
+        ----------
+        component_name : string
+            Name of the component.
+
+        Returns
+        -------
+        dict of pandas.DataFrame
+            Dynamic data of the component.
+
+        """
+        return self.components[component_name].dynamic

--- a/pypsa/network/descriptors.py
+++ b/pypsa/network/descriptors.py
@@ -1,0 +1,269 @@
+"""
+Network descriptors module.
+
+Contains single helper class (_NetworkDescriptors) which is used to inherit
+to Network class. Should not be used directly.
+
+Also See
+--------
+pypsa.components.descriptors
+
+"""
+
+from __future__ import annotations
+
+import logging
+from itertools import repeat
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from pypsa.common import as_index, deprecated_common_kwargs, deprecated_in_next_major
+from pypsa.network.abstract import _NetworkABC
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+logger = logging.getLogger(__name__)
+
+
+class _NetworkDescriptors(_NetworkABC):
+    @deprecated_in_next_major(
+        details="Use `n.components[c].extendables` instead.",
+    )
+    def get_extendable_i(self, c: str) -> pd.Index:
+        """
+        Getter function.
+
+        Get the index of extendable elements of a given component.
+
+        Deprecated: Use n.components[c].get_extendable_i() instead.
+        """
+        return self.components[c].extendables
+
+    @deprecated_in_next_major(details="Use `n.components[c].fixed` instead.")
+    def get_non_extendable_i(self, c: str) -> pd.Index:
+        """
+        Getter function.
+
+        Get the index of non-extendable elements of a given component.
+
+        Deprecated: Use n.components[c].self.fixed instead.
+        """
+        return self.components[c].fixed
+
+    @deprecated_in_next_major(details="Use `n.components[c].committables` instead.")
+    def get_committable_i(self, c: str) -> pd.Index:
+        """
+        Getter function.
+
+        Get the index of commitable elements of a given component.
+
+        Deprecated: Use n.components[c].get_committable_i() instead.
+        """
+        return self.components[c].committables
+
+    @deprecated_in_next_major(
+        details="Use `n.components[c].get_active_assets` instead."
+    )
+    def get_active_assets(
+        self,
+        c: str,
+        investment_period: int | str | Sequence | None = None,
+    ) -> pd.Series:
+        """
+        Get active components mask of component type in investment period(s).
+
+        See the :py:meth:`pypsa.descriptors.components.Component.get_active_assets`.
+
+        Parameters
+        ----------
+        c : string
+            Component name
+        investment_period : int, str, Sequence
+            Investment period(s) to check
+
+        Returns
+        -------
+        pd.Series
+            Boolean mask for active components
+
+        """
+        return self.components[c].get_active_assets(investment_period=investment_period)
+
+    @deprecated_common_kwargs
+    def get_switchable_as_dense(
+        self,
+        component: str,
+        attr: str,
+        snapshots: Sequence | None = None,
+        inds: pd.Index | None = None,
+    ) -> pd.DataFrame:
+        """
+        Return a Dataframe for a time-varying component attribute .
+
+        Values for all non-time-varying components are filled in with the default
+        values for the attribute.
+
+        Parameters
+        ----------
+        component : string
+            Component object name, e.g. 'Generator' or 'Link'
+        attr : string
+            Attribute name
+        snapshots : pandas.Index
+            Restrict to these snapshots rather than n.snapshots.
+        inds : pandas.Index
+            Restrict to these components rather than n.components.index
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Examples
+        --------
+        >>> n.get_switchable_as_dense('Generator', 'p_max_pu', n.snapshots[:2]) # doctest: +SKIP
+        Generator            Manchester Wind  Manchester Gas  Norway Wind  Norway Gas  Frankfurt Wind  Frankfurt Gas
+        snapshot
+        2015-01-01 00:00:00         0.930020             1.0     0.974583         1.0        0.559078            1.0
+        2015-01-01 01:00:00         0.485748             1.0     0.481290         1.0        0.752910            1.0
+
+        """
+        sns = as_index(self, snapshots, "snapshots")
+
+        static = self.static(component)[attr]
+        empty = pd.DataFrame(index=sns)
+        dynamic = self.dynamic(component).get(attr, empty).loc[sns]
+
+        index = static.index
+        if inds is not None:
+            index = index.intersection(inds)
+
+        diff = index.difference(dynamic.columns)
+        static_to_dynamic = pd.DataFrame({**static[diff]}, index=sns)
+        res = pd.concat([dynamic, static_to_dynamic], axis=1, names=sns.names)[index]
+        res.index.name = sns.name
+        res.columns.name = component
+        return res
+
+    @deprecated_common_kwargs
+    def get_switchable_as_iter(
+        self,
+        component: str,
+        attr: str,
+        snapshots: Sequence,
+        inds: pd.Index | None = None,
+    ) -> pd.DataFrame:
+        """
+        Return an iterator over snapshots for a time-varying component attribute.
+
+        Values for all non-time-varying components are filled in with the default
+        values for the attribute.
+
+        Parameters
+        ----------
+        component : string
+            Component object name, e.g. 'Generator' or 'Link'
+        attr : string
+            Attribute name
+        snapshots : pandas.Index
+            Restrict to these snapshots rather than n.snapshots.
+        inds : pandas.Index
+            Restrict to these items rather than all of n.{generators, ..}.index
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Examples
+        --------
+        >>> gen = n.get_switchable_as_iter('Generator', 'p_max_pu', n.snapshots[:2])
+        >>> next(gen)  # doctest: +ELLIPSIS
+        Generator
+        Manchester Wind    0.930020
+        Manchester Gas     1.000000
+        Norway Wind        0.974583
+        Norway Gas         1.000000
+        Frankfurt Wind     0.559078
+        Frankfurt Gas      1.000000
+        dtype: float64
+
+        """
+        static = self.static(component)
+        dynamic = self.dynamic(component)
+
+        index = static.index
+        varying_i = dynamic[attr].columns
+        fixed_i = static.index.difference(varying_i)
+
+        if inds is not None:
+            inds = pd.Index(inds)
+            index = inds.intersection(index)
+            varying_i = inds.intersection(varying_i)
+            fixed_i = inds.intersection(fixed_i)
+
+        # Short-circuit only fixed
+        if len(varying_i) == 0:
+            return repeat(static.loc[fixed_i, attr], len(snapshots))
+
+        def is_same_indices(i1: pd.Index, i2: pd.Index) -> bool:
+            return len(i1) == len(i2) and (i1 == i2).all()
+
+        if is_same_indices(fixed_i.append(varying_i), index):
+
+            def reindex_maybe(s: pd.Series | pd.DataFrame) -> pd.Series | pd.DataFrame:
+                return s
+
+        else:
+
+            def reindex_maybe(s: pd.Series | pd.DataFrame) -> pd.Series | pd.DataFrame:
+                return s.reindex(index)
+
+        return (
+            reindex_maybe(
+                pd.concat(
+                    [static.loc[fixed_i, attr], dynamic[attr].loc[sn, varying_i]],
+                    axis=0,
+                )
+            )
+            for sn in snapshots
+        )
+
+    def bus_carrier_unit(self, bus_carrier: str | Sequence[str] | None) -> str:
+        """
+        Determine the unit associated with a specific bus carrier in the network.
+
+        Parameters
+        ----------
+        bus_carrier : str | Sequence[str] | None
+            The carrier type of the bus to query.
+
+        Returns
+        -------
+        str: The unit associated with the specified bus carrier. If no bus carrier is provided,
+            returns "carrier dependent".
+
+        Raises
+        ------
+        ValueError: If the specified bus carrier is not found in the network or if multiple units
+                    are found for the specified bus carrier.
+
+        """
+        if bus_carrier is None:
+            return "carrier dependent"
+
+        if isinstance(bus_carrier, str):
+            bus_carrier = [bus_carrier]
+
+        not_included = set(bus_carrier) - set(self.c.buses.static.carrier.unique())
+        if not_included:
+            msg = f"Bus carriers {not_included} not in network"
+            raise ValueError(msg)
+        unit = self.c.buses.static[
+            self.c.buses.static.carrier.isin(bus_carrier)
+        ].unit.unique()
+        if len(unit) > 1:
+            logger.warning("Multiple units found for carrier %s: %s", bus_carrier, unit)
+            return "carrier dependent"
+        return unit.item()

--- a/pypsa/network/index.py
+++ b/pypsa/network/index.py
@@ -9,7 +9,7 @@ and convert the Network accordingly.
 
 Also See
 --------
-pypsa.network.index
+pypsa.components.index
 
 """
 
@@ -75,10 +75,6 @@ class _NetworkIndex(_NetworkABC):
         weightings_from_timedelta: bool
             Wheter to use the timedelta of `snapshots` as `snapshot_weightings` if
             `snapshots` is of type `pd.DatetimeIndex`.  Defaults to False.
-
-        Returns
-        -------
-        None
 
         """
         # Check if snapshots contain timezones
@@ -296,13 +292,8 @@ class _NetworkIndex(_NetworkABC):
 
         Parameters
         ----------
-        n : pypsa.Network
         periods : list
             List of periods to be selected/initialized.
-
-        Returns
-        -------
-        None.
 
         """
         periods_ = pd.Index(periods, name="period")

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -388,9 +388,6 @@ def optimize_security_constrained(
         Keyword argument used by `linopy.Model.solve`, such as `solver_name`,
         `problem_fn` or solver options directly passed to the solver.
 
-    Returns
-    -------
-    None
 
     """
     if model_kwargs is None:
@@ -482,9 +479,6 @@ def optimize_with_rolling_horizon(
     **kwargs:
         Keyword argument used by `linopy.Model.solve`, such as `solver_name`,
 
-    Returns
-    -------
-    None
 
     """
     if snapshots is None:

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -15,10 +15,8 @@ from numpy import inf, isfinite
 from scipy import sparse
 from xarray import DataArray, Dataset, concat
 
-from pypsa.common import as_index
+from pypsa.common import as_index, expand_series
 from pypsa.descriptors import (
-    additional_linkports,
-    expand_series,
     get_activity_mask,
     get_bounds_pu,
     nominal_attrs,
@@ -603,7 +601,7 @@ def define_nodal_balance_constraints(
     ]
 
     if not n.links.empty:
-        for i in additional_linkports(n):
+        for i in n.components.links.additional_ports:
             eff = get_as_dense(n, "Link", f"efficiency{i}", sns)
             args.append(["Link", "p", f"bus{i}", eff])
 
@@ -633,7 +631,7 @@ def define_nodal_balance_constraints(
         cbuses = n.static(c)[column][lambda ds: ds.isin(buses)].rename("Bus")
 
         #  drop non-existent multiport buses which are ''
-        if column in ["bus" + i for i in additional_linkports(n)]:
+        if column in ["bus" + i for i in n.c.links.additional_ports]:
             cbuses = cbuses[cbuses != ""]
 
         expr = expr.sel({c: cbuses.index})
@@ -1061,9 +1059,7 @@ def define_total_supply_constraints(n: Network, sns: Sequence) -> None:
     sns : Sequence
         A list of snapshots (time steps) over which the constraints are applied.
 
-    Returns
-    -------
-    None
+
 
     """
     sns_ = as_index(n, sns, "snapshots")

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -33,10 +33,6 @@ def define_tech_capacity_expansion_limit(n: Network, sns: Sequence) -> None:
     sns : list-like
         Set of snapshots to which the constraint should be applied.
 
-    Returns
-    -------
-    None.
-
     """
     m = n.model
     glcs = n.global_constraints.loc[
@@ -106,10 +102,6 @@ def define_nominal_constraints_per_bus_carrier(n: Network, sns: pd.Index) -> Non
     n : pypsa.Network
     sns : list-like
         Set of snapshots to which the constraint should be applied.
-
-    Returns
-    -------
-    None.
 
     """
     m = n.model
@@ -252,10 +244,6 @@ def define_primary_energy_limit(n: Network, sns: pd.Index) -> None:
     sns : list-like
         Set of snapshots to which the constraint should be applied.
 
-    Returns
-    -------
-    None.
-
     """
     m = n.model
     weightings = n.snapshot_weightings.loc[sns]
@@ -331,10 +319,6 @@ def define_operational_limit(n: Network, sns: pd.Index) -> None:
     sns : list-like
         Set of snapshots to which the constraint should be applied.
 
-    Returns
-    -------
-    None.
-
     """
     m = n.model
     weightings = n.snapshot_weightings.loc[sns]
@@ -400,9 +384,6 @@ def define_transmission_volume_expansion_limit(n: Network, sns: Sequence) -> Non
     sns : list-like
         Set of snapshots to which the constraint should be applied.
 
-    Returns
-    -------
-    None.
 
     """
     m = n.model
@@ -462,10 +443,6 @@ def define_transmission_expansion_cost_limit(n: Network, sns: pd.Index) -> None:
     n : pypsa.Network
     sns : list-like
         Set of snapshots to which the constraint should be applied.
-
-    Returns
-    -------
-    None.
 
     """
     m = n.model

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -15,7 +15,7 @@ from linopy import Model, merge
 from linopy.solvers import available_solvers
 
 from pypsa.common import as_index
-from pypsa.descriptors import additional_linkports, get_committable_i, nominal_attrs
+from pypsa.descriptors import get_committable_i, nominal_attrs
 from pypsa.descriptors import get_switchable_as_dense as get_as_dense
 from pypsa.optimization.abstract import (
     optimize_and_run_non_linear_powerflow,
@@ -361,7 +361,7 @@ def assign_solution(n: Network) -> None:
             elif c == "Link" and attr == "p":
                 set_from_frame(n, c, "p0", df)
 
-                for i in ["1"] + additional_linkports(n):
+                for i in ["1"] + n.c.links.additional_ports:
                     i_eff = "" if i == "1" else i
                     eff = get_as_dense(n, "Link", f"efficiency{i_eff}", sns)
                     set_from_frame(n, c, f"p{i}", -df * eff)
@@ -487,7 +487,7 @@ def post_processing(n: Network) -> None:
         ("Link", "p0", "bus0"),
         ("Link", "p1", "bus1"),
     ]
-    ca.extend([("Link", f"p{i}", f"bus{i}") for i in additional_linkports(n)])
+    ca.extend([("Link", f"p{i}", f"bus{i}") for i in n.c.links.additional_ports])
 
     def sign(c: str) -> int:
         return n.static(c).sign if "sign" in n.static(c) else -1  # sign for 'Link'

--- a/pypsa/plot/maps/static.py
+++ b/pypsa/plot/maps/static.py
@@ -448,10 +448,6 @@ class MapPlotter:
 
         Parameters
         ----------
-        x : numpy.ndarray
-            X data to add jitter to.
-        y : numpy.ndarray
-            Y data to add jitter to.
         jitter : float
             The amount of jitter to add. Function adds a random number between -jitter and
             jitter to each element in the data arrays.
@@ -940,7 +936,7 @@ class MapPlotter:
         """
         return abs(flow) ** 0.5 * width_factor
 
-    def draw_map(
+    def draw_map(  # noqa: D417
         self,
         ax: Axes | None = None,
         projection: Any = None,
@@ -983,18 +979,8 @@ class MapPlotter:
 
         Parameters
         ----------
-        n : pypsa.Network
-            Network to plot
-        layouter : networkx.drawing.layout, default None
-            Layouting function from `networkx <https://networkx.github.io/>`_ which
-            overrules coordinates given in ``n.buses[['x', 'y']]``. See
-            `list <https://networkx.github.io/documentation/stable/reference/drawing.html#module-networkx.drawing.layout>`_
-            of available options.
         boundaries : list/tuple, default None
             Boundaries of the plot in format [x1, x2, y1, y2]
-        margin : float, defaults to 0.05
-            Margin at the sides as proportion of distance between max/min x, y
-            Will be ignored if boundaries are given.
         ax : matplotlib.pyplot.Axes, defaults to None
             Axis to plot on. Defaults to plt.gca() if geomap is False, otherwise
             to plt.axes(projection=projection).
@@ -1016,9 +1002,6 @@ class MapPlotter:
             If False, no geographical features are plotted.
         title : string, default ""
             Graph title
-        jitter : float, default None
-            Amount of random noise to add to bus positions to distinguish
-            overlapping buses
         branch_components : list, default n.branch_components
             Branch components to be plotted
         bus_sizes : float/dict/pandas.Series
@@ -1052,8 +1035,8 @@ class MapPlotter:
             with widths in display units. The latter is useful for plotting
             consistent branch widths and flows in different zoom levels.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         line_flow : str/callable/dict/pandas.Series/Network.snapshots, default None
             Flow to be for each line branch. If an element of
             n.snapshots is given, the flow at this timestamp will be

--- a/pypsa/plot/statistics/schema.py
+++ b/pypsa/plot/statistics/schema.py
@@ -180,7 +180,7 @@ def _combine_schemas() -> dict:
                     "allowed": allowed_by_default,
                 }
 
-                # Allow if additional parameters selection again
+                # Allow if Other Parameters selection again
                 if param in SCHEMA_ADDITIONAL_PARAMETERS.get(stat_name, []):
                     combined_schema[stat_name][plot_type][param]["allowed"] = True
 

--- a/pypsa/statistics/abstract.py
+++ b/pypsa/statistics/abstract.py
@@ -240,7 +240,7 @@ class AbstractStatisticsAccessor(ABC):
         if is_one_component := isinstance(comps, str):
             comps = [comps]
         if comps is None:
-            comps = n.branch_components | n.one_port_components
+            comps = sorted(n.branch_components | n.one_port_components)
         if nice_names is None:
             # TODO move to _apply_option_kwargs
             nice_names = options.params.statistics.nice_names

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -21,7 +21,7 @@ from pypsa.common import (
     deprecated_kwargs,
     pass_empty_series_if_keyerror,
 )
-from pypsa.descriptors import bus_carrier_unit, nominal_attrs
+from pypsa.descriptors import nominal_attrs
 from pypsa.statistics.abstract import AbstractStatisticsAccessor
 
 if TYPE_CHECKING:
@@ -159,7 +159,70 @@ class StatisticHandler:
 
 
 class StatisticsAccessor(AbstractStatisticsAccessor):
-    """Accessor to calculate different statistical values."""
+    """
+    Accessor to calculate different metrics from the network.
+
+    The accessor can be used with any [pypsa.Network][] instance via `n.statistics`. All
+    statistics methods are another level of accessors, which means that they can yield
+    statistics as pandas DataFrames or plots based on them. See the examples for more
+    details.
+
+    User Guide
+    ----------
+    Check out the corresponding user guide: [:material-bookshelf: Statistics](/user-guide/statistics)
+
+    Examples
+    --------
+    The examples below can be used with any statistical method. The default arguments
+    used and the plot type yielded will vary.
+
+    Get aggregated statistics in a single DataFrame:
+
+    >>> n_solved.statistics()
+                        Optimal Capacity  ...  Market Value
+    Generator gas          982.03448  ...   1559.511099
+              wind        7292.13406  ...    589.813549
+    Line      AC          5613.82931  ...    -43.277041
+    Link      DC          4003.90110  ...      0.132018
+    Load      load           0.00000  ...           NaN
+    <BLANKLINE>
+    [5 rows x 12 columns]
+
+    Get the energy balance:
+
+    >>> n_solved.statistics.energy_balance()
+    component  carrier  bus_carrier
+    Generator  gas      AC              1465.27439
+               wind     AC             31082.35370
+    Load       load     AC            -32547.62808
+    dtype: float64
+
+    Get the optimal capacity:
+
+    >>> n_solved.statistics.optimal_capacity()
+    component  carrier
+    Generator  gas         982.03448
+               wind       7292.13406
+    Line       AC         5613.82931
+    Link       DC         4003.90110
+    dtype: float64
+
+    Create a basic plot on any statistic:
+
+    >>> n_solved.statistics.energy_balance.plot() # doctest: +SKIP
+    #TODO Add plot
+
+    Choose a specific plot type:
+
+    >>> n_solved.statistics.energy_balance.plot("bar") # doctest: +SKIP
+    #TODO Add plot
+
+    Create a interactive plot:
+
+    >>> n_solved.statistics.energy_balance.iplot() # doctest: +SKIP
+    #TODO Add plot
+
+    """
 
     _methods = [
         "system_cost",
@@ -283,7 +346,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         aggregate_time: None = None,
     ) -> pd.DataFrame:
         """
-        Calculate statistical values for a network.
+        Calculate **multiple statistical values** for a network.
 
         This function calls multiple function in the background in order to
         derive a full table of relevant network information. It groups the
@@ -336,6 +399,16 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         df :
             pandas.DataFrame with columns given the different quantities.
 
+        Examples
+        --------
+        >>> n_solved.statistics.optimal_capacity()
+        component  carrier
+        Generator  gas         982.03448
+                   wind       7292.13406
+        Line       AC         5613.82931
+        Link       DC         4003.90110
+        dtype: float64
+
         """
         if aggregate_time is not None:
             warnings.warn(
@@ -380,7 +453,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return pd.concat(res, axis=1).sort_index(axis=0)
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def capex(
+    def capex(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
@@ -395,7 +468,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         cost_attribute: str = "capital_cost",
     ) -> pd.DataFrame:
         """
-        Calculate the capital expenditure.
+        Calculate the **capital expenditure**.
 
         Includes newly installed and existing assets, measured in the specified
         currency.
@@ -440,8 +513,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         cost_attribute : str
             Network attribute that should be used to calculate Capital Expenditure.
             Defaults to `capital_cost`.
@@ -452,9 +525,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             Capital expenditure with components as rows and a single column of
             aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.capex()
+        Examples
+        --------
+        >>> n_solved.statistics.capex()
         Series([], dtype: float64)
 
         """
@@ -482,7 +555,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def installed_capex(
+    def installed_capex(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
@@ -497,7 +570,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         cost_attribute: str = "capital_cost",
     ) -> pd.DataFrame:
         """
-        Calculate the capital expenditure of already built capacities.
+        Calculate the **capital expenditure** of already built capacities.
 
         Parameters
         ----------
@@ -539,8 +612,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         cost_attribute : str
             Network attribute that should be used to calculate Capital Expenditure.
             Defaults to `capital_cost`.
@@ -551,11 +624,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             Capital expenditure of already built capacities with components as rows and
             a single column of aggregated values.
 
-        Example
-        -------
-
-
-        >>> n.statistics.installed_capex().sort_index()
+        Examples
+        --------
+        >>> n_solved.statistics.installed_capex()
         component  carrier
         Generator  gas        2.120994e+07
                    wind       6.761698e+05
@@ -588,7 +659,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def expanded_capex(
+    def expanded_capex(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
@@ -603,7 +674,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         cost_attribute: str = "capital_cost",
     ) -> pd.DataFrame:
         """
-        Calculate the capital expenditure of expanded capacities.
+        Calculate the **capital expenditure** of expanded capacities.
 
         Parameters
         ----------
@@ -645,8 +716,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         cost_attribute : str
             Network attribute that should be used to calculate Capital Expenditure.
             Defaults to `capital_cost`.
@@ -657,9 +728,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             Capital expenditure of expanded capacities with components as rows and
             a single column of aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.expanded_capex().sort_index() # doctest: +ELLIPSIS
+        Examples
+        --------
+        >>> n_solved.statistics.expanded_capex()
         component  carrier
         Generator  gas       -2.120994e+07
                    wind      -6.761698e+05
@@ -699,7 +770,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def optimal_capacity(
+    def optimal_capacity(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
@@ -714,7 +785,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         storage: bool = False,
     ) -> pd.DataFrame:
         """
-        Calculate the optimal capacity of the network components in MW.
+        Calculate the **optimal capacity** of the network components in MW.
 
         Positive capacity values correspond to production capacities and
         negative values to consumption capacities.
@@ -759,8 +830,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         storage : bool, default=False
             Whether to consider only storage capacities of the components
             `Store` and `StorageUnit`.
@@ -771,11 +842,15 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             Optimal capacity of the network components with components as rows and
             a single column of aggregated values.
 
-        Example
-        -------
-
-        >>> n.statistics.optimal_capacity()
-        Series([], dtype: float64)
+        Examples
+        --------
+        >>> n_solved.statistics.optimal_capacity()
+        component  carrier
+        Generator  gas         982.03448
+                   wind       7292.13406
+        Line       AC         5613.82931
+        Link       DC         4003.90110
+        dtype: float64
 
         """
         if storage:
@@ -811,7 +886,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def installed_capacity(
+    def installed_capacity(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_groups: Callable | str = "sum",
@@ -826,7 +901,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         storage: bool = False,
     ) -> pd.DataFrame:
         """
-        Calculate the installed capacity of the network components in MW.
+        Calculate the **installed capacity** of the network components in MW.
 
         Positive capacity values correspond to production capacities and
         negative values to consumption capacities.
@@ -871,8 +946,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         storage : bool, default=False
             Whether to consider only storage capacities of the components
             `Store` and `StorageUnit`.
@@ -883,10 +958,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
                 Installed capacity of the network components with components as rows and
                 a single column of aggregated values.
 
-        Example
-        -------
-
-        >>> n.statistics.installed_capacity().sort_index()
+        Examples
+        --------
+        >>> n_solved.statistics.installed_capacity()
         component  carrier
         Generator  gas        150000.0
                    wind          290.0
@@ -942,7 +1016,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         round: int | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the expanded capacity of the network components in MW.
+        Calculate the **expanded capacity** of the network components in MW.
 
         Positive capacity values correspond to production capacities and
         negative values to consumption capacities.
@@ -993,10 +1067,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             Expanded capacity of the network components with components as rows and
             a single column of aggregated values.
 
-        Example
-        -------
-
-        >>> n.statistics.expanded_capacity()
+        Examples
+        --------
+        >>> n_solved.statistics.expanded_capacity()
         Series([], dtype: float64)
 
         """
@@ -1031,7 +1104,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def opex(
+    def opex(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
@@ -1047,7 +1120,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         cost_types: str | Sequence[str] | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the operational expenditure in the network in given currency.
+        Calculate the **operational expenditure** in the network in given currency.
 
         Operational expenditures include the marginal, marginal quadratic,
         storage holding, spillage, start-up, shut-down and stand-by costs.
@@ -1092,8 +1165,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -1112,10 +1185,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             either time steps as columns (if aggregate_time=False) or a single column
             of aggregated values.
 
-        Example
-        -------
-
-        >>> n.statistics.opex()
+        Examples
+        --------
+        >>> n_solved.statistics.opex()
         Series([], dtype: float64)
 
         """
@@ -1197,7 +1269,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def system_cost(
+    def system_cost(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
@@ -1212,7 +1284,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         round: int | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the total system cost.
+        Calculate the **total system cost**.
 
         Sum of the capital and operational expenditures.
 
@@ -1256,8 +1328,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -1270,9 +1342,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             System cost with components as rows and a single column of
             aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.system_cost()
+        Examples
+        --------
+        >>> n_solved.statistics.system_cost()
         Series([], dtype: float64)
 
         """
@@ -1307,7 +1379,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def supply(
+    def supply(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
@@ -1322,7 +1394,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         round: int | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the supply of components in the network.
+        Calculate the **supply** of components in the network.
 
         Units depend on the regarded bus carrier.
 
@@ -1366,8 +1438,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -1381,9 +1453,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             either time steps as columns (if aggregate_time=False) or a single column
             of aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.supply()
+        Examples
+        --------
+        >>> n_solved.statistics.supply()
         Series([], dtype: float64)
 
         """
@@ -1406,7 +1478,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def withdrawal(
+    def withdrawal(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
@@ -1421,7 +1493,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         round: int | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the withdrawal of components in the network.
+        Calculate the **withdrawal** of components in the network.
 
         Units depend on the regarded bus carrier.
 
@@ -1465,8 +1537,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -1480,9 +1552,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             either time steps as columns (if aggregate_time=False) or a single column
             of aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.withdrawal()
+        Examples
+        --------
+        >>> n_solved.statistics.withdrawal()
         Series([], dtype: float64)
 
         """
@@ -1505,7 +1577,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def transmission(
+    def transmission(  # noqa: D417
         self,
         comps: Collection[str] | str | None = None,
         aggregate_time: str | bool = "sum",
@@ -1520,7 +1592,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         round: int | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the transmission of branch components in the network.
+        Calculate the **transmission** of branch components in the network.
 
         Units depend on the regarded bus carrier.
 
@@ -1564,8 +1636,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -1579,9 +1651,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             either time steps as columns (if aggregate_time=False) or a single column
             of aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.transmission()
+        Examples
+        --------
+        >>> n_solved.statistics.transmission()
         Series([], dtype: object)
 
         """
@@ -1617,7 +1689,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
     @deprecated_kwargs(kind="direction", deprecated_in="0.34", removed_in="1.0")
-    def energy_balance(
+    def energy_balance(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
@@ -1633,7 +1705,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         direction: str | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate energy balance of components in network.
+        Calculate the **energy balance** of components in network.
 
         This method computes the energy balance across various network components, where
         positive values represent supply and negative values represent withdrawal. Units
@@ -1679,8 +1751,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -1699,9 +1771,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             (if aggregate_time=False) or a single column of aggregated values.
             Units depend on the bus carrier and aggregation method.
 
-        Example
-        -------
-        >>> n.statistics.energy_balance()
+        Examples
+        --------
+        >>> n_solved.statistics.energy_balance()
         Series([], dtype: float64)
 
         """
@@ -1749,11 +1821,11 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         )
 
         df.attrs["name"] = "Energy Balance"
-        df.attrs["unit"] = bus_carrier_unit(n, bus_carrier)
+        df.attrs["unit"] = n.bus_carrier_unit(bus_carrier)
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def curtailment(
+    def curtailment(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
@@ -1768,7 +1840,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         round: int | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the curtailment of components in the network in MWh.
+        Calculate the **curtailment** of components in the network in MWh.
 
         The calculation only considers assets with a `p_max_pu` time
         series, which is used to quantify the available power potential.
@@ -1813,8 +1885,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -1828,9 +1900,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             either time steps as columns (if aggregate_time=False) or a single column
             of aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.curtailment()
+        Examples
+        --------
+        >>> n_solved.statistics.curtailment()
         Series([], Name: generators, dtype: float64)
 
         """
@@ -1862,7 +1934,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def capacity_factor(
+    def capacity_factor(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "mean",
@@ -1877,7 +1949,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         round: int | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the capacity factor of components in the network.
+        Calculate the **capacity factor** of components in the network.
 
         Parameters
         ----------
@@ -1919,8 +1991,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -1934,9 +2006,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             either time steps as columns (if aggregate_time=False) or a single column
             of aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.capacity_factor()
+        Examples
+        --------
+        >>> n_solved.statistics.capacity_factor()
         Series([], dtype: float64)
 
         """
@@ -1968,7 +2040,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
     @deprecated_kwargs(kind="direction", deprecated_in="0.34", removed_in="1.0")
-    def revenue(
+    def revenue(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "sum",
@@ -1984,7 +2056,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         direction: str | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the revenue of components in the network in given currency.
+        Calculate the **revenue** of components in the network in given currency.
 
         The revenue is defined as the net revenue of an asset, i.e cost
         of input - revenue of output.
@@ -2029,8 +2101,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -2047,9 +2119,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             either time steps as columns (if aggregate_time=False) or a single column
             of aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.revenue()
+        Examples
+        --------
+        >>> n_solved.statistics.revenue()
         Series([], dtype: float64)
 
         """
@@ -2092,7 +2164,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         return df
 
     @MethodHandlerWrapper(handler_class=StatisticHandler, inject_attrs={"n": "_n"})
-    def market_value(
+    def market_value(  # noqa: D417
         self,
         comps: str | Sequence[str] | None = None,
         aggregate_time: str | bool = "mean",
@@ -2107,7 +2179,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         round: int | None = None,
     ) -> pd.DataFrame:
         """
-        Calculate the market value of components in the network.
+        Calculate the **market value** of components in the network.
 
         Curreny is currency/MWh or currency/unit_{bus_carrier} where unit_{bus_carrier}
         is the unit of the bus carrier.
@@ -2152,8 +2224,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             option (default: 2). See `pypsa.options.params.statistics.describe()` for
             more information.
 
-        Additional Parameters
-        ---------------------
+        Other Parameters
+        ----------------
         aggregate_time : str | bool, default="sum"
             Type of aggregation when aggregating time series. Deactivate by setting to
             False. Any pandas aggregation function can be used. Note that when
@@ -2167,9 +2239,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             either time steps as columns (if aggregate_time=False) or a single column
             of aggregated values.
 
-        Example
-        -------
-        >>> n.statistics.market_value()
+        Examples
+        --------
+        >>> n_solved.statistics.market_value()
         Series([], dtype: float64)
 
         """

--- a/pypsa/statistics/grouping.py
+++ b/pypsa/statistics/grouping.py
@@ -82,9 +82,7 @@ class Groupers:
         value : Callable
             Custom grouper function.
 
-        Returns
-        -------
-        None
+
 
         """
         raise NotImplementedError()
@@ -197,9 +195,6 @@ class Groupers:
             * port (str): Component port as integer string
             * nice_names (bool, optional): Whether to use nice carrier names
 
-        Returns
-        -------
-        None
 
         """
         setattr(self, name, func)

--- a/test/test_descriptors.py
+++ b/test/test_descriptors.py
@@ -1,16 +1,18 @@
+import warnings
+
 import pandas as pd
 import pytest
 
 import pypsa
+from pypsa.common import expand_series
 from pypsa.descriptors import (
     additional_linkports,
-    allocate_series_dataframes,
-    expand_series,
     get_extendable_i,
     get_non_extendable_i,
     get_switchable_as_dense,
     get_switchable_as_iter,
 )
+from pypsa.pf import allocate_series_dataframes
 
 
 @pytest.fixture
@@ -99,5 +101,9 @@ def test_additional_linkports():
     n.add("Bus", "bus2")
     n.add("Link", "link0", bus0="bus0", bus1="bus1", bus2="bus2")
 
-    ports = additional_linkports(n, n.links.columns)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+        ports = additional_linkports(n, n.links.columns)
     assert ports == ["2"]
+    assert ports == n.c.links.additional_ports

--- a/test/test_docs.py
+++ b/test/test_docs.py
@@ -22,11 +22,15 @@ except ImportError:
 
 sub_network_parent = pypsa.examples.ac_dc_meshed().determine_network_topology()
 # Warning: Keep in sync with settings in doc/conf.py
+n_solved = pypsa.examples.ac_dc_meshed()
+n_solved.optimize()
+
 doctest_globals = {
     "np": np,
     "pd": pd,
     "pypsa": pypsa,
     "n": pypsa.examples.ac_dc_meshed(),
+    "n_solved": n_solved,
     "c": pypsa.examples.ac_dc_meshed().components.generators,
     "sub_network_parent": pypsa.examples.ac_dc_meshed().determine_network_topology(),
     "sub_network": sub_network_parent.sub_networks.loc["0", "obj"],


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Refactors, deprecates and moves logic of `descriptors.py` in Network class or more suitable module
- Moves more components logic to Network class
- Improved docstrings for a couple of modules

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
