### PR TITLE
use n.snapshot_weightings.objective in `n.statistics.opex()`

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -40,6 +40,9 @@ Upcoming Release
 * The components subpackage was further restructured. The known API remains untouched.
   (https://github.com/PyPSA/PyPSA/pull/1223)
 
+* Bugfix: The function ``n.statistics.opex()`` now considers the correct
+  snapshot weightings ``n.snapshot_weightings.objective``. 
+
 Bug Fixes
 --------
 

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -1343,7 +1343,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         # @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
             result = []
-            weights = get_weightings(n, c)
+            weights = n.snapshot_weightings.objective
             weights_one = pd.Series(1.0, index=weights.index)
             com_i = n.get_committable_i(c)
 


### PR DESCRIPTION
closes #1200

But we generally need more consistency for when which snapshot weightings are used.