### PR TITLE
fix: resolve user warning when using regex groups

### DIFF
--- a/pypsa/components/_types/links.py
+++ b/pypsa/components/_types/links.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from pypsa.components._types._patch import patch_add_docstring
 from pypsa.components.components import Components
-from pypsa.constants import PATTERN_PORTS_GE_2
+from pypsa.constants import RE_PORTS_GE_2
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -87,5 +87,5 @@ class Links(Components):
         return [
             match.group(1)
             for col in self.static.columns
-            if (match := PATTERN_PORTS_GE_2.search(col))
+            if (match := RE_PORTS_GE_2.search(col))
         ]

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -27,7 +27,7 @@ from pypsa.common import equals
 from pypsa.components.descriptors import ComponentsDescriptorsMixin
 from pypsa.components.index import ComponentsIndexMixin
 from pypsa.components.transform import ComponentsTransformMixin
-from pypsa.constants import DEFAULT_EPSG, DEFAULT_TIMESTAMP, PATTERN_PORTS
+from pypsa.constants import DEFAULT_EPSG, DEFAULT_TIMESTAMP, RE_PORTS
 from pypsa.definitions.structures import Dict
 
 logger = logging.getLogger(__name__)
@@ -633,9 +633,7 @@ class Components(
 
         """
         return [
-            match.group(1)
-            for col in self.static
-            if (match := PATTERN_PORTS.search(col))
+            match.group(1) for col in self.static if (match := RE_PORTS.search(col))
         ]
 
 

--- a/pypsa/consistency.py
+++ b/pypsa/consistency.py
@@ -13,7 +13,7 @@ import pandas as pd
 from deprecation import deprecated
 
 from pypsa.common import deprecated_common_kwargs
-from pypsa.constants import PATTERN_PORTS
+from pypsa.constants import RE_PORTS_FILTER
 from pypsa.network.abstract import _NetworkABC
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ class ConsistencyError(ValueError):
 
 
 def _bus_columns(df: pd.DataFrame) -> pd.Index:
-    return df.columns[df.columns.str.contains(PATTERN_PORTS)]
+    return df.columns[df.columns.str.contains(RE_PORTS_FILTER)]
 
 
 def _log_or_raise(strict: bool, message: str, *args: Any) -> None:

--- a/pypsa/constants.py
+++ b/pypsa/constants.py
@@ -5,8 +5,8 @@ import re
 DEFAULT_EPSG = 4326
 DEFAULT_TIMESTAMP = "now"
 
-RE_PORTS = r"^bus(\d*)$"
-PATTERN_PORTS = re.compile(RE_PORTS)
+RE_PORTS = re.compile(r"^bus(\d*)$")
+# Pattern for filtering bus columns without capture groups
+RE_PORTS_FILTER = re.compile(r"^bus\d*$")
 # Pattern to get port numbers greater or equal to 2
-RE_PORTS_GE_2 = r"^bus([2-9]\d*)$"
-PATTERN_PORTS_GE_2 = re.compile(RE_PORTS_GE_2)
+RE_PORTS_GE_2 = re.compile(r"^bus([2-9]\d*)$")

--- a/pypsa/constants.py
+++ b/pypsa/constants.py
@@ -9,4 +9,4 @@ RE_PORTS = re.compile(r"^bus(\d*)$")
 # Pattern for filtering bus columns without capture groups
 RE_PORTS_FILTER = re.compile(r"^bus\d*$")
 # Pattern to get port numbers greater or equal to 2
-RE_PORTS_GE_2 = re.compile(r"^bus([2-9]\d*)$")
+RE_PORTS_GE_2 = re.compile(r"^bus((?:[2-9]|[1-9]\d+))$")

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -13,7 +13,7 @@ import pandas as pd
 from deprecation import deprecated
 
 from pypsa.common import deprecated_common_kwargs, deprecated_in_next_major
-from pypsa.constants import PATTERN_PORTS_GE_2
+from pypsa.constants import RE_PORTS_GE_2
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Sequence
@@ -444,9 +444,7 @@ def additional_linkports(n: Network, where: Iterable[str] | None = None) -> list
     """
     if where is None:
         where = n.links.columns
-    return [
-        match.group(1) for col in where if (match := PATTERN_PORTS_GE_2.search(col))
-    ]
+    return [match.group(1) for col in where if (match := RE_PORTS_GE_2.search(col))]
 
 
 @deprecated(

--- a/pypsa/optimization/common.py
+++ b/pypsa/optimization/common.py
@@ -59,7 +59,12 @@ def get_strongly_meshed_buses(n: Network, threshold: int = 45) -> pd.Series:
 
     """
     all_buses = pd.Series(
-        hstack([ravel(c.static.filter(regex=RE_PORTS)) for c in n.iterate_components()])
+        hstack(
+            [
+                ravel(c.static.filter(regex=RE_PORTS.pattern))
+                for c in n.iterate_components()
+            ]
+        )
     )
     all_buses = all_buses[all_buses != ""]
     counts = all_buses.value_counts()

--- a/pypsa/statistics/abstract.py
+++ b/pypsa/statistics/abstract.py
@@ -12,7 +12,7 @@ import pandas as pd
 from deprecation import deprecated
 
 from pypsa._options import options
-from pypsa.constants import PATTERN_PORTS
+from pypsa.constants import RE_PORTS
 from pypsa.statistics.grouping import deprecated_groupers, groupers
 
 if TYPE_CHECKING:
@@ -249,7 +249,7 @@ class AbstractStatisticsAccessor(ABC):
             ports = [
                 match.group(1)
                 for col in n.static(c)
-                if (match := PATTERN_PORTS.search(str(col)))
+                if (match := RE_PORTS.search(str(col)))
             ]
             if not at_port:
                 ports = [ports[0]]

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -1,0 +1,163 @@
+"""Test constants module."""
+
+import re
+
+import pytest
+
+from pypsa.constants import (
+    DEFAULT_EPSG,
+    DEFAULT_TIMESTAMP,
+    RE_PORTS,
+    RE_PORTS_FILTER,
+    RE_PORTS_GE_2,
+)
+
+
+class TestConstants:
+    """Test constants values."""
+
+    def test_default_epsg(self):
+        """Test DEFAULT_EPSG constant."""
+        assert DEFAULT_EPSG == 4326
+        assert isinstance(DEFAULT_EPSG, int)
+
+    def test_default_timestamp(self):
+        """Test DEFAULT_TIMESTAMP constant."""
+        assert DEFAULT_TIMESTAMP == "now"
+        assert isinstance(DEFAULT_TIMESTAMP, str)
+
+
+class TestRegexPatterns:
+    """Test regex pattern constants."""
+
+    def test_re_ports_basic_matches(self):
+        """Test RE_PORTS pattern matches basic bus columns."""
+        assert RE_PORTS.match("bus")
+        assert RE_PORTS.match("bus0")
+        assert RE_PORTS.match("bus1")
+        assert RE_PORTS.match("bus2")
+        assert RE_PORTS.match("bus10")
+        assert RE_PORTS.match("bus123")
+
+    def test_re_ports_capture_groups(self):
+        """Test RE_PORTS pattern capture groups."""
+        match = RE_PORTS.match("bus")
+        assert match.group(1) == ""
+
+        match = RE_PORTS.match("bus0")
+        assert match.group(1) == "0"
+
+        match = RE_PORTS.match("bus123")
+        assert match.group(1) == "123"
+
+    def test_re_ports_non_matches(self):
+        """Test RE_PORTS pattern non-matches."""
+        assert not RE_PORTS.match("Bus")
+        assert not RE_PORTS.match("bus_")
+        assert not RE_PORTS.match("bus-1")
+        assert not RE_PORTS.match("busx")
+        assert not RE_PORTS.match("load")
+        assert not RE_PORTS.match("generator")
+        assert not RE_PORTS.match("")
+
+    def test_re_ports_filter_matches(self):
+        """Test RE_PORTS_FILTER pattern matches."""
+        assert RE_PORTS_FILTER.match("bus")
+        assert RE_PORTS_FILTER.match("bus0")
+        assert RE_PORTS_FILTER.match("bus1")
+        assert RE_PORTS_FILTER.match("bus2")
+        assert RE_PORTS_FILTER.match("bus10")
+        assert RE_PORTS_FILTER.match("bus123")
+
+    def test_re_ports_filter_non_matches(self):
+        """Test RE_PORTS_FILTER pattern non-matches."""
+        assert not RE_PORTS_FILTER.match("Bus")
+        assert not RE_PORTS_FILTER.match("bus_")
+        assert not RE_PORTS_FILTER.match("bus-1")
+        assert not RE_PORTS_FILTER.match("busx")
+        assert not RE_PORTS_FILTER.match("load")
+        assert not RE_PORTS_FILTER.match("")
+
+    def test_re_ports_ge_2_matches(self):
+        """Test RE_PORTS_GE_2 pattern matches ports >= 2."""
+        assert RE_PORTS_GE_2.match("bus2")
+        assert RE_PORTS_GE_2.match("bus3")
+        assert RE_PORTS_GE_2.match("bus9")
+        assert RE_PORTS_GE_2.match("bus10")
+        assert RE_PORTS_GE_2.match("bus11")
+        assert RE_PORTS_GE_2.match("bus23")
+        assert RE_PORTS_GE_2.match("bus100")
+        assert RE_PORTS_GE_2.match("bus999")
+
+    def test_re_ports_ge_2_capture_groups(self):
+        """Test RE_PORTS_GE_2 pattern capture groups."""
+        match = RE_PORTS_GE_2.match("bus2")
+        assert match.group(1) == "2"
+
+        match = RE_PORTS_GE_2.match("bus10")
+        assert match.group(1) == "10"
+
+        match = RE_PORTS_GE_2.match("bus123")
+        assert match.group(1) == "123"
+
+    def test_re_ports_ge_2_non_matches(self):
+        """Test RE_PORTS_GE_2 pattern non-matches for ports < 2."""
+        assert not RE_PORTS_GE_2.match("bus")
+        assert not RE_PORTS_GE_2.match("bus0")
+        assert not RE_PORTS_GE_2.match("bus1")
+        assert not RE_PORTS_GE_2.match("Bus2")
+        assert not RE_PORTS_GE_2.match("bus_2")
+        assert not RE_PORTS_GE_2.match("bus-2")
+        assert not RE_PORTS_GE_2.match("busx")
+        assert not RE_PORTS_GE_2.match("")
+
+    def test_regex_pattern_types(self):
+        """Test that regex patterns are compiled Pattern objects."""
+        assert isinstance(RE_PORTS, re.Pattern)
+        assert isinstance(RE_PORTS_FILTER, re.Pattern)
+        assert isinstance(RE_PORTS_GE_2, re.Pattern)
+
+    @pytest.mark.parametrize(
+        ("pattern", "test_string", "expected"),
+        [
+            (RE_PORTS, "bus", True),
+            (RE_PORTS, "bus0", True),
+            (RE_PORTS, "bus123", True),
+            (RE_PORTS, "Bus", False),
+            (RE_PORTS_FILTER, "bus", True),
+            (RE_PORTS_FILTER, "bus0", True),
+            (RE_PORTS_FILTER, "Bus", False),
+            (RE_PORTS_GE_2, "bus2", True),
+            (RE_PORTS_GE_2, "bus1", False),
+            (RE_PORTS_GE_2, "bus0", False),
+        ],
+    )
+    def test_regex_patterns_parametrized(self, pattern, test_string, expected):
+        """Parametrized test for regex patterns."""
+        result = pattern.match(test_string) is not None
+        assert result == expected
+
+    def test_regex_patterns_edge_cases(self):
+        """Test regex patterns with edge cases."""
+        # Test with leading zeros - should not match for GE_2
+        assert RE_PORTS.match("bus00")
+        assert RE_PORTS_FILTER.match("bus00")
+        assert not RE_PORTS_GE_2.match("bus00")  # 00 < 2
+        assert not RE_PORTS_GE_2.match("bus01")  # 01 < 2
+        assert not RE_PORTS_GE_2.match("bus001")  # Leading zeros should not match
+
+        # Test with very long numbers
+        long_num = "2" * 100  # Use 2 instead of 1 since 111...1 >= 2
+        assert RE_PORTS.match(f"bus{long_num}")
+        assert RE_PORTS_FILTER.match(f"bus{long_num}")
+        assert RE_PORTS_GE_2.match(f"bus{long_num}")
+
+        # Test multi-digit numbers starting with 1 that are >= 2
+        assert RE_PORTS_GE_2.match("bus10")
+        assert RE_PORTS_GE_2.match("bus15")
+        assert RE_PORTS_GE_2.match("bus100")
+
+        # Test partial matches (should not match)
+        assert not RE_PORTS.match("bus123extra")
+        assert not RE_PORTS_FILTER.match("bus123extra")
+        assert not RE_PORTS_GE_2.match("bus123extra")


### PR DESCRIPTION
## Changes proposed in this Pull Request
Follow up on #1242
I made two small changes and added a couple of tests, just FYI @SpamAndEgg
- Resolve user warning when using a regex with groups, when they are not needed
- Define only compiled patterns and use `.pattern` if needed

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] ~A note for the release notes `doc/release_notes.rst` of the upcoming release is included.~
- [x] I consent to the release of this PR's code under the MIT license.
