### PR TITLE
fix: remove `typing-extensions` from runtime dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,6 @@ jobs:
         python -m pip install uv
         uv pip install --system toml
         uv pip install --system setuptools_scm
-        uv pip install --system typing_extensions
         uv pip install --system .
 
     - name: Update CITATION.cff

--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -2,17 +2,26 @@
 Release Notes
 #######################
 
-.. Upcoming Release
-.. ================
+Upcoming Release
+================
 
-.. .. warning:: 
+.. warning:: 
   
-..    The features listed below are not released yet, but will be part of the next release! 
-..    To use the features already you have to install the ``master`` branch, e.g. 
-..    ``pip install git+https://github.com/pypsa/pypsa``.
+   The features listed below are not released yet, but will be part of the next release! 
+   To use the features already you have to install the ``master`` branch, e.g. 
+   ``pip install git+https://github.com/pypsa/pypsa``.
+
+Bug Fixes
+---------
+
+* Fixed missing dependency issue for `typing-extensions`
+  (https://github.com/PyPSA/PyPSA/pull/1264)
 
 `v0.35.0 <https://github.com/PyPSA/PyPSA/releases/tag/v0.35.0>`__ (22th June 2025)
 =======================================================================================
+
+Features
+--------
 
 * New **interactive** plotting library
 
@@ -43,7 +52,7 @@ Release Notes
     reference will follow with a stable version of it.
 
 Bug Fixes
---------
+---------
 
 * Bugfix: The function ``n.statistics.opex()`` now considers the correct
   snapshot weightings ``n.snapshot_weightings.objective``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
     "ruff",
     "mypy",
     "jupyter>=1.1.1",
+    "typing-extensions>=4.14.0",
 ]
 docs = [
     "numpydoc==1.8.0",

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -20,7 +20,6 @@ import xarray as xr
 from deprecation import deprecated
 from pandas.errors import ParserError
 from pyproj import CRS
-from typing_extensions import Self
 
 from pypsa._options import options
 from pypsa.common import _check_for_update, check_optional_dependency, deprecated_kwargs
@@ -36,6 +35,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
     from pandapower.auxiliary import pandapowerNet
+    from typing_extensions import Self
 
     from pypsa import Network
 logger = logging.getLogger(__name__)

--- a/pypsa/type_utils.py
+++ b/pypsa/type_utils.py
@@ -1,11 +1,10 @@
 """Typing utilities."""
 
-from typing import Any
+from typing import Any, TypeVar
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like
-from typing_extensions import TypeVar
 
 from pypsa.network.abstract import _NetworkABC
 


### PR DESCRIPTION
Closes #1263

## Changes proposed in this Pull Request
We wanna follow [non-self-return-type (PYI034) | Ruff](https://docs.astral.sh/ruff/rules/non-self-return-type/) so `typing_extensions` is still needed, but we can remove it from the runtime dependencies.

## Checklist

- [x] ~Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.~
- [x] ~Unit tests for new features were added (if applicable).~
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
