### PR TITLE
fix: network version info log

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,11 +11,8 @@ Release Notes
 ..    To use the features already you have to install the ``master`` branch, e.g. 
 ..    ``pip install git+https://github.com/pypsa/pypsa``.
 
-Bug Fixes
----------
-
-* Correct use of snapshot weighting columns in statistics module. The
-  doscstring for ``n.snapshot_weightings`` was clarified.
+Features
+--------
 
 * Added utility function ``pypsa.common.annuity`` to calculate the annuity
   factor for a given discount rate and lifetime. Also known as capital recovery
@@ -27,6 +24,16 @@ Bug Fixes
       \frac{r}{1 - (1 + r)^{-n}}
 
   where :math:`r` is the discount rate and :math:`n` is the lifetime in years.
+
+Bug Fixes
+---------
+
+* Correct use of snapshot weighting columns in statistics module. The
+  doscstring for ``n.snapshot_weightings`` was clarified.
+
+* Resolved an issue where the network version was not correctly identified during I/O, 
+  resulting in false update information being logged.
+  (https://github.com/PyPSA/PyPSA/pull/1300)
 
 `v0.35.1 <https://github.com/PyPSA/PyPSA/releases/tag/v0.35.1>`__ (3rd July 2025)
 =======================================================================================

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1164,7 +1164,7 @@ class NetworkIOMixin(_NetworkABC):
 
         """
         # n.meta
-        self.meta = importer.get_meta() | {}
+        self.meta = importer.get_meta()
 
         # n.crs
         crs = importer.get_crs()
@@ -1174,16 +1174,18 @@ class NetworkIOMixin(_NetworkABC):
             self._crs = crs
 
         # other network attributes
-        attrs = importer.get_attributes() | {}
-        name = attrs.pop("name")
-        self.name = name if pd.notna(name) else ""
+        attrs = importer.get_attributes() or {}
+        if "name" in attrs:
+            name = attrs.pop("name")
+            if pd.notna(name):
+                self.name = name
 
-        version = attrs.pop("pypsa_version", "0.0.0").split(".")
-        major = int(version[0])
-        minor = int(version[1])
-        patch = int(version[2])
-
-        pypsa_version_tuple = (major, minor, patch)
+        if "pypsa_version" in attrs:
+            pypsa_version_tuple = tuple(
+                int(v) for v in attrs.pop("pypsa_version", "0.0.0").split(".")
+            )
+        else:
+            pypsa_version_tuple = (0, 0, 0)
 
         for attr, val in attrs.items():
             if attr in ["model", "objective", "objective_constant"]:

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -695,7 +695,7 @@ class Network(
         DatetimeIndex(['2015-01-01'], dtype='datetime64[ns]', name='snapshot', freq=None)
 
         """
-        if self.is_solved and hasattr(self.model, "solver_model"):
+        if self.is_solved and hasattr(self._model, "solver_model"):
             msg = "Copying a solved network with an attached solver model is not supported."
             msg += " Please delete the model first using `n.model.solver_model = None`."
             raise ValueError(msg)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -573,3 +573,14 @@ def test_sort_attrs():
     empty_df = pd.DataFrame()
     result = _sort_attrs(empty_df, ["a", "b"], axis=1)
     assert result.empty
+
+
+def test_version_warning(caplog):
+    # Assert no info logged with "version"
+    n = pypsa.examples.ac_dc_meshed()
+    assert "Importing network from PyPSA version" not in caplog.text
+
+    n._pypsa_version = "0.10.0"
+    n.export_to_netcdf("test.nc")
+    pypsa.Network("test.nc")
+    assert "Importing network from PyPSA version v0.10.0" in caplog.text


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Resolved an issue where the network version was not correctly identified during I/O, resulting in false update information being logged.
- Also fixes logs when copying a solved networks which was loaded again.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
