### PR TITLE
fix: allow copying solved network after setting solver_model to None

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -28,6 +28,9 @@ Features
 Bug Fixes
 ---------
 
+* Fixed issue when copying a solved network after setting ``solver_model`` to ``None``.
+  (https://github.com/PyPSA/PyPSA/issues/1319)
+
 * Correct use of snapshot weighting columns in statistics module. The
   doscstring for ``n.snapshot_weightings`` was clarified.
 

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -695,7 +695,11 @@ class Network(
         DatetimeIndex(['2015-01-01'], dtype='datetime64[ns]', name='snapshot', freq=None)
 
         """
-        if self.is_solved and hasattr(self._model, "solver_model"):
+        if (
+            self.is_solved
+            and hasattr(self._model, "solver_model")
+            and self._model.solver_model is not None
+        ):
             msg = "Copying a solved network with an attached solver model is not supported."
             msg += " Please delete the model first using `n.model.solver_model = None`."
             raise ValueError(msg)

--- a/test/test_bugs.py
+++ b/test/test_bugs.py
@@ -162,3 +162,24 @@ def test_1268(tmpdir):
     n = pypsa.Network()
     n.import_from_excel(fn)
     assert len(n.buses) == 1
+
+
+def test_1319():
+    """
+    Copying a solved network should work after setting solver_model to None.
+    See https://github.com/PyPSA/PyPSA/issues/1319.
+    """
+    n = pypsa.examples.ac_dc_meshed()
+    n.optimize()
+
+    # Should raise error when trying to copy with solver_model attached
+    with pytest.raises(
+        ValueError, match="Copying a solved network with an attached solver model"
+    ):
+        n.copy()
+
+    # Should work after setting solver_model to None
+    n.model.solver_model = None
+    n_copy = n.copy()  # Should not raise an error
+    assert n_copy is not n
+    assert len(n_copy.buses) == len(n.buses)


### PR DESCRIPTION
Closes #1319

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
