### PR TITLE
make start-up and shut-down variables continuous

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,6 +11,12 @@ Release Notes
 ..    To use the features already you have to install the ``master`` branch, e.g. 
 ..    ``pip install git+https://github.com/pypsa/pypsa``.
 
+* Start up and shut down variables are now initialised as continuous variables
+  with bounds [0,1] instead of as binary variables. They can already only take
+  the values 0 or 1 as they depend on the difference of the binary status
+  variables of adjacent snapshots. This should speed up the branch-and-bound
+  algorithm as it reduces the number of binary variables in the model.
+
 Bug Fixes
 ---------
 

--- a/pypsa/optimization/variables.py
+++ b/pypsa/optimization/variables.py
@@ -60,10 +60,8 @@ def define_start_up_variables(n: Network, sns: Sequence, c: str) -> None:
 
     active = get_activity_mask(n, c, sns, com_i)
     coords = (sns, com_i)
-    is_binary = not n._linearized_uc
-    kwargs = {"upper": 1, "lower": 0} if not is_binary else {}
     n.model.add_variables(
-        coords=coords, name=f"{c}-start_up", mask=active, binary=is_binary, **kwargs
+        coords=coords, name=f"{c}-start_up", mask=active, upper=1, lower=0
     )
 
 
@@ -75,10 +73,8 @@ def define_shut_down_variables(n: Network, sns: Sequence, c: str) -> None:
 
     active = get_activity_mask(n, c, sns, com_i)
     coords = (sns, com_i)
-    is_binary = not n._linearized_uc
-    kwargs = {"upper": 1, "lower": 0} if not is_binary else {}
     n.model.add_variables(
-        coords=coords, name=f"{c}-shut_down", binary=is_binary, **kwargs, mask=active
+        coords=coords, name=f"{c}-shut_down", mask=active, upper=1, lower=0
     )
 
 


### PR DESCRIPTION
Start up and shut down variables are now initialised as continuous variables
  with bounds [0,1] instead of as binary variables. They can already only take
  the values 0 or 1 as they depend on the difference of the binary status
  variables of adjacent snapshots. This should speed up the branch-and-bound
  algorithm as it reduces the number of binary variables in the model.

closes #1303

