### PR TITLE
Add utility function to compute annuity

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -17,6 +17,17 @@ Bug Fixes
 * Correct use of snapshot weighting columns in statistics module. The
   doscstring for ``n.snapshot_weightings`` was clarified.
 
+* Added utility function ``pypsa.common.annuity`` to calculate the annuity
+  factor for a given discount rate and lifetime. Also known as capital recovery
+  factor, it is used to convert a capital cost into an annualized cost. The
+  formula is: 
+
+  .. math::
+  
+      \frac{r}{1 - (1 + r)^{-n}}
+
+  where :math:`r` is the discount rate and :math:`n` is the lifetime in years.
+
 `v0.35.1 <https://github.com/PyPSA/PyPSA/releases/tag/v0.35.1>`__ (3rd July 2025)
 =======================================================================================
 

--- a/pypsa/common.py
+++ b/pypsa/common.py
@@ -886,4 +886,4 @@ def annuity(r: float | pd.Series, n: int | pd.Series) -> float | pd.Series:
     dtype: float64
 
     """
-    return r / (1. - 1. / (1. + r) ** n)
+    return r / (1.0 - 1.0 / (1.0 + r) ** n)

--- a/pypsa/common.py
+++ b/pypsa/common.py
@@ -853,3 +853,37 @@ def expand_series(ser: pd.Series, columns: Sequence[str]) -> pd.DataFrame:
 
     """
     return ser.to_frame(columns[0]).reindex(columns=columns).ffill(axis=1)
+
+
+def annuity(r: float | pd.Series, n: int | pd.Series) -> float | pd.Series:
+    """Calculate the annuity factor for a given discount rate and lifetime.
+
+    Parameters
+    ----------
+    r : float | pd.Series
+        Discount rate (as a decimal, e.g. 0.05 for 5%).
+    n : int | pd.Series
+        Lifetime of loan or asset (in years).
+
+    Returns
+    -------
+    float | pd.Series
+        The annuity factor.
+
+    Examples
+    --------
+    >>> pypsa.common.annuity(0.05, 10)  # 5% discount rate over 10 years
+    0.12950457496545661
+
+    >>> pypsa.common.annuity(pd.Series([0.05, 0.03]), pd.Series([10, 20]))
+    0    0.129505
+    1    0.067216
+    dtype: float64
+
+    >>> pypsa.common.annuity(pd.Series([0.05, 0.03]), 20)
+    0    0.080243
+    1    0.067216
+    dtype: float64
+
+    """
+    return r / (1. - 1. / (1. + r) ** n)

--- a/pypsa/common.py
+++ b/pypsa/common.py
@@ -858,6 +858,8 @@ def expand_series(ser: pd.Series, columns: Sequence[str]) -> pd.DataFrame:
 def annuity(r: float | pd.Series, n: int | pd.Series) -> float | pd.Series:
     """Calculate the annuity factor for a given discount rate and lifetime.
 
+    According to formula $r / (1 - (1 + r)^{-n})$.
+
     Parameters
     ----------
     r : float | pd.Series


### PR DESCRIPTION
Add utility function to calculate annuity factor (capital recovery factor) from given discount rate and lifetime. This can be useful for calculating `capital_cost` attributes from technology-data given in upfront cost, lifetime and discount rate; as well as getting back to the upfront cost from annuitized investment costs.
