### PR TITLE
add global constraint query strings

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,6 +11,10 @@ Release Notes
 ..    To use the features already you have to install the ``master`` branch, e.g. 
 ..    ``pip install git+https://github.com/pypsa/pypsa``.
 
+* New attribute ``query_string`` for global constraints (``primary_energy`` and
+  ``operational_limit``) to filter the components considered in the global
+  constraint. This allows defining global constraints for a subset of components.
+
 `v0.35.0 <https://github.com/PyPSA/PyPSA/releases/tag/v0.35.0>`__ (22th June 2025)
 =======================================================================================
 

--- a/pypsa/data/component_attrs/global_constraints.csv
+++ b/pypsa/data/component_attrs/global_constraints.csv
@@ -3,6 +3,7 @@ name,string,n/a,n/a,Unique name,Input (required)
 type,string,n/a,primary_energy,"Type of constraint (only ""primary energy"", i.e. limits on the usage of primary energy before generator conversion, is supported at the moment)",Input (optional)
 investment_period,float,n/a,NaN,"time period when the constraint is applied, if not specified, constraint is applied to all investment periods",Input (optional)
 carrier_attribute,string,n/a,co2_emissions,"If the global constraint is connected with an energy carrier, name the associated carrier attribute. This must appear as a column in network.carriers.",Input (optional)
+query_string,string,n/a,"","Filter to apply to the generators, storage units and stores that are considered for the global constraint. This is a pandas query string, e.g. ""carrier == 'solar'"" or ""p_nom >= 1000"".",Input (optional)
 sense,string,n/a,==,"Constraint sense; must be one of <=, == or >=",Input (optional)
 constant,float,n/a,0,"Constant for right-hand-side of constraint for optimisation period. For a CO2 constraint, this would be tonnes of CO2-equivalent emissions.",Input (optional)
 mu,float,currency/constant,0,Shadow price of global constraint,Output


### PR DESCRIPTION
New attribute ``query_string`` for global constraints (``primary_energy`` and ``operational_limit``) to filter the components considered in the global constraint. This allows defining global constraints for a subset of components.

### Example to play through

```py

import pypsa

n = pypsa.examples.model_energy()

n.add("Carrier", "gas", co2_emissions=0.2)

n.generators["country"] = "DE"
n.stores["country"] = "DE"
n.storage_units["country"] = "DE"

n.add(
    "Generator",
    "gas_DE",
    carrier="gas",
    bus="electricity",
    efficiency=1,
    p_nom=1000,
    marginal_cost=40,
    country="DE",
)

n.add(
    "Generator",
    "gas_FR",
    carrier="gas",
    bus="electricity",
    efficiency=1,
    p_nom=1000,
    marginal_cost=50,
    country="FR",
)

n.add(
    "GlobalConstraint",
    "co2_limit",
    type="primary_energy",
    carrier_attribute="co2_emissions",
    constant=0,
    sense="<=",
    query_string="country == 'DE'",
)

n.model.constraints["GlobalConstraint-co2_limit"].print()

n.optimize()

n.global_constraints

(n.snapshot_weightings.generators @ n.generators_t.p).div(1e3).round(1).sort_values()

n.global_constraints.query_string = ""

n.model.constraints["GlobalConstraint-co2_limit"].print()

n.optimize()

(n.snapshot_weightings.generators @ n.generators_t.p).div(1e3).round(1).sort_values()
``