### PR TITLE
feat: exclude inactive components from model build

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -11,6 +11,10 @@ Release Notes
 ..    To use the features already you have to install the ``master`` branch, e.g. 
 ..    ``pip install git+https://github.com/pypsa/pypsa``.
 
+* Inactive components (see pypsa.Components.inactive_assets) are now excluded from the
+  the optimization model entirely. This has no effect on the results, but it can
+  reduce the memory footprint when solving the model.
+
 Bug Fixes
 ---------
 

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -177,7 +177,7 @@ class OptimizationAbstractMixin:
         n = self._n
 
         n.lines["carrier"] = n.lines.bus0.map(n.buses.carrier)
-        ext_i = n.components["Line"].extendables.copy()
+        ext_i = n.c.lines.extendables.difference(n.c.lines.inactive_assets)
         typed_i = n.lines.query('type != ""').index
         ext_untyped_i = ext_i.difference(typed_i)
         ext_typed_i = ext_i.intersection(typed_i)

--- a/pypsa/optimization/common.py
+++ b/pypsa/optimization/common.py
@@ -44,7 +44,9 @@ def set_from_frame(n: Network, c: str, attr: str, df: pd.DataFrame) -> None:
     """Update values in time-dependent attribute from new dataframe."""
     dynamic = n.dynamic(c)
     if (attr not in dynamic) or (dynamic[attr].empty):
-        dynamic[attr] = df.reindex(n.snapshots).fillna(0.0)
+        dynamic[attr] = (
+            df.reindex(n.snapshots).reindex(n.c[c].static.index, axis=1).fillna(0.0)
+        )
     else:
         dynamic[attr].loc[df.index, df.columns] = df
         dynamic[attr] = dynamic[attr].fillna(0.0)

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -55,9 +55,8 @@ def define_tech_capacity_expansion_limit(n: Network, sns: Sequence) -> None:
             if "carrier" not in static:
                 continue
 
-            ext_i = n.components[c].extendables.intersection(
-                static.index[static.carrier == carrier]
-            )
+            ext_i = n.components[c].extendables.difference(n.c[c].inactive_assets)
+            ext_i = ext_i.intersection(static.index[static.carrier == carrier])
             if period is not None:
                 ext_i = ext_i[n.get_active_assets(c, period)[ext_i]]
 
@@ -146,9 +145,8 @@ def define_nominal_constraints_per_bus_carrier(n: Network, sns: pd.Index) -> Non
             if c not in n.one_port_components or "carrier" not in static:
                 continue
 
-            ext_i = n.components[c].extendables.intersection(
-                static.index[static.carrier == carrier]
-            )
+            ext_i = n.c[c].extendables.difference(n.c[c].inactive_assets)
+            ext_i = ext_i.intersection(static.index[static.carrier == carrier])
             if period is not None:
                 ext_i = ext_i[n.get_active_assets(c, period)[ext_i]]
 
@@ -220,7 +218,9 @@ def define_growth_limit(n: Network, sns: pd.Index) -> None:
             carrier_map = component_carriers
 
         carriers_match = unique_component_names[carrier_map.isin(carrier_i)]
-        limited_names = carriers_match.intersection(n.components[c].extendables)
+        limited_names = carriers_match.intersection(
+            n.c[c].extendables.difference(n.c[c].inactive_assets)
+        )
 
         if limited_names.empty:
             continue
@@ -476,7 +476,7 @@ def define_transmission_volume_expansion_limit(n: Network, sns: Sequence) -> Non
         for c in ["Line", "Link"]:
             attr = nominal_attrs[c]
 
-            ext_i = n.components[c].extendables
+            ext_i = n.components[c].extendables.difference(n.c[c].inactive_assets)
             if ext_i.empty:
                 continue
 
@@ -540,7 +540,7 @@ def define_transmission_expansion_cost_limit(n: Network, sns: pd.Index) -> None:
         for c in ["Line", "Link"]:
             attr = nominal_attrs[c]
 
-            ext_i = n.components[c].extendables
+            ext_i = n.components[c].extendables.difference(n.c[c].inactive_assets)
             if ext_i.empty:
                 continue
 

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -121,7 +121,7 @@ def define_objective(n: Network, sns: pd.Index) -> None:
 
     for c_name, attr in nom_attr:
         c = as_components(n, c_name)
-        ext_i = c.extendables
+        ext_i = c.extendables.difference(c.inactive_assets)
 
         if ext_i.empty:
             continue
@@ -215,7 +215,7 @@ def define_objective(n: Network, sns: pd.Index) -> None:
     # stand-by cost
     for c_name in ["Generator", "Link"]:
         c = as_components(n, c_name)
-        com_i = c.committables
+        com_i = c.committables.difference(c.inactive_assets)
 
         if com_i.empty:
             continue
@@ -234,7 +234,7 @@ def define_objective(n: Network, sns: pd.Index) -> None:
     # investment
     for c_name, attr in nominal_attrs.items():
         c = as_components(n, c_name)
-        ext_i = c.extendables
+        ext_i = c.extendables.difference(c.inactive_assets)
 
         if ext_i.empty:
             continue
@@ -262,7 +262,7 @@ def define_objective(n: Network, sns: pd.Index) -> None:
     keys = ["start_up", "shut_down"]  # noqa: F841
     for c_name, attr in lookup.query("variable in @keys").index:
         c = as_components(n, c_name)
-        com_i = c.committables
+        com_i = c.committables.difference(c.inactive_assets)
 
         if com_i.empty:
             continue
@@ -837,7 +837,9 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         afterwards.
         """
         for c, attr in nominal_attrs.items():
-            ext_i = self._n.components[c].extendables
+            ext_i = self._n.components[c].extendables.difference(
+                self._n.components[c].inactive_assets
+            )
             self._n.static(c).loc[ext_i, attr] = self._n.static(c).loc[
                 ext_i, attr + "_opt"
             ]


### PR DESCRIPTION
Closes #1056 

## Changes proposed in this Pull Request
Adds `c.active_assets` and `c.inactive_assets` to API and filters inactive assets during model build in `variables.py` and `constraints.py`. Not sure if we wanna drop inactive assets just always from `c.fixed`, `c.extendable` and `c.committable`. This would be much cleaner. Let me know what you think.

I need to double check #433 again, but this can probably be closed as stale and it also refers to something different to #1056. Here we remove inactive components entirely when they are inactive across all dimensions. This does not replace the boolean mask for inactivity in certain investment periods/scenarios.

Also a couple more tests for writing solutions back need to be added.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
