### PR TITLE
feat: full support for current and new components API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,10 @@ jobs:
         - ubuntu-latest
         - macos-latest
         - windows-latest
+        api: [current]
         include:
         - os: ubuntu-latest
-          python-version: ${{ fromJSON(needs.build.outputs.python-versions) }}
-          api: new_api
+          api: new
 
     env:
       MPLBACKEND: Agg  # https://github.com/orgs/community/discussions/26434
@@ -82,12 +82,12 @@ jobs:
         uv pip install "$(ls dist/*.whl)"
 
     - name: Run unit tests (old API)
-      if: matrix.api == 'old_api'
+      if: matrix.api == 'current'
       run: |
         uv run pytest --mpl --cov=pypsa && uv run coverage xml
 
     - name: Run unit tests (new API)
-      if: matrix.api == 'new_api'
+      if: matrix.api == 'new'
       run: |
         uv run pytest --new-components-api
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,11 @@ jobs:
         - ubuntu-latest
         - macos-latest
         - windows-latest
+        include:
+        - os: ubuntu-latest
+          python-version: ${{ fromJSON(needs.build.outputs.python-versions) }}
+          api: new_api
+
     env:
       MPLBACKEND: Agg  # https://github.com/orgs/community/discussions/26434
     steps:
@@ -76,9 +81,15 @@ jobs:
         uv sync --all-extras --no-install-project
         uv pip install "$(ls dist/*.whl)"
 
-    - name: Run unit tests
+    - name: Run unit tests (old API)
+      if: matrix.api == 'old_api'
       run: |
         uv run pytest --mpl --cov=pypsa && uv run coverage xml
+
+    - name: Run unit tests (new API)
+      if: matrix.api == 'new_api'
+      run: |
+        uv run pytest --new-components-api
 
     - name: Upload code coverage report
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,12 @@ jobs:
         - ubuntu-latest
         - macos-latest
         - windows-latest
-        api: [current]
-        include:
-        - os: ubuntu-latest
-          api: new
+        api: [default, new_api]
+        exclude:
+        - os: macos-latest
+          api: new_api
+        - os: windows-latest
+          api: new_api
 
     env:
       MPLBACKEND: Agg  # https://github.com/orgs/community/discussions/26434
@@ -82,12 +84,12 @@ jobs:
         uv pip install "$(ls dist/*.whl)"
 
     - name: Run unit tests (old API)
-      if: matrix.api == 'current'
+      if: matrix.api == 'old'
       run: |
         uv run pytest --mpl --cov=pypsa && uv run coverage xml
 
     - name: Run unit tests (new API)
-      if: matrix.api == 'new'
+      if: matrix.api == 'new_api'
       run: |
         uv run pytest --new-components-api
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
         uv pip install "$(ls dist/*.whl)"
 
     - name: Run unit tests (old API)
-      if: matrix.api == 'old'
+      if: matrix.api == 'default'
       run: |
         uv run pytest --mpl --cov=pypsa && uv run coverage xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,9 @@ include = ["pypsa"]
 [tool.pytest.ini_options]
 filterwarnings = [
     "error::DeprecationWarning", # Raise all DeprecationWarnings as errors
-    "error::FutureWarning",      # Raise all FutureWarnings as errors
+    # "error::FutureWarning",      # Raise all FutureWarnings as errors # TODO Add again
+    # "error:RuntimeWarning",
+    # "error:UserWarning",
     "ignore::matplotlib._api.deprecation.MatplotlibDeprecationWarning:pydev",
     # See https://github.com/microsoft/debugpy/issues/1623
 ]

--- a/pypsa/_options.py
+++ b/pypsa/_options.py
@@ -314,7 +314,7 @@ class OptionsNode:
         >>> pypsa.options.describe_options() # doctest: +ELLIPSIS
         PyPSA Options
         =============
-        api.legacy_components:
+        api.new_components_api:
             Default: True
             Description: WARNING: Experimental feature. Not all PyPSA functionality is supported yet. Use legacy components API for backwards compatibility to PyPSA versions prior to 1.0.0. It is still recommended to use the new API and not to rely on the legacy API. This option will be removed with PyPSA 2.0.0.
         debug.runtime_verification:
@@ -355,7 +355,7 @@ class OptionsNode:
         >>> pypsa.options.describe() # doctest: +ELLIPSIS
         PyPSA Options
         =============
-        api.legacy_components:
+        api.new_components_api:
             Default: True
             Description: WARNING: Experimental feature. Not all PyPSA functionality is supported yet. Use legacy components API for backwards compatibility to PyPSA versions prior to 1.0.0. It is still recommended to use the new API and not to rely on the legacy API. This option will be removed with PyPSA 2.0.0.
         debug.runtime_verification:
@@ -435,12 +435,12 @@ options._add_option(
 
 # API
 options._add_option(
-    "api.legacy_components",
-    True,
-    "WARNING: Experimental feature. Not all PyPSA functionality is supported yet. "
-    "Use legacy components API for backwards compatibility to PyPSA versions prior to "
-    "1.0.0. It is still recommended to use the new API and not to rely on the legacy "
-    "API. This option will be removed with PyPSA 2.0.0.",
+    "api.new_components_api",
+    False,
+    "Activate the new components API, which replaces the static components data access "
+    "with the more flexible components class. This will just change the api and not any "
+    "functionality. Components class features are always available. "
+    "See https://go.pypsa.org/new-components-api for more details.",
 )
 
 # Warnings category

--- a/pypsa/_options.py
+++ b/pypsa/_options.py
@@ -315,8 +315,8 @@ class OptionsNode:
         PyPSA Options
         =============
         api.new_components_api:
-            Default: True
-            Description: WARNING: Experimental feature. Not all PyPSA functionality is supported yet. Use legacy components API for backwards compatibility to PyPSA versions prior to 1.0.0. It is still recommended to use the new API and not to rely on the legacy API. This option will be removed with PyPSA 2.0.0.
+            Default: False
+            Description: Activate the new components API, which replaces the static components data access with the more flexible components class. This will just change the api and not any functionality. Components class features are always available. See https://go.pypsa.org/new-components-api for more details.
         debug.runtime_verification:
             Default: False
             Description: Enable runtime verification of PyPSA's internal state. This is useful for debugging and development purposes. This will lead to overhead in performance and should not be used in production.
@@ -356,8 +356,8 @@ class OptionsNode:
         PyPSA Options
         =============
         api.new_components_api:
-            Default: True
-            Description: WARNING: Experimental feature. Not all PyPSA functionality is supported yet. Use legacy components API for backwards compatibility to PyPSA versions prior to 1.0.0. It is still recommended to use the new API and not to rely on the legacy API. This option will be removed with PyPSA 2.0.0.
+            Default: False
+            Description: Activate the new components API, which replaces the static components data access with the more flexible components class. This will just change the api and not any functionality. Components class features are always available. See https://go.pypsa.org/new-components-api for more details.
         debug.runtime_verification:
             Default: False
             Description: Enable runtime verification of PyPSA's internal state. This is useful for debugging and development purposes. This will lead to overhead in performance and should not be used in production.

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -632,7 +632,7 @@ def get_clustering_from_busmap(
     clustered.add("Link", new_links.index, **new_links)
 
     if with_time:
-        for attr, df in n.links_t.items():
+        for attr, df in n.c.links.dynamic.items():
             if not df.empty:
                 clustered._import_series_from_df(df, "Link", attr)
 

--- a/pypsa/collection.py
+++ b/pypsa/collection.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pandas as pd
 
+from pypsa._options import options
 from pypsa.definitions.structures import Dict
 from pypsa.networks import Network
 from pypsa.statistics.expressions import StatisticsAccessor
@@ -314,25 +315,21 @@ _all_components = (
     r"stores|shunt_impedances|shapes"
 )
 
-_all_component_names = (
-    r"SubNetwork|Bus|Carrier|GlobalConstraint|Line|LineType|"
-    "Transformer|TransformerType|Link|Load|Generator|StorageUnit|"
-    "Store|ShuntImpedance|Shape"
-)
 
-_component_classes = rf"components((\['({_all_components}|{_all_component_names})'])|(\.({_all_components})))"
+def _get_method_patterns() -> dict[str, str]:
+    new_api = options.api.new_components_api
+    _all_component_names = (
+        r"SubNetwork|Bus|Carrier|GlobalConstraint|Line|LineType|"
+        "Transformer|TransformerType|Link|Load|Generator|StorageUnit|"
+        "Store|ShuntImpedance|Shape"
+    )
 
+    _component_classes = (
+        ("(" if new_api else "")
+        + rf"(components|c)((\['({_all_components}|{_all_component_names})'])|(\.({_all_components})))"
+        + ("|" + _all_components + ")" if new_api else "")
+    )
 
-class MemberProxy:
-    """Wrapper for network accessors that combines results from multiple networks.
-
-    This class handles arbitrary nesting of accessor methods and properties,
-    dynamically proxying calls to the underlying network objects.
-    """
-
-    collection: NetworkCollection
-
-    # Method patterns for special handling
     _method_patterns = {
         # run_per_network
         # ---------------
@@ -341,14 +338,14 @@ class MemberProxy:
         r")$",
         # ---------------
         "vertical_concat": rf"^("
-        rf"({_all_components})|"
+        rf"({_all_components if not new_api else ''})|"
         rf"({_component_classes}.static)|"
         rf"static|"
         rf"get_active_assets"
         rf")$",
         # ---------------
         "horizontal_concat": rf"^("
-        rf"(({_all_components})_t)|"
+        rf"({'(' + _all_components + ')_t' if not new_api else ''})|"
         rf"({_component_classes}.dynamic)|"
         rf"dynamic|"
         rf"get_switchable_as_dense"
@@ -367,10 +364,21 @@ class MemberProxy:
         r")$",
         # ---------------
         "continue_proxy": rf"^("
-        rf"components|"
+        rf"components|c|"
         rf"{_component_classes}"
         rf")$",
     }
+    return _method_patterns
+
+
+class MemberProxy:
+    """Wrapper for network accessors that combines results from multiple networks.
+
+    This class handles arbitrary nesting of accessor methods and properties,
+    dynamically proxying calls to the underlying network objects.
+    """
+
+    collection: NetworkCollection
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
         """Create new instance of MemberProxy.
@@ -395,7 +403,7 @@ class MemberProxy:
     def _is_intermediate_path(self) -> bool:
         """Check if this accessor path is an intermediate path that should continue as MemberProxy."""
         # Check if this path could be part of a longer supported path
-        for processor_name, pattern in self._method_patterns.items():
+        for processor_name, pattern in _get_method_patterns().items():
             if processor_name == "continue_proxy" and re.match(
                 pattern, self.accessor_path
             ):
@@ -479,7 +487,7 @@ class MemberProxy:
     def get_processor(self) -> Any:
         """Determine the appropriate processor for the current accessor path."""
         # Check for pattern-based method processor
-        for processor_name, pattern in self._method_patterns.items():
+        for processor_name, pattern in _get_method_patterns().items():
             if re.match(pattern, self.accessor_path):
                 processor = getattr(self, processor_name)
                 return processor

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -239,7 +239,7 @@ def _additional_linkports(
 
     """
     if where is None:
-        where = n.links.columns
+        where = n.c.links.static.columns
     return [match.group(1) for col in where if (match := RE_PORTS_GE_2.search(col))]
 
 
@@ -279,7 +279,9 @@ def _update_linkports_component_attrs(
         )
         # Also update container for varying attributes
         if attr in ["efficiency", "p"] and target not in n.dynamic(c):
-            df = pd.DataFrame(index=n.snapshots, columns=n.links.index[:0], dtype=float)
+            df = pd.DataFrame(
+                index=n.snapshots, columns=n.c.links.static.index[:0], dtype=float
+            )
             n.dynamic(c)[target] = df
         elif attr == "bus" and target not in n.static(c).columns:
             n.static(c)[target] = n.components[c]["attrs"].loc[target, "default"]

--- a/pypsa/network/components.py
+++ b/pypsa/network/components.py
@@ -148,35 +148,39 @@ class NetworkComponentsMixin(_NetworkABC):
     def sub_networks(self) -> Any:
         return (
             self.c.sub_networks.static
-            if options.api.legacy_components
+            if not options.api.new_components_api
             else self.c.subnetworks
         )
 
     @sub_networks.setter
     def sub_networks(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.sub_networks.static = value
 
     @property
     def buses(self) -> Any:
-        return self.c.buses.static if options.api.legacy_components else self.c.buses
+        return (
+            self.c.buses.static if not options.api.new_components_api else self.c.buses
+        )
 
     @buses.setter
     def buses(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.buses.static = value
 
     @property
     def carriers(self) -> Any:
         return (
-            self.c.carriers.static if options.api.legacy_components else self.c.carriers
+            self.c.carriers.static
+            if not options.api.new_components_api
+            else self.c.carriers
         )
 
     @carriers.setter
     def carriers(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.carriers.static = value
 
@@ -184,23 +188,25 @@ class NetworkComponentsMixin(_NetworkABC):
     def global_constraints(self) -> Any:
         return (
             self.c.global_constraints.static
-            if options.api.legacy_components
+            if not options.api.new_components_api
             else self.c.global_constraints
         )
 
     @global_constraints.setter
     def global_constraints(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.global_constraints.static = value
 
     @property
     def lines(self) -> Any:
-        return self.c.lines.static if options.api.legacy_components else self.c.lines
+        return (
+            self.c.lines.static if not options.api.new_components_api else self.c.lines
+        )
 
     @lines.setter
     def lines(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.lines.static = value
 
@@ -208,13 +214,13 @@ class NetworkComponentsMixin(_NetworkABC):
     def line_types(self) -> Any:
         return (
             self.c.line_types.static
-            if options.api.legacy_components
+            if not options.api.new_components_api
             else self.c.line_types
         )
 
     @line_types.setter
     def line_types(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.line_types.static = value
 
@@ -222,13 +228,13 @@ class NetworkComponentsMixin(_NetworkABC):
     def transformers(self) -> Any:
         return (
             self.c.transformers.static
-            if options.api.legacy_components
+            if not options.api.new_components_api
             else self.c.transformers
         )
 
     @transformers.setter
     def transformers(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.transformers.static = value
 
@@ -236,33 +242,37 @@ class NetworkComponentsMixin(_NetworkABC):
     def transformer_types(self) -> Any:
         return (
             self.c.transformer_types.static
-            if options.api.legacy_components
+            if not options.api.new_components_api
             else self.c.transformer_types
         )
 
     @transformer_types.setter
     def transformer_types(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.transformer_types.static = value
 
     @property
     def links(self) -> Any:
-        return self.c.links.static if options.api.legacy_components else self.c.links
+        return (
+            self.c.links.static if not options.api.new_components_api else self.c.links
+        )
 
     @links.setter
     def links(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.links.static = value
 
     @property
     def loads(self) -> Any:
-        return self.c.loads.static if options.api.legacy_components else self.c.loads
+        return (
+            self.c.loads.static if not options.api.new_components_api else self.c.loads
+        )
 
     @loads.setter
     def loads(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.loads.static = value
 
@@ -270,13 +280,13 @@ class NetworkComponentsMixin(_NetworkABC):
     def generators(self) -> Any:
         return (
             self.c.generators.static
-            if options.api.legacy_components
+            if not options.api.new_components_api
             else self.c.generators
         )
 
     @generators.setter
     def generators(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.generators.static = value
 
@@ -284,23 +294,27 @@ class NetworkComponentsMixin(_NetworkABC):
     def storage_units(self) -> Any:
         return (
             self.c.storage_units.static
-            if options.api.legacy_components
+            if not options.api.new_components_api
             else self.c.storage_units
         )
 
     @storage_units.setter
     def storage_units(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.storage_units.static = value
 
     @property
     def stores(self) -> Any:
-        return self.c.stores.static if options.api.legacy_components else self.c.stores
+        return (
+            self.c.stores.static
+            if not options.api.new_components_api
+            else self.c.stores
+        )
 
     @stores.setter
     def stores(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.stores.static = value
 
@@ -308,65 +322,69 @@ class NetworkComponentsMixin(_NetworkABC):
     def shunt_impedances(self) -> Any:
         return (
             self.c.shunt_impedances.static
-            if options.api.legacy_components
+            if not options.api.new_components_api
             else self.c.shunt_impedances
         )
 
     @shunt_impedances.setter
     def shunt_impedances(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.shunt_impedances.static = value
 
     @property
     def shapes(self) -> Any:
-        return self.c.shapes.static if options.api.legacy_components else self.c.shapes
+        return (
+            self.c.shapes.static
+            if not options.api.new_components_api
+            else self.c.shapes
+        )
 
     @shapes.setter
     def shapes(self, value: pd.DataFrame) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise AttributeError(_STATIC_SETTER_WARNING)
         self.c.shapes.static = value
 
     @property
     def sub_networks_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("sub_networks"))
         return self.c.sub_networks.dynamic
 
     @sub_networks_t.setter
     def sub_networks_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("sub_networks"))
         self.c.sub_networks.dynamic = value
 
     @property
     def buses_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("buses"))
         return self.c.buses.dynamic
 
     @buses_t.setter
     def buses_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("buses"))
         self.c.buses.dynamic = value
 
     @property
     def carriers_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("carriers"))
         return self.c.carriers.dynamic
 
     @carriers_t.setter
     def carriers_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("carriers"))
         self.c.carriers.dynamic = value
 
     @property
     def global_constraints_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(
                 _DYNAMIC_GETTER_WARNING.format("global_constraints")
             )
@@ -374,7 +392,7 @@ class NetworkComponentsMixin(_NetworkABC):
 
     @global_constraints_t.setter
     def global_constraints_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(
                 _DYNAMIC_SETTER_WARNING.format("global_constraints")
             )
@@ -382,43 +400,43 @@ class NetworkComponentsMixin(_NetworkABC):
 
     @property
     def lines_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("lines"))
         return self.c.lines.dynamic
 
     @lines_t.setter
     def lines_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("lines"))
         self.c.lines.dynamic = value
 
     @property
     def line_types_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("line_types"))
         return self.c.line_types.dynamic
 
     @line_types_t.setter
     def line_types_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("line_types"))
         self.c.line_types.dynamic = value
 
     @property
     def transformers_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("transformers"))
         return self.c.transformers.dynamic
 
     @transformers_t.setter
     def transformers_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("transformers"))
         self.c.transformers.dynamic = value
 
     @property
     def transformer_types_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(
                 _DYNAMIC_GETTER_WARNING.format("transformer_types")
             )
@@ -426,7 +444,7 @@ class NetworkComponentsMixin(_NetworkABC):
 
     @transformer_types_t.setter
     def transformer_types_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(
                 _DYNAMIC_SETTER_WARNING.format("transformer_types")
             )
@@ -434,85 +452,85 @@ class NetworkComponentsMixin(_NetworkABC):
 
     @property
     def links_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("links"))
         return self.c.links.dynamic
 
     @links_t.setter
     def links_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("links"))
         self.c.links.dynamic = value
 
     @property
     def loads_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("loads"))
         return self.c.loads.dynamic
 
     @loads_t.setter
     def loads_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("loads"))
         self.c.loads.dynamic = value
 
     @property
     def generators_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("generators"))
         return self.c.generators.dynamic
 
     @generators_t.setter
     def generators_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("generators"))
         self.c.generators.dynamic = value
 
     @property
     def storage_units_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("storage_units"))
         return self.c.storage_units.dynamic
 
     @storage_units_t.setter
     def storage_units_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("storage_units"))
         self.c.storage_units.dynamic = value
 
     @property
     def stores_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("stores"))
         return self.c.stores.dynamic
 
     @stores_t.setter
     def stores_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("stores"))
         self.c.stores.dynamic = value
 
     @property
     def shunt_impedances_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("shunt_impedances"))
         return self.c.shunt_impedances.dynamic
 
     @shunt_impedances_t.setter
     def shunt_impedances_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("shunt_impedances"))
         self.c.shunt_impedances.dynamic = value
 
     @property
     def shapes_t(self) -> Dict:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("shapes"))
         return self.c.shapes.dynamic
 
     @shapes_t.setter
     def shapes_t(self, value: Dict) -> None:
-        if not options.api.legacy_components:
+        if options.api.new_components_api:
             raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("shapes"))
         self.c.shapes.dynamic = value
 

--- a/pypsa/network/components.py
+++ b/pypsa/network/components.py
@@ -149,7 +149,7 @@ class NetworkComponentsMixin(_NetworkABC):
         return (
             self.c.sub_networks.static
             if not options.api.new_components_api
-            else self.c.subnetworks
+            else self.c.sub_networks
         )
 
     @sub_networks.setter

--- a/pypsa/network/components.py
+++ b/pypsa/network/components.py
@@ -13,6 +13,7 @@ are set.
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Any
 
 from pypsa._options import options
@@ -349,189 +350,301 @@ class NetworkComponentsMixin(_NetworkABC):
     @property
     def sub_networks_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("sub_networks"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("sub_networks"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.sub_networks.dynamic
 
     @sub_networks_t.setter
     def sub_networks_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("sub_networks"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("sub_networks"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.sub_networks.dynamic = value
 
     @property
     def buses_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("buses"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("buses"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.buses.dynamic
 
     @buses_t.setter
     def buses_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("buses"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("buses"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.buses.dynamic = value
 
     @property
     def carriers_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("carriers"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("carriers"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.carriers.dynamic
 
     @carriers_t.setter
     def carriers_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("carriers"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("carriers"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.carriers.dynamic = value
 
     @property
     def global_constraints_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(
-                _DYNAMIC_GETTER_WARNING.format("global_constraints")
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("global_constraints"),
+                DeprecationWarning,
+                stacklevel=2,
             )
         return self.c.global_constraints.dynamic
 
     @global_constraints_t.setter
     def global_constraints_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(
-                _DYNAMIC_SETTER_WARNING.format("global_constraints")
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("global_constraints"),
+                DeprecationWarning,
+                stacklevel=2,
             )
         self.c.global_constraints.dynamic = value
 
     @property
     def lines_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("lines"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("lines"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.lines.dynamic
 
     @lines_t.setter
     def lines_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("lines"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("lines"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.lines.dynamic = value
 
     @property
     def line_types_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("line_types"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("line_types"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.line_types.dynamic
 
     @line_types_t.setter
     def line_types_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("line_types"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("line_types"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.line_types.dynamic = value
 
     @property
     def transformers_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("transformers"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("transformers"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.transformers.dynamic
 
     @transformers_t.setter
     def transformers_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("transformers"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("transformers"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.transformers.dynamic = value
 
     @property
     def transformer_types_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(
-                _DYNAMIC_GETTER_WARNING.format("transformer_types")
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("transformer_types"),
+                DeprecationWarning,
+                stacklevel=2,
             )
         return self.c.transformer_types.dynamic
 
     @transformer_types_t.setter
     def transformer_types_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(
-                _DYNAMIC_SETTER_WARNING.format("transformer_types")
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("transformer_types"),
+                DeprecationWarning,
+                stacklevel=2,
             )
         self.c.transformer_types.dynamic = value
 
     @property
     def links_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("links"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("links"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.links.dynamic
 
     @links_t.setter
     def links_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("links"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("links"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.links.dynamic = value
 
     @property
     def loads_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("loads"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("loads"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.loads.dynamic
 
     @loads_t.setter
     def loads_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("loads"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("loads"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.loads.dynamic = value
 
     @property
     def generators_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("generators"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("generators"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.generators.dynamic
 
     @generators_t.setter
     def generators_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("generators"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("generators"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.generators.dynamic = value
 
     @property
     def storage_units_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("storage_units"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("storage_units"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.storage_units.dynamic
 
     @storage_units_t.setter
     def storage_units_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("storage_units"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("storage_units"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.storage_units.dynamic = value
 
     @property
     def stores_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("stores"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("stores"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.stores.dynamic
 
     @stores_t.setter
     def stores_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("stores"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("stores"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.stores.dynamic = value
 
     @property
     def shunt_impedances_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("shunt_impedances"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("shunt_impedances"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.shunt_impedances.dynamic
 
     @shunt_impedances_t.setter
     def shunt_impedances_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("shunt_impedances"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("shunt_impedances"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.shunt_impedances.dynamic = value
 
     @property
     def shapes_t(self) -> Dict:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_GETTER_WARNING.format("shapes"))
+            warnings.warn(
+                _DYNAMIC_GETTER_WARNING.format("shapes"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self.c.shapes.dynamic
 
     @shapes_t.setter
     def shapes_t(self, value: Dict) -> None:
         if options.api.new_components_api:
-            raise DeprecationWarning(_DYNAMIC_SETTER_WARNING.format("shapes"))
+            warnings.warn(
+                _DYNAMIC_SETTER_WARNING.format("shapes"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.c.shapes.dynamic = value
 
     @property

--- a/pypsa/network/graph.py
+++ b/pypsa/network/graph.py
@@ -71,7 +71,7 @@ class NetworkGraphMixin:
                 branch_components = n.branch_components
             else:
                 branch_components = set(branch_components)
-            buses_i = n.buses.index
+            buses_i = n.c.buses.static.index
         elif isinstance(n, SubNetwork):
             if branch_components is None:
                 branch_components = n.n.passive_branch_components
@@ -155,7 +155,7 @@ class NetworkGraphMixin:
             if branch_components is None:
                 branch_components = n.branch_components
             if busorder is None:
-                busorder = n.buses.index
+                busorder = n.c.buses.static.index
         elif isinstance(n, SubNetwork):
             if branch_components is None:
                 branch_components = n.n.passive_branch_components
@@ -247,7 +247,7 @@ class NetworkGraphMixin:
             if branch_components is None:
                 branch_components = self.branch_components
             if busorder is None:
-                busorder = self.buses.index
+                busorder = self.c.buses.static.index
         elif isinstance(self, SubNetwork):
             if branch_components is None:
                 branch_components = self.n.passive_branch_components

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -2147,11 +2147,13 @@ class NetworkIOMixin(_NetworkABC):
                 **pdf[self.components[component]["list_name"]],
             )
 
-        self.generators["control"] = self.generators.bus.map(self.buses["control"])
+        self.c.generators.static["control"] = self.c.generators.static.bus.map(
+            self.c.buses.static["control"]
+        )
 
         # for consistency with pypower, take the v_mag set point from the generators
-        self.buses.loc[self.generators.bus, "v_mag_pu_set"] = np.asarray(
-            self.generators["v_set_pu"]
+        self.c.buses.static.loc[self.c.generators.static.bus, "v_mag_pu_set"] = (
+            np.asarray(self.c.generators.static["v_set_pu"])
         )
 
     def import_from_pandapower_net(

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -7,6 +7,7 @@ import json
 import logging
 import math
 import tempfile
+import warnings
 from abc import abstractmethod
 from functools import partial
 from typing import TYPE_CHECKING, Any, overload
@@ -1086,19 +1087,31 @@ class NetworkIOMixin(_NetworkABC):
         # exportable component types
         allowed_types = (float, int, bool, str) + tuple(np.sctypeDict.values())
 
-        # first export network properties
-        _attrs = {
-            attr: getattr(self, attr)
-            for attr in dir(self)
-            if (
-                not attr.startswith("__")
-                and isinstance(getattr(self, attr), allowed_types)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=".*the API for how to access components data has.*",
+                category=DeprecationWarning,
             )
-        }
+
+            _attrs = {
+                attr: getattr(self, attr)
+                for attr in dir(self)
+                if (
+                    not attr.startswith("__")
+                    and isinstance(getattr(self, attr), allowed_types)
+                )
+            }
         _attrs = {}
         for attr in dir(self):
             if not attr.startswith("__"):
-                value = getattr(self, attr)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        message=".*the API for how to access components data has.*",
+                        category=DeprecationWarning,
+                    )
+                    value = getattr(self, attr)
                 if isinstance(value, allowed_types):
                     # TODO: This needs to be refactored with NetworkData class
                     # Skip properties without setter, but not 'pypsa_version'

--- a/pypsa/network/power_flow.py
+++ b/pypsa/network/power_flow.py
@@ -72,7 +72,7 @@ def _allocate_pf_outputs(n: Network, linear: bool = False) -> None:
         "Bus": ["p", "v_ang", "v_mag_pu"],
         "Line": ["p0", "p1"],
         "Transformer": ["p0", "p1"],
-        "Link": ["p" + col[3:] for col in n.links.columns if col[:3] == "bus"],
+        "Link": ["p" + col[3:] for col in n.c.links.static.columns if col[:3] == "bus"],
     }
 
     if not linear:
@@ -162,21 +162,21 @@ def _network_prepare_and_run_pf(
     sns = as_index(n, snapshots, "snapshots")
 
     # deal with links
-    if not n.links.empty:
+    if not n.c.links.static.empty:
         p_set = get_as_dense(n, "Link", "p_set", sns)
         n.links_t.p0.loc[sns] = p_set.loc[sns]
         for i in ["1"] + n.c.links.additional_ports:
             eff_name = "efficiency" if i == "1" else f"efficiency{i}"
             efficiency = get_as_dense(n, "Link", eff_name, sns)
-            links = n.links.index[n.links[f"bus{i}"] != ""]
+            links = n.c.links.static.index[n.c.links.static[f"bus{i}"] != ""]
             n.links_t[f"p{i}"].loc[sns, links] = (
                 -n.links_t.p0.loc[sns, links] * efficiency.loc[sns, links]
             )
 
-    itdf = pd.DataFrame(index=sns, columns=n.sub_networks.index, dtype=int)
-    difdf = pd.DataFrame(index=sns, columns=n.sub_networks.index)
-    cnvdf = pd.DataFrame(index=sns, columns=n.sub_networks.index, dtype=bool)
-    for sub_network in n.sub_networks.obj:
+    itdf = pd.DataFrame(index=sns, columns=n.c.sub_networks.static.index, dtype=int)
+    difdf = pd.DataFrame(index=sns, columns=n.c.sub_networks.static.index)
+    cnvdf = pd.DataFrame(index=sns, columns=n.c.sub_networks.static.index, dtype=bool)
+    for sub_network in n.c.sub_networks.static.obj:
         if not skip_pre:
             sub_network.find_bus_controls()
 
@@ -348,19 +348,22 @@ def sub_network_pf_singlebus(
     _calculate_controllable_nodal_power_balance(sub_network, n, sns, buses_o)
 
     v_mag_pu_set = get_as_dense(n, "Bus", "v_mag_pu_set", sns)
-    n.buses_t.v_mag_pu.loc[sns, sub_network.slack_bus] = v_mag_pu_set.loc[
+    n.c.buses.dynamic.v_mag_pu.loc[sns, sub_network.slack_bus] = v_mag_pu_set.loc[
         :, sub_network.slack_bus
     ]
-    n.buses_t.v_ang.loc[sns, sub_network.slack_bus] = 0.0
+    n.c.buses.dynamic.v_ang.loc[sns, sub_network.slack_bus] = 0.0
 
     if distribute_slack:
         for bus, group in sub_network.generators().groupby("bus"):
             if slack_weights in ["p_nom", "p_nom_opt"]:
-                if all(n.generators[slack_weights] == 0):
+                if all(n.c.generators.static[slack_weights] == 0):
                     msg = f"Invalid slack weights! Generator attribute {slack_weights} is always zero."
                     raise ValueError(msg)
                 bus_generator_shares = (
-                    n.generators[slack_weights].loc[group.index].pipe(normed).fillna(0)
+                    n.c.generators.static[slack_weights]
+                    .loc[group.index]
+                    .pipe(normed)
+                    .fillna(0)
                 )
             elif slack_weights == "p_set":
                 generators_t_p_choice = get_as_dense(n, "Generator", slack_weights, sns)
@@ -386,50 +389,52 @@ def sub_network_pf_singlebus(
                 bus_generator_shares = slack_weights.pipe(normed).fillna(0)  # type: ignore
             n.generators_t.p.loc[sns, group.index] += (
                 bus_generator_shares.multiply(
-                    -n.buses_t.p.loc[sns, bus], axis=0
+                    -n.c.buses.dynamic.p.loc[sns, bus], axis=0
                 )
             )  # fmt: skip
     else:
         n.generators_t.p.loc[sns, sub_network.slack_generator] -= (
-            n.buses_t.p.loc[sns, sub_network.slack_bus]
+            n.c.buses.dynamic.p.loc[sns, sub_network.slack_bus]
         )  # fmt: skip
 
     n.generators_t.q.loc[sns, sub_network.slack_generator] -= (
-        n.buses_t.q.loc[sns, sub_network.slack_bus]
+        n.c.buses.dynamic.q.loc[sns, sub_network.slack_bus]
     )  # fmt: skip
 
-    n.buses_t.p.loc[sns, sub_network.slack_bus] = 0.0
-    n.buses_t.q.loc[sns, sub_network.slack_bus] = 0.0
+    n.c.buses.dynamic.p.loc[sns, sub_network.slack_bus] = 0.0
+    n.c.buses.dynamic.q.loc[sns, sub_network.slack_bus] = 0.0
 
     return 0, 0.0, True  # dummy substitute for newton raphson output
 
 
 def apply_line_types(n: Network) -> None:
     """Calculate line electrical parameters x, r, b, g from standard types."""
-    lines_with_types_b = n.lines.type != ""
+    lines_with_types_b = n.c.lines.static.type != ""
     if lines_with_types_b.zsum() == 0:
         return
 
     # Get unique line types from lines
-    line_types_used = n.lines.loc[lines_with_types_b, "type"].unique()
+    line_types_used = n.c.lines.static.loc[lines_with_types_b, "type"].unique()
 
     missing_types = pd.Index(line_types_used).difference(n.c.line_types.component_names)
 
     if not missing_types.empty:
-        msg = f"The type(s) {', '.join(missing_types)} do(es) not exist in n.line_types"
+        msg = f"The type(s) {', '.join(missing_types)} do(es) not exist in n.c.line_types.static"
         raise ValueError(msg)
 
-    lines = n.lines.loc[lines_with_types_b, ["type", "length", "num_parallel"]].copy()
+    lines = n.c.lines.static.loc[
+        lines_with_types_b, ["type", "length", "num_parallel"]
+    ].copy()
 
     if n.has_scenarios:
         # For stochastic network, use the first scenario's line types
         # User changes across line type data are caught by the consistency check
-        line_types_to_use = n.line_types.xs(
-            n.line_types.index.get_level_values(0)[0], level=0
+        line_types_to_use = n.c.line_types.static.xs(
+            n.c.line_types.static.index.get_level_values(0)[0], level=0
         )
         lines = lines.join(line_types_to_use, on="type")
     else:
-        lines = lines.join(n.line_types, on="type")
+        lines = lines.join(n.c.line_types.static, on="type")
 
     for attr in ["r", "x"]:
         lines[attr] = (
@@ -447,17 +452,17 @@ def apply_line_types(n: Network) -> None:
 
     # now set calculated values on live lines
     for attr in ["r", "x", "b"]:
-        n.lines.loc[lines_with_types_b, attr] = lines[attr]
+        n.c.lines.static.loc[lines_with_types_b, attr] = lines[attr]
 
 
 def apply_transformer_types(n: Network) -> None:
     """Calculate transformer electrical parameters x, r, b, g from standard types."""
-    trafos_with_types_b = n.transformers.type != ""
+    trafos_with_types_b = n.c.transformers.static.type != ""
     if trafos_with_types_b.zsum() == 0:
         return
 
     missing_types = pd.Index(
-        n.transformers.loc[trafos_with_types_b, "type"].unique()
+        n.c.transformers.static.loc[trafos_with_types_b, "type"].unique()
     ).difference(n.transformer_types.index)
     if not missing_types.empty:
         msg = (
@@ -468,7 +473,7 @@ def apply_transformer_types(n: Network) -> None:
 
     # Get a copy of the transformers data
     # (joining pulls in "phase_shift", "s_nom", "tap_side" from TransformerType)
-    t = n.transformers.loc[
+    t = n.c.transformers.static.loc[
         trafos_with_types_b, ["type", "tap_position", "num_parallel"]
     ].join(n.transformer_types, on="type")
 
@@ -495,8 +500,8 @@ def apply_transformer_types(n: Network) -> None:
 
     # now set calculated values on live transformers
     attrs = ["r", "x", "g", "b", "phase_shift", "s_nom", "tap_side", "tap_ratio"]
-    n.transformers.loc[trafos_with_types_b, attrs] = t[attrs].astype(
-        n.transformers[attrs].dtypes
+    n.c.transformers.static.loc[trafos_with_types_b, attrs] = t[attrs].astype(
+        n.c.transformers.static[attrs].dtypes
     )
 
     # TODO: status, rate_A
@@ -536,10 +541,10 @@ def apply_transformer_t_model(n: Network) -> None:
     Uses wye-delta transformation.
 
     """
-    z_series = n.transformers.r_pu + 1j * n.transformers.x_pu
-    y_shunt = n.transformers.g_pu + 1j * n.transformers.b_pu
+    z_series = n.c.transformers.static.r_pu + 1j * n.c.transformers.static.x_pu
+    y_shunt = n.c.transformers.static.g_pu + 1j * n.c.transformers.static.b_pu
 
-    ts_b = (n.transformers.model == "t") & (y_shunt != 0.0)
+    ts_b = (n.c.transformers.static.model == "t") & (y_shunt != 0.0)
 
     if ts_b.zsum() == 0:
         return
@@ -548,10 +553,10 @@ def apply_transformer_t_model(n: Network) -> None:
         z_series.loc[ts_b] / 2, z_series.loc[ts_b] / 2, 1 / y_shunt.loc[ts_b]
     )
 
-    n.transformers.loc[ts_b, "r_pu"] = real(zc)
-    n.transformers.loc[ts_b, "x_pu"] = imag(zc)
-    n.transformers.loc[ts_b, "g_pu"] = real(2 / za)
-    n.transformers.loc[ts_b, "b_pu"] = imag(2 / za)
+    n.c.transformers.static.loc[ts_b, "r_pu"] = real(zc)
+    n.c.transformers.static.loc[ts_b, "x_pu"] = imag(zc)
+    n.c.transformers.static.loc[ts_b, "g_pu"] = real(2 / za)
+    n.c.transformers.static.loc[ts_b, "b_pu"] = imag(2 / za)
 
 
 def aggregate_multi_graph(sub_network: SubNetwork) -> None:
@@ -570,7 +575,7 @@ def aggregate_multi_graph(sub_network: SubNetwork) -> None:
             continue
         line_objs = list(graph.adj[u][v].keys())
         if len(line_objs) > 1:
-            lines = n.lines.loc[[line[1] for line in line_objs]]
+            lines = n.c.lines.static.loc[[line[1] for line in line_objs]]
             attr_inv = ["x", "r"]
             attr_sum = ["s_nom", "b", "g", "s_nom_max", "s_nom_min"]
             attr_mean = ["capital_cost", "length", "terrain_factor"]
@@ -707,51 +712,69 @@ class NetworkPowerFlowMixin(_NetworkABC):
 
         apply_transformer_types(self)
 
-        buses = self.buses
+        buses = self.c.buses.static
 
         if self.has_scenarios:
             buses = buses.xs(self.scenarios[0], level="scenario")
 
-        self.lines["v_nom"] = self.lines.bus0.map(buses.v_nom)
-        self.lines.loc[self.lines.carrier == "", "carrier"] = self.lines.bus0.map(
-            buses.carrier
+        self.c.lines.static["v_nom"] = self.c.lines.static.bus0.map(buses.v_nom)
+        self.c.lines.static.loc[self.c.lines.static.carrier == "", "carrier"] = (
+            self.c.lines.static.bus0.map(buses.carrier)
         )
 
-        self.lines["x_pu"] = self.lines.x / (self.lines.v_nom**2)
-        self.lines["r_pu"] = self.lines.r / (self.lines.v_nom**2)
-        self.lines["b_pu"] = self.lines.b * self.lines.v_nom**2
-        self.lines["g_pu"] = self.lines.g * self.lines.v_nom**2
-        self.lines["x_pu_eff"] = self.lines["x_pu"]
-        self.lines["r_pu_eff"] = self.lines["r_pu"]
+        self.c.lines.static["x_pu"] = self.c.lines.static.x / (
+            self.c.lines.static.v_nom**2
+        )
+        self.c.lines.static["r_pu"] = self.c.lines.static.r / (
+            self.c.lines.static.v_nom**2
+        )
+        self.c.lines.static["b_pu"] = (
+            self.c.lines.static.b * self.c.lines.static.v_nom**2
+        )
+        self.c.lines.static["g_pu"] = (
+            self.c.lines.static.g * self.c.lines.static.v_nom**2
+        )
+        self.c.lines.static["x_pu_eff"] = self.c.lines.static["x_pu"]
+        self.c.lines.static["r_pu_eff"] = self.c.lines.static["r_pu"]
 
         # convert transformer impedances from base power s_nom to base = 1 MVA
-        self.transformers["x_pu"] = self.transformers.x / self.transformers.s_nom
-        self.transformers["r_pu"] = self.transformers.r / self.transformers.s_nom
-        self.transformers["b_pu"] = self.transformers.b * self.transformers.s_nom
-        self.transformers["g_pu"] = self.transformers.g * self.transformers.s_nom
-        self.transformers["x_pu_eff"] = (
-            self.transformers["x_pu"] * self.transformers["tap_ratio"]
+        self.c.transformers.static["x_pu"] = (
+            self.c.transformers.static.x / self.c.transformers.static.s_nom
         )
-        self.transformers["r_pu_eff"] = (
-            self.transformers["r_pu"] * self.transformers["tap_ratio"]
+        self.c.transformers.static["r_pu"] = (
+            self.c.transformers.static.r / self.c.transformers.static.s_nom
+        )
+        self.c.transformers.static["b_pu"] = (
+            self.c.transformers.static.b * self.c.transformers.static.s_nom
+        )
+        self.c.transformers.static["g_pu"] = (
+            self.c.transformers.static.g * self.c.transformers.static.s_nom
+        )
+        self.c.transformers.static["x_pu_eff"] = (
+            self.c.transformers.static["x_pu"] * self.c.transformers.static["tap_ratio"]
+        )
+        self.c.transformers.static["r_pu_eff"] = (
+            self.c.transformers.static["r_pu"] * self.c.transformers.static["tap_ratio"]
         )
 
         apply_transformer_t_model(self)
 
-        self.shunt_impedances["v_nom"] = self.shunt_impedances["bus"].map(buses.v_nom)
-        self.shunt_impedances["b_pu"] = (
-            self.shunt_impedances.b * self.shunt_impedances.v_nom**2
+        self.c.shunt_impedances.static["v_nom"] = self.c.shunt_impedances.static[
+            "bus"
+        ].map(buses.v_nom)
+        self.c.shunt_impedances.static["b_pu"] = (
+            self.c.shunt_impedances.static.b * self.c.shunt_impedances.static.v_nom**2
         )
-        self.shunt_impedances["g_pu"] = (
-            self.shunt_impedances.g * self.shunt_impedances.v_nom**2
-        )
-
-        self.links.loc[self.links.carrier == "", "carrier"] = self.links.bus0.map(
-            buses.carrier
+        self.c.shunt_impedances.static["g_pu"] = (
+            self.c.shunt_impedances.static.g * self.c.shunt_impedances.static.v_nom**2
         )
 
-        self.stores.loc[self.stores.carrier == "", "carrier"] = self.stores.bus.map(
-            buses.carrier
+        self.c.links.static.loc[self.c.links.static.carrier == "", "carrier"] = (
+            self.c.links.static.bus0.map(buses.carrier)
+        )
+
+        self.c.stores.static.loc[self.c.stores.static.carrier == "", "carrier"] = (
+            self.c.stores.static.bus.map(buses.carrier)
         )
 
         _update_linkports_component_attrs(self)
@@ -887,7 +910,7 @@ class NetworkPowerFlowMixin(_NetworkABC):
         )
         p0 = p0_base.to_frame("base")
 
-        for sub_network in self.sub_networks.obj:
+        for sub_network in self.c.sub_networks.static.obj:
             sub_network._branches = sub_network.branches()
             sub_network.calculate_BODF()
 
@@ -896,7 +919,9 @@ class NetworkPowerFlowMixin(_NetworkABC):
                 logger.warning("No type given for %s, assuming it is a line", branch)
                 branch = ("Line", branch)
 
-            sub_network = self.sub_networks.obj[passive_branches.sub_network[branch]]
+            sub_network = self.c.sub_networks.static.obj[
+                passive_branches.sub_network[branch]
+            ]
 
             branch_i = sub_network._branches.index.get_loc(branch)
             p0_new = p0_base + pd.Series(
@@ -1026,7 +1051,7 @@ class SubNetworkPowerFlowMixin:
             n.calculate_dependent_values()
             self.find_bus_controls()
 
-        if self.n.sub_networks.at[self.name, "carrier"] == "DC":
+        if self.n.c.sub_networks.static.at[self.name, "carrier"] == "DC":
             attribute = "r_pu_eff"
         else:
             attribute = "x_pu_eff"
@@ -1081,7 +1106,7 @@ class SubNetworkPowerFlowMixin:
         if not skip_pre:
             self.n.calculate_dependent_values()
 
-        if self.n.sub_networks.at[self.name, "carrier"] != "AC":
+        if self.n.c.sub_networks.static.at[self.name, "carrier"] != "AC":
             logger.warning("Non-AC networks not supported for Y!")
             return
 
@@ -1126,12 +1151,12 @@ class SubNetworkPowerFlowMixin:
 
         # bus shunt impedances
         b_sh = (
-            n.shunt_impedances.b_pu.groupby(n.shunt_impedances.bus)
+            n.c.shunt_impedances.static.b_pu.groupby(n.c.shunt_impedances.static.bus)
             .sum()
             .reindex(buses_o, fill_value=0.0)
         )
         g_sh = (
-            n.shunt_impedances.g_pu.groupby(n.shunt_impedances.bus)
+            n.c.shunt_impedances.static.g_pu.groupby(n.c.shunt_impedances.static.bus)
             .sum()
             .reindex(buses_o, fill_value=0.0)
         )
@@ -1179,13 +1204,15 @@ class SubNetworkPowerFlowMixin:
 
         else:
             slacks = gens[gens.control == "Slack"].index.unique("name")
-            network_gen_names = self.n.generators.index.get_level_values("name")
+            network_gen_names = self.n.c.generators.static.index.get_level_values(
+                "name"
+            )
 
             if len(slacks) == 0:
                 self.slack_generator = gen_names[0]
 
                 is_slack_generators = network_gen_names == self.slack_generator
-                self.n.generators.loc[is_slack_generators, "control"] = "Slack"
+                self.n.c.generators.static.loc[is_slack_generators, "control"] = "Slack"
                 logger.debug(
                     "No slack generator found in sub-network %s, using %s as the slack generator",
                     self.name,
@@ -1197,7 +1224,7 @@ class SubNetworkPowerFlowMixin:
             else:
                 self.slack_generator = slacks[0]
                 non_slack_generators = network_gen_names.isin(slacks[1:])
-                self.n.generators.loc[non_slack_generators, "control"] = "PV"
+                self.n.c.generators.static.loc[non_slack_generators, "control"] = "PV"
                 logger.debug(
                     "More than one slack generator found in sub-network %s, using %s as the slack generator",
                     self.name,
@@ -1211,7 +1238,7 @@ class SubNetworkPowerFlowMixin:
             else:
                 self.slack_bus = gens.bus.loc[self.slack_generator]
         # also put it into the dataframe
-        self.n.sub_networks.at[self.name, "slack_bus"] = self.slack_bus
+        self.n.c.sub_networks.static.at[self.name, "slack_bus"] = self.slack_bus
 
         logger.debug(
             "Slack bus for sub-network %s is %s",
@@ -1233,22 +1260,22 @@ class SubNetworkPowerFlowMixin:
         buses_i = self.buses_i()
 
         # default bus control is PQ
-        n.buses.loc[buses_i, "control"] = "PQ"
+        n.c.buses.static.loc[buses_i, "control"] = "PQ"
 
         # find all buses with one or more gens with PV
         pvs = gens[gens.control == "PV"].index.to_series()
         if len(pvs) > 0:
             pvs = pvs.groupby(gens.bus).first()
-            n.buses.loc[pvs.index, "control"] = "PV"
-            n.buses.loc[pvs.index, "generator"] = pvs
+            n.c.buses.static.loc[pvs.index, "control"] = "PV"
+            n.c.buses.static.loc[pvs.index, "generator"] = pvs
 
-        is_slack_bus = n.buses.index.get_level_values("name") == self.slack_bus
-        n.buses.loc[is_slack_bus, "control"] = "Slack"
-        n.buses.loc[is_slack_bus, "generator"] = (
+        is_slack_bus = n.c.buses.static.index.get_level_values("name") == self.slack_bus
+        n.c.buses.static.loc[is_slack_bus, "control"] = "Slack"
+        n.c.buses.static.loc[is_slack_bus, "generator"] = (
             self.slack_generator if self.slack_generator is not None else ""
         )
 
-        buses_control = n.buses.loc[buses_i, "control"]
+        buses_control = n.c.buses.static.loc[buses_i, "control"]
         self.pvs = buses_control.index[buses_control == "PV"]
         self.pqs = buses_control.index[buses_control == "PQ"]
 
@@ -1319,7 +1346,7 @@ class SubNetworkPowerFlowMixin:
         sns = as_index(self.n, snapshots, "snapshots")
         logger.info(
             "Performing non-linear load-flow on %s sub-network %s for snapshots %s",
-            self.n.sub_networks.at[self.name, "carrier"],
+            self.n.c.sub_networks.static.at[self.name, "carrier"],
             self,
             sns,
         )
@@ -1362,11 +1389,13 @@ class SubNetworkPowerFlowMixin:
             slack_weights: np.ndarray | None = None,
         ) -> np.ndarray:
             last_pq = -1 if distribute_slack else None
-            n.buses_t.v_ang.loc[now, self.pvpqs] = guess[: len(self.pvpqs)]
-            n.buses_t.v_mag_pu.loc[now, self.pqs] = guess[len(self.pvpqs) : last_pq]
+            n.c.buses.dynamic.v_ang.loc[now, self.pvpqs] = guess[: len(self.pvpqs)]
+            n.c.buses.dynamic.v_mag_pu.loc[now, self.pqs] = guess[
+                len(self.pvpqs) : last_pq
+            ]
 
-            v_mag_pu = n.buses_t.v_mag_pu.loc[now, buses_o]
-            v_ang = n.buses_t.v_ang.loc[now, buses_o]
+            v_mag_pu = n.c.buses.dynamic.v_mag_pu.loc[now, buses_o]
+            v_ang = n.c.buses.dynamic.v_ang.loc[now, buses_o]
             V = v_mag_pu * np.exp(1j * v_ang)
 
             if distribute_slack:
@@ -1388,11 +1417,13 @@ class SubNetworkPowerFlowMixin:
             slack_weights: np.ndarray | None = None,
         ) -> csr_matrix:
             last_pq = -1 if distribute_slack else None
-            n.buses_t.v_ang.loc[now, self.pvpqs] = guess[: len(self.pvpqs)]
-            n.buses_t.v_mag_pu.loc[now, self.pqs] = guess[len(self.pvpqs) : last_pq]
+            n.c.buses.dynamic.v_ang.loc[now, self.pvpqs] = guess[: len(self.pvpqs)]
+            n.c.buses.dynamic.v_mag_pu.loc[now, self.pqs] = guess[
+                len(self.pvpqs) : last_pq
+            ]
 
-            v_mag_pu = n.buses_t.v_mag_pu.loc[now, buses_o]
-            v_ang = n.buses_t.v_ang.loc[now, buses_o]
+            v_mag_pu = n.c.buses.dynamic.v_mag_pu.loc[now, buses_o]
+            v_ang = n.c.buses.dynamic.v_ang.loc[now, buses_o]
 
             V = v_mag_pu * np.exp(1j * v_ang)
 
@@ -1431,15 +1462,15 @@ class SubNetworkPowerFlowMixin:
 
         # Set what we know: slack V and v_mag_pu for PV buses
         v_mag_pu_set = get_as_dense(n, "Bus", "v_mag_pu_set", sns)
-        n.buses_t.v_mag_pu.loc[sns, self.pvs] = v_mag_pu_set.loc[:, self.pvs]
-        n.buses_t.v_mag_pu.loc[sns, self.slack_bus] = v_mag_pu_set.loc[
+        n.c.buses.dynamic.v_mag_pu.loc[sns, self.pvs] = v_mag_pu_set.loc[:, self.pvs]
+        n.c.buses.dynamic.v_mag_pu.loc[sns, self.slack_bus] = v_mag_pu_set.loc[
             :, self.slack_bus
         ]
-        n.buses_t.v_ang.loc[sns, self.slack_bus] = 0.0
+        n.c.buses.dynamic.v_ang.loc[sns, self.slack_bus] = 0.0
 
         if not use_seed:
-            n.buses_t.v_mag_pu.loc[sns, self.pqs] = 1.0
-            n.buses_t.v_ang.loc[sns, self.pvpqs] = 0.0
+            n.c.buses.dynamic.v_mag_pu.loc[sns, self.pqs] = 1.0
+            n.c.buses.dynamic.v_ang.loc[sns, self.pvpqs] = 0.0
 
         slack_args = {"distribute_slack": distribute_slack}
         slack_variable_b = 1 if distribute_slack else 0
@@ -1447,7 +1478,9 @@ class SubNetworkPowerFlowMixin:
         if distribute_slack:
             if isinstance(slack_weights, str) and slack_weights == "p_set":
                 generators_t_p_choice = get_as_dense(n, "Generator", slack_weights, sns)
-                bus_generation = generators_t_p_choice.rename(columns=n.generators.bus)
+                bus_generation = generators_t_p_choice.rename(
+                    columns=n.c.generators.static.bus
+                )
                 slack_weights_calc = (
                     pd.DataFrame(
                         bus_generation.T.groupby(bus_generation.columns).sum().T,
@@ -1461,7 +1494,7 @@ class SubNetworkPowerFlowMixin:
                 "p_nom",
                 "p_nom_opt",
             ]:
-                if all(n.generators[slack_weights] == 0):
+                if all(n.c.generators.static[slack_weights] == 0):
                     msg = (
                         f"Invalid slack weights! Generator attribute {slack_weights} is "
                         f"always zero."
@@ -1469,7 +1502,7 @@ class SubNetworkPowerFlowMixin:
                     raise ValueError(msg)
 
                 slack_weights_calc = (
-                    n.generators.groupby("bus")[slack_weights]
+                    n.c.generators.static.groupby("bus")[slack_weights]
                     .sum()
                     .reindex(buses_o)
                     .pipe(normed)
@@ -1479,7 +1512,7 @@ class SubNetworkPowerFlowMixin:
             elif generator_slack_weights_b:
                 # convert generator-based slack weights to bus-based slack weights
                 slack_weights_calc = (
-                    slack_weights.rename(n.generators.bus)  # type: ignore
+                    slack_weights.rename(n.c.generators.static.bus)  # type: ignore
                     .groupby(slack_weights.index.name)  # type: ignore
                     .sum()
                     .reindex(buses_o)
@@ -1504,14 +1537,14 @@ class SubNetworkPowerFlowMixin:
         diffs = pd.Series(index=sns, dtype=float)
         convs = pd.Series(False, index=sns)
         for i, now in enumerate(sns):
-            p = n.buses_t.p.loc[now, buses_o]
-            q = n.buses_t.q.loc[now, buses_o]
+            p = n.c.buses.dynamic.p.loc[now, buses_o]
+            q = n.c.buses.dynamic.q.loc[now, buses_o]
             ss[i] = s = p + 1j * q
 
             # Make a guess for what we don't know: V_ang for PV and PQs and v_mag_pu for PQ buses
             guess = r_[
-                n.buses_t.v_ang.loc[now, self.pvpqs],
-                n.buses_t.v_mag_pu.loc[now, self.pqs],
+                n.c.buses.dynamic.v_ang.loc[now, self.pvpqs],
+                n.c.buses.dynamic.v_mag_pu.loc[now, self.pqs],
             ]
 
             if distribute_slack:
@@ -1542,11 +1575,13 @@ class SubNetworkPowerFlowMixin:
             last_pq = -1
         else:
             last_pq = None
-        n.buses_t.v_ang.loc[sns, self.pvpqs] = roots[:, : len(self.pvpqs)]
-        n.buses_t.v_mag_pu.loc[sns, self.pqs] = roots[:, len(self.pvpqs) : last_pq]
+        n.c.buses.dynamic.v_ang.loc[sns, self.pvpqs] = roots[:, : len(self.pvpqs)]
+        n.c.buses.dynamic.v_mag_pu.loc[sns, self.pqs] = roots[
+            :, len(self.pvpqs) : last_pq
+        ]
 
-        v_mag_pu = n.buses_t.v_mag_pu.loc[sns, buses_o].values
-        v_ang = n.buses_t.v_ang.loc[sns, buses_o].values
+        v_mag_pu = n.c.buses.dynamic.v_mag_pu.loc[sns, buses_o].values
+        v_ang = n.c.buses.dynamic.v_ang.loc[sns, buses_o].values
 
         V = v_mag_pu * np.exp(1j * v_ang)
 
@@ -1581,30 +1616,36 @@ class SubNetworkPowerFlowMixin:
             s_calc[i] = V[i] * np.conj(self.Y * V[i])
         slack_index = int(buses_o.get_loc(self.slack_bus))
         if distribute_slack:
-            n.buses_t.p.loc[sns, sn_buses] = s_calc.real[:, buses_indexer(sn_buses)]
+            n.c.buses.dynamic.p.loc[sns, sn_buses] = s_calc.real[
+                :, buses_indexer(sn_buses)
+            ]
         else:
-            n.buses_t.p.loc[sns, self.slack_bus] = s_calc[:, slack_index].real
-        n.buses_t.q.loc[sns, self.slack_bus] = s_calc[:, slack_index].imag
-        n.buses_t.q.loc[sns, self.pvs] = s_calc[:, buses_indexer(self.pvs)].imag
+            n.c.buses.dynamic.p.loc[sns, self.slack_bus] = s_calc[:, slack_index].real
+        n.c.buses.dynamic.q.loc[sns, self.slack_bus] = s_calc[:, slack_index].imag
+        n.c.buses.dynamic.q.loc[sns, self.pvs] = s_calc[:, buses_indexer(self.pvs)].imag
 
         # set shunt impedance powers
         shunt_impedances_i = self.shunt_impedances_i()
         if len(shunt_impedances_i):
             # add voltages
             shunt_impedances_v_mag_pu = v_mag_pu[
-                :, buses_indexer(n.shunt_impedances.loc[shunt_impedances_i, "bus"])
+                :,
+                buses_indexer(
+                    n.c.shunt_impedances.static.loc[shunt_impedances_i, "bus"]
+                ),
             ]
             n.shunt_impedances_t.p.loc[sns, shunt_impedances_i] = (
                 shunt_impedances_v_mag_pu**2
-            ) * n.shunt_impedances.loc[shunt_impedances_i, "g_pu"].values
+            ) * n.c.shunt_impedances.static.loc[shunt_impedances_i, "g_pu"].values
             n.shunt_impedances_t.q.loc[sns, shunt_impedances_i] = (
                 shunt_impedances_v_mag_pu**2
-            ) * n.shunt_impedances.loc[shunt_impedances_i, "b_pu"].values
+            ) * n.c.shunt_impedances.static.loc[shunt_impedances_i, "b_pu"].values
 
         # let slack generator take up the slack
         if distribute_slack:
             distributed_slack_power = (
-                n.buses_t.p.loc[sns, sn_buses] - ss[:, buses_indexer(sn_buses)].real
+                n.c.buses.dynamic.p.loc[sns, sn_buses]
+                - ss[:, buses_indexer(sn_buses)].real
             )
             for bus, group in self.generators().groupby("bus"):
                 if isinstance(slack_weights, str) and slack_weights == "p_set":
@@ -1627,7 +1668,9 @@ class SubNetworkPowerFlowMixin:
                             slack_weights.loc[group.index].pipe(normed).fillna(0)  # type: ignore
                         )
                     else:
-                        bus_generators_p_nom = n.generators.p_nom.loc[group.index]
+                        bus_generators_p_nom = n.c.generators.static.p_nom.loc[
+                            group.index
+                        ]
                         # distribute evenly if no p_nom given
                         if all(bus_generators_p_nom) == 0:
                             bus_generators_p_nom = 1
@@ -1641,16 +1684,19 @@ class SubNetworkPowerFlowMixin:
                     )
         else:
             n.generators_t.p.loc[sns, self.slack_generator] += (
-                n.buses_t.p.loc[sns, self.slack_bus] - ss[:, slack_index].real
+                n.c.buses.dynamic.p.loc[sns, self.slack_bus] - ss[:, slack_index].real
             )
 
         # set the Q of the slack and PV generators
         n.generators_t.q.loc[sns, self.slack_generator] += (
-            n.buses_t.q.loc[sns, self.slack_bus] - ss[:, slack_index].imag
+            n.c.buses.dynamic.q.loc[sns, self.slack_bus] - ss[:, slack_index].imag
         )
 
-        n.generators_t.q.loc[sns, n.buses.loc[self.pvs, "generator"]] += np.asarray(
-            n.buses_t.q.loc[sns, self.pvs] - ss[:, buses_indexer(self.pvs)].imag
+        n.generators_t.q.loc[sns, n.c.buses.static.loc[self.pvs, "generator"]] += (
+            np.asarray(
+                n.c.buses.dynamic.q.loc[sns, self.pvs]
+                - ss[:, buses_indexer(self.pvs)].imag
+            )
         )
 
         return iters, diffs, convs
@@ -1675,7 +1721,7 @@ class SubNetworkPowerFlowMixin:
         sns = as_index(self.n, snapshots, "snapshots")
         logger.info(
             "Performing linear load-flow on %s sub-network %s for snapshot(s) %s",
-            self.n.sub_networks.at[self.name, "carrier"],
+            self.n.c.sub_networks.static.at[self.name, "carrier"],
             self,
             snapshots,
         )
@@ -1694,7 +1740,7 @@ class SubNetworkPowerFlowMixin:
         # allow all shunt impedances to dispatch as set
         shunt_impedances_i = self.shunt_impedances_i()
         n.shunt_impedances_t.p.loc[sns, shunt_impedances_i] = (
-            n.shunt_impedances.g_pu.loc[shunt_impedances_i].values
+            n.c.shunt_impedances.static.g_pu.loc[shunt_impedances_i].values
         )
 
         # allow all one ports to dispatch as set
@@ -1707,7 +1753,7 @@ class SubNetworkPowerFlowMixin:
             n.dynamic(c.name).p.loc[sns, c.static.query("active").index] = c_p_set
 
         # set the power injection at each node
-        n.buses_t.p.loc[sns, buses_o] = sum(
+        n.c.buses.dynamic.p.loc[sns, buses_o] = sum(
             [
                 (
                     (
@@ -1736,7 +1782,7 @@ class SubNetworkPowerFlowMixin:
 
         v_diff = np.zeros((len(sns), len(buses_o)))
         if len(branches_i) > 0:
-            p = n.buses_t["p"].loc[sns, buses_o].values - self.p_bus_shift
+            p = n.c.buses.dynamic["p"].loc[sns, buses_o].values - self.p_bus_shift
             v_diff[:, 1:] = spsolve(self.B[1:, 1:], p[:, 1:].T).T
             flows = (
                 pd.DataFrame(v_diff * self.H.T, columns=branches_i, index=sns)
@@ -1748,19 +1794,19 @@ class SubNetworkPowerFlowMixin:
                 n.dynamic(c.name).p0.loc[sns, f.columns] = f
                 n.dynamic(c.name).p1.loc[sns, f.columns] = -f
 
-        if n.sub_networks.at[self.name, "carrier"] == "DC":
-            n.buses_t.v_mag_pu.loc[sns, buses_o] = 1 + v_diff
-            n.buses_t.v_ang.loc[sns, buses_o] = 0.0
+        if n.c.sub_networks.static.at[self.name, "carrier"] == "DC":
+            n.c.buses.dynamic.v_mag_pu.loc[sns, buses_o] = 1 + v_diff
+            n.c.buses.dynamic.v_ang.loc[sns, buses_o] = 0.0
         else:
-            n.buses_t.v_ang.loc[sns, buses_o] = v_diff
-            n.buses_t.v_mag_pu.loc[sns, buses_o] = 1.0
+            n.c.buses.dynamic.v_ang.loc[sns, buses_o] = v_diff
+            n.c.buses.dynamic.v_mag_pu.loc[sns, buses_o] = 1.0
 
         # set slack bus power to pick up remained
         slack_adjustment = (
-            -n.buses_t.p.loc[sns, buses_o[1:]].sum(axis=1).fillna(0.0)
-            - n.buses_t.p.loc[sns, buses_o[0]]
+            -n.c.buses.dynamic.p.loc[sns, buses_o[1:]].sum(axis=1).fillna(0.0)
+            - n.c.buses.dynamic.p.loc[sns, buses_o[0]]
         )
-        n.buses_t.p.loc[sns, buses_o[0]] += slack_adjustment
+        n.c.buses.dynamic.p.loc[sns, buses_o[0]] += slack_adjustment
 
         # let slack generator take up the slack
         if self.slack_generator is not None:

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -758,8 +758,8 @@ class Network(
         if len(snapshots_) > 0:
             n.set_snapshots(snapshots_)
             # Apply time-varying data
-            for component in self.iterate_components():
-                dynamic = getattr(n, component.list_name + "_t")
+            for component in self.components:
+                dynamic = getattr(n.c, component.list_name).dynamic
                 for k in component.dynamic:
                     # Check if all snapshots_ are in the index
                     if set(snapshots_).issubset(component.dynamic[k].index):
@@ -1063,7 +1063,7 @@ class Network(
             self.c.sub_networks.static.drop(
                 self.c.sub_networks.static.index, inplace=True
             )
-            for dynamic in self.sub_networks_t.values():
+            for dynamic in self.c.sub_networks.dynamic.values():
                 dynamic.drop(dynamic.columns, inplace=True)
 
         if self.has_scenarios:

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -176,34 +176,38 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
         """
         n = self._n
 
-        n.lines["carrier"] = n.lines.bus0.map(n.buses.carrier)
+        n.c.lines.static["carrier"] = n.c.lines.static.bus0.map(
+            n.c.buses.static.carrier
+        )
         ext_i = n.c.lines.extendables.difference(n.c.lines.inactive_assets)
-        typed_i = n.lines.query('type != ""').index
+        typed_i = n.c.lines.static.query('type != ""').index
         ext_untyped_i = ext_i.difference(typed_i)
         ext_typed_i = ext_i.intersection(typed_i)
         base_s_nom = (
             np.sqrt(3)
-            * n.lines["type"].map(n.line_types.i_nom)
-            * n.lines.bus0.map(n.buses.v_nom)
+            * n.c.lines.static["type"].map(n.c.line_types.static.i_nom)
+            * n.c.lines.static.bus0.map(n.c.buses.static.v_nom)
         )
-        n.lines.loc[ext_typed_i, "num_parallel"] = (n.lines.s_nom / base_s_nom)[
-            ext_typed_i
-        ]
+        n.c.lines.static.loc[ext_typed_i, "num_parallel"] = (
+            n.c.lines.static.s_nom / base_s_nom
+        )[ext_typed_i]
 
         def update_line_params(n: Network, s_nom_prev: float | pd.Series) -> None:
-            factor = n.lines.s_nom_opt / s_nom_prev
+            factor = n.c.lines.static.s_nom_opt / s_nom_prev
             for attr, carrier in (("x", "AC"), ("r", "DC")):  # noqa: B007
-                ln_i = n.lines.query("carrier == @carrier").index.intersection(
+                ln_i = n.c.lines.static.query("carrier == @carrier").index.intersection(
                     ext_untyped_i
                 )
-                n.lines.loc[ln_i, attr] /= factor[ln_i]
+                n.c.lines.static.loc[ln_i, attr] /= factor[ln_i]
             ln_i = ext_i.intersection(typed_i)
-            n.lines.loc[ln_i, "num_parallel"] = (n.lines.s_nom_opt / base_s_nom)[ln_i]
+            n.c.lines.static.loc[ln_i, "num_parallel"] = (
+                n.c.lines.static.s_nom_opt / base_s_nom
+            )[ln_i]
 
         def msq_diff(n: Network, s_nom_prev: float | pd.Series) -> float:
             lines_err = (
-                np.sqrt((s_nom_prev - n.lines.s_nom_opt).pow(2).mean())
-                / n.lines["s_nom_opt"].mean()
+                np.sqrt((s_nom_prev - n.c.lines.static.s_nom_opt).pow(2).mean())
+                / n.c.lines.static["s_nom_opt"].mean()
             )
             logger.info(
                 "Mean square difference after iteration %s is %s",
@@ -218,7 +222,7 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
             setattr(n, f"status_{iteration}", status)
             setattr(n, f"objective_{iteration}", n.objective)
             n.iteration = iteration
-            n.global_constraints = n.global_constraints.rename(
+            n.c.global_constraints.static = n.c.global_constraints.static.rename(
                 columns={"mu": f"mu_{iteration}"}
             )
 
@@ -236,7 +240,7 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
             link_threshold = link_threshold or {}
 
             if line_unit_size:
-                n.lines["s_nom"] = n.lines.apply(
+                n.c.lines.static["s_nom"] = n.c.lines.static.apply(
                     lambda row: discretized_capacity(
                         nom_opt=row["s_nom_opt"],
                         nom_max=row["s_nom_max"],
@@ -248,9 +252,13 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
                 )
 
             if link_unit_size:
-                for carrier in link_unit_size.keys() & n.links.carrier.unique():
-                    idx = n.links.carrier == carrier
-                    n.links.loc[idx, "p_nom"] = n.links.loc[idx].apply(
+                for carrier in (
+                    link_unit_size.keys() & n.c.links.static.carrier.unique()
+                ):
+                    idx = n.c.links.static.carrier == carrier
+                    n.c.links.static.loc[idx, "p_nom"] = n.c.links.static.loc[
+                        idx
+                    ].apply(
                         lambda row: discretized_capacity(
                             nom_opt=row["p_nom_opt"],
                             nom_max=row["p_nom_max"],
@@ -279,7 +287,11 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
                 )
                 break
 
-            s_nom_prev = n.lines.s_nom_opt.copy() if iteration else n.lines.s_nom.copy()
+            s_nom_prev = (
+                n.c.lines.static.s_nom_opt.copy()
+                if iteration
+                else n.c.lines.static.s_nom.copy()
+            )
             status, termination_condition = n.optimize(snapshots, **kwargs)
             if status != "ok":
                 msg = (
@@ -305,19 +317,20 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
         )
 
         link_carriers = {"DC"} if not link_unit_size else link_unit_size.keys() | {"DC"}
-        ext_links_to_fix_b = n.links.p_nom_extendable & n.links.carrier.isin(
-            link_carriers
+        ext_links_to_fix_b = (
+            n.c.links.static.p_nom_extendable
+            & n.c.links.static.carrier.isin(link_carriers)
         )
-        s_nom_orig = n.lines.s_nom.copy()
-        p_nom_orig = n.links.p_nom.copy()
+        s_nom_orig = n.c.lines.static.s_nom.copy()
+        p_nom_orig = n.c.links.static.p_nom.copy()
 
-        n.lines.loc[ext_i, "s_nom"] = n.lines.loc[ext_i, "s_nom_opt"]
-        n.lines.loc[ext_i, "s_nom_extendable"] = False
+        n.c.lines.static.loc[ext_i, "s_nom"] = n.c.lines.static.loc[ext_i, "s_nom_opt"]
+        n.c.lines.static.loc[ext_i, "s_nom_extendable"] = False
 
-        n.links.loc[ext_links_to_fix_b, "p_nom"] = n.links.loc[
+        n.c.links.static.loc[ext_links_to_fix_b, "p_nom"] = n.c.links.static.loc[
             ext_links_to_fix_b, "p_nom_opt"
         ]
-        n.links.loc[ext_links_to_fix_b, "p_nom_extendable"] = False
+        n.c.links.static.loc[ext_links_to_fix_b, "p_nom_extendable"] = False
 
         discretize_branch_components(
             n,
@@ -331,19 +344,23 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
         n.calculate_dependent_values()
         status, condition = n.optimize(snapshots, **kwargs)
 
-        n.lines.loc[ext_i, "s_nom"] = s_nom_orig.loc[ext_i]
-        n.lines.loc[ext_i, "s_nom_extendable"] = True
+        n.c.lines.static.loc[ext_i, "s_nom"] = s_nom_orig.loc[ext_i]
+        n.c.lines.static.loc[ext_i, "s_nom_extendable"] = True
 
-        n.links.loc[ext_links_to_fix_b, "p_nom"] = p_nom_orig.loc[ext_links_to_fix_b]
-        n.links.loc[ext_links_to_fix_b, "p_nom_extendable"] = True
+        n.c.links.static.loc[ext_links_to_fix_b, "p_nom"] = p_nom_orig.loc[
+            ext_links_to_fix_b
+        ]
+        n.c.links.static.loc[ext_links_to_fix_b, "p_nom_extendable"] = True
 
         ## add costs of additional infrastructure to objective value of last iteration
         obj_links = (
-            n.links[ext_links_to_fix_b]
+            n.c.links.static[ext_links_to_fix_b]
             .eval("capital_cost * (p_nom_opt - p_nom_min)")
             .sum()
         )
-        obj_lines = n.lines.eval("capital_cost * (s_nom_opt - s_nom_min)").sum()
+        obj_lines = n.c.lines.static.eval(
+            "capital_cost * (s_nom_opt - s_nom_min)"
+        ).sum()
         n._objective += obj_links + obj_lines
         n._objective_constant -= obj_links + obj_lines
 
@@ -411,7 +428,7 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
             **model_kwargs,
         )
 
-        for sub_network in n.sub_networks.obj:
+        for sub_network in n.c.sub_networks.static.obj:
             branches_i = sub_network.branches_i()
             outages = branches_i.intersection(branch_outages)
 
@@ -503,10 +520,10 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
             )
 
             if i:
-                if not n.stores.empty:
-                    n.stores.e_initial = n.stores_t.e.loc[snapshots[start - 1]]
-                if not n.storage_units.empty:
-                    n.storage_units.state_of_charge_initial = (
+                if not n.c.stores.static.empty:
+                    n.c.stores.static.e_initial = n.stores_t.e.loc[snapshots[start - 1]]
+                if not n.c.storage_units.static.empty:
+                    n.c.storage_units.static.state_of_charge_initial = (
                         n.storage_units_t.state_of_charge.loc[snapshots[start - 1]]
                     )
 
@@ -580,15 +597,15 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
         for c in ("Link",):
             n.dynamic(c)["p_set"] = n.dynamic(c)["p0"]
 
-        n.generators.control = "PV"
-        for sub_network in n.sub_networks.obj:
-            n.generators.loc[sub_network.slack_generator, "control"] = "Slack"
+        n.c.generators.static.control = "PV"
+        for sub_network in n.c.sub_networks.static.obj:
+            n.c.generators.static.loc[sub_network.slack_generator, "control"] = "Slack"
         # Need some PQ buses so that Jacobian doesn't break
-        for sub_network in n.sub_networks.obj:
+        for sub_network in n.c.sub_networks.static.obj:
             generators = sub_network.generators_i()
             other_generators = generators.difference([sub_network.slack_generator])
             if not other_generators.empty:
-                n.generators.loc[other_generators[0], "control"] = "PQ"
+                n.c.generators.static.loc[other_generators[0], "control"] = "PQ"
 
         # Step 2: Perform non-linear power flow for all snapshots
         logger.info("Running non-linear power flow iteratively...")

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -521,10 +521,14 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
 
             if i:
                 if not n.c.stores.static.empty:
-                    n.c.stores.static.e_initial = n.stores_t.e.loc[snapshots[start - 1]]
+                    n.c.stores.static.e_initial = n.c.stores.dynamic.e.loc[
+                        snapshots[start - 1]
+                    ]
                 if not n.c.storage_units.static.empty:
                     n.c.storage_units.static.state_of_charge_initial = (
-                        n.storage_units_t.state_of_charge.loc[snapshots[start - 1]]
+                        n.c.storage_units.dynamic.state_of_charge.loc[
+                            snapshots[start - 1]
+                        ]
                     )
 
             status, condition = n.optimize(sns, **kwargs)

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -865,7 +865,7 @@ def define_nodal_balance_constraints(
     """
     m = n.model
     if buses is None:
-        buses = n.buses.index.unique("name")
+        buses = n.c.buses.static.index.unique("name")
 
     links = as_components(n, "Link")
 

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -408,7 +408,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
         if groupby is None:
             groupby = ["carrier", "bus_carrier"]
         if (
-            self._n.buses.carrier.unique().size > 1
+            self._n.c.buses.static.carrier.unique().size > 1
             and groupby is None
             and bus_carrier is None
         ):

--- a/pypsa/optimization/mga.py
+++ b/pypsa/optimization/mga.py
@@ -327,7 +327,9 @@ class OptimizationAbstractMGAMixin:
             snapshots = n.snapshots
 
         if weights is None:
-            weights = {"Generator": {"p_nom": pd.Series(1, index=n.generators.index)}}
+            weights = {
+                "Generator": {"p_nom": pd.Series(1, index=n.c.generators.static.index)}
+            }
 
         # check that network has been solved
         if not self._n.is_solved:

--- a/pypsa/plot/maps/common.py
+++ b/pypsa/plot/maps/common.py
@@ -108,6 +108,6 @@ def apply_layouter(
     coordinates = pd.DataFrame(layouter(G)).T.rename({0: "x", 1: "y"}, axis=1)
 
     if inplace:
-        n.buses[["x", "y"]] = coordinates
+        n.c.buses.static[["x", "y"]] = coordinates
         return None
     return coordinates.x, coordinates.y

--- a/pypsa/plot/maps/interactive.py
+++ b/pypsa/plot/maps/interactive.py
@@ -542,7 +542,7 @@ def explore(
 
     if not n.c.loads.static.empty and "Load" in components:
         loads = n.c.loads.static.copy()
-        loads["p_set_sum"] = n.c.c.loads.dynamic.p_set.sum(axis=0).round(1)
+        loads["p_set_sum"] = n.c.loads.dynamic.p_set.sum(axis=0).round(1)
         gdf_loads = gpd.GeoDataFrame(
             loads,
             geometry=gpd.points_from_xy(

--- a/pypsa/plot/maps/interactive.py
+++ b/pypsa/plot/maps/interactive.py
@@ -542,7 +542,7 @@ def explore(
 
     if not n.c.loads.static.empty and "Load" in components:
         loads = n.c.loads.static.copy()
-        loads["p_set_sum"] = n.c.loads_t.p_set.sum(axis=0).round(1)
+        loads["p_set_sum"] = n.c.c.loads.dynamic.p_set.sum(axis=0).round(1)
         gdf_loads = gpd.GeoDataFrame(
             loads,
             geometry=gpd.points_from_xy(

--- a/pypsa/plot/statistics/base.py
+++ b/pypsa/plot/statistics/base.py
@@ -44,7 +44,7 @@ class PlotsGenerator(ABC):
 
     def get_unique_carriers(self) -> pd.DataFrame:
         """Get unique carriers from the network."""
-        carriers = self._n.carriers
+        carriers = self._n.c.carriers.static
         if isinstance(carriers.index, pd.MultiIndex):
             for level in carriers.index.names:
                 if level != "name":

--- a/pypsa/plot/statistics/maps.py
+++ b/pypsa/plot/statistics/maps.py
@@ -96,7 +96,7 @@ class MapPlotGenerator(PlotsGenerator, MapPlotter):
         trans_carriers = get_transmission_carriers(n, bus_carrier=bus_carrier).unique(
             "carrier"
         )
-        non_transmission_carriers = n.carriers.index.difference(trans_carriers)
+        non_transmission_carriers = n.c.carriers.static.index.difference(trans_carriers)
 
         # Get bus sizes from statistics function
         bus_sizes = func(

--- a/pypsa/statistics/abstract.py
+++ b/pypsa/statistics/abstract.py
@@ -249,9 +249,9 @@ class AbstractStatisticsAccessor(ABC):
 
         idx = self._get_component_index(obj, c)
         ports = n.static(c).loc[idx, f"bus{port}"]
-        port_carriers = ports.map(n.buses.carrier)
+        port_carriers = ports.map(n.c.buses.static.carrier)
         if isinstance(bus_carrier, str):
-            if bus_carrier in n.buses.carrier.unique():
+            if bus_carrier in n.c.buses.static.carrier.unique():
                 mask = port_carriers == bus_carrier
             else:
                 mask = port_carriers.str.contains(bus_carrier, regex=True)

--- a/pypsa/statistics/grouping.py
+++ b/pypsa/statistics/grouping.py
@@ -266,7 +266,7 @@ class Groupers:
         carrier_series = static.get("carrier", fall_back).rename("carrier")
         if nice_names:
             carrier_series = carrier_series.replace(
-                n.carriers.nice_name[lambda ds: ds != ""]
+                n.c.carriers.static.nice_name[lambda ds: ds != ""]
             ).replace("", "-")
         return carrier_series
 
@@ -341,7 +341,7 @@ class Groupers:
         """
         bus = f"bus{port}"
         component_buses = n.static(c)[bus]
-        buses_country = n.buses.country
+        buses_country = n.c.buses.static.country
         return self._map_with_multiindex(component_buses, buses_country).rename(
             "country"
         )
@@ -366,7 +366,7 @@ class Groupers:
         """
         bus = f"bus{port}"
         component_buses = n.static(c)[bus]
-        buses_location = n.buses.location
+        buses_location = n.c.buses.static.location
         return self._map_with_multiindex(component_buses, buses_location).rename(
             "location"
         )
@@ -391,7 +391,7 @@ class Groupers:
         """
         bus = f"bus{port}"
         component_buses = n.static(c)[bus]
-        buses_unit = n.buses.unit
+        buses_unit = n.c.buses.static.unit
         return self._map_with_multiindex(component_buses, buses_unit).rename("unit")
 
     def name(self, n: Network, c: str) -> pd.Series:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -81,7 +81,7 @@ def ac_dc_periods(ac_dc_network):
     n.investment_periods = [2013]
     gens_i = n.c.generators.static.index
     rng = np.random.default_rng()  # Create a random number generator
-    n.generators_t.p[gens_i] = rng.random(size=(len(n.snapshots), len(gens_i)))
+    n.c.generators.dynamic.p[gens_i] = rng.random(size=(len(n.snapshots), len(gens_i)))
     return n
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,6 +11,23 @@ from pypsa.constants import DEFAULT_EPSG
 
 pypsa.options.debug.runtime_verification = True
 
+
+def pytest_addoption(parser):
+    """Add custom pytest command line options."""
+    parser.addoption(
+        "--new-components-api",
+        action="store_true",
+        default=False,
+        help="Activate the new components API (options.api.new_components_api)",
+    )
+
+
+def pytest_configure(config):
+    """Configure pytest session with custom options."""
+    if config.getoption("--new-components-api"):
+        pypsa.options.api.new_components_api = True
+
+
 COMPONENT_NAMES = [
     "sub_networks",
     "buses",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -79,7 +79,7 @@ def ac_dc_periods(ac_dc_network):
     n = ac_dc_network
     n.snapshots = pd.MultiIndex.from_product([[2013], n.snapshots])
     n.investment_periods = [2013]
-    gens_i = n.generators.index
+    gens_i = n.c.generators.static.index
     rng = np.random.default_rng()  # Create a random number generator
     n.generators_t.p[gens_i] = rng.random(size=(len(n.snapshots), len(gens_i)))
     return n
@@ -136,7 +136,7 @@ def ac_dc_shapes(ac_dc_network):
             ]
         )
 
-    bboxes = n.buses.apply(lambda row: create_bbox(row["x"], row["y"]), axis=1)
+    bboxes = n.c.buses.static.apply(lambda row: create_bbox(row["x"], row["y"]), axis=1)
 
     # Convert to GeoSeries
     geo_series = gpd.GeoSeries(bboxes, crs=DEFAULT_EPSG)
@@ -158,9 +158,9 @@ def ac_dc_shapes(ac_dc_network):
 @pytest.fixture
 def scipy_network():
     n = pypsa.examples.scigrid_de()
-    n.generators.control = "PV"
-    g = n.generators[n.generators.bus == "492"]
-    n.generators.loc[g.index, "control"] = "PQ"
+    n.c.generators.static.control = "PV"
+    g = n.c.generators.static[n.c.generators.static.bus == "492"]
+    n.c.generators.static.loc[g.index, "control"] = "PQ"
     n.calculate_dependent_values()
     n.determine_network_topology()
     return n

--- a/test/test_bugs.py
+++ b/test/test_bugs.py
@@ -19,7 +19,7 @@ def test_1144():
     See https://github.com/PyPSA/PyPSA/issues/1144.
     """
     n = pypsa.examples.ac_dc_meshed()
-    n.generators["build_year"] = [2020, 2020, 2030, 2030, 2040, 2040]
+    n.c.generators.static["build_year"] = [2020, 2020, 2030, 2030, 2040, 2040]
     n.investment_periods = [2020, 2030, 2040]
     capacity = n.statistics.installed_capacity(comps="Generator")
     assert capacity[2020].sum() < capacity[2030].sum() < capacity[2040].sum()
@@ -32,14 +32,18 @@ def test_890():
     n = pypsa.examples.scigrid_de()
     n.calculate_dependent_values()
 
-    n.lines = n.lines.reindex(columns=n.components["Line"]["attrs"].index[1:])
-    n.lines["type"] = np.nan
-    n.buses = n.buses.reindex(columns=n.components["Bus"]["attrs"].index[1:])
-    n.buses["frequency"] = 50
+    n.c.lines.static = n.c.lines.static.reindex(
+        columns=n.components["Line"]["attrs"].index[1:]
+    )
+    n.c.lines.static["type"] = np.nan
+    n.c.buses.static = n.c.buses.static.reindex(
+        columns=n.components["Bus"]["attrs"].index[1:]
+    )
+    n.c.buses.static["frequency"] = 50
 
     n.set_investment_periods([2020, 2030])
 
-    weighting = pd.Series(1, n.buses.index)
+    weighting = pd.Series(1, n.c.buses.static.index)
     busmap = n.cluster.busmap_by_kmeans(bus_weightings=weighting, n_clusters=50)
     nc = n.cluster.cluster_by_busmap(busmap)
 
@@ -129,7 +133,7 @@ def test_multiport_assignment_defaults_single_add():
     n.add("Bus", "bus2")
     n.add("Link", "link", bus0="bus", bus1="bus2")
     n.add("Link", "link2", bus0="bus", bus1="bus2", bus2="bus")
-    assert n.links.loc["link", "bus2"] == ""
+    assert n.c.links.static.loc["link", "bus2"] == ""
 
 
 def test_multiport_assignment_defaults_multiple_add():
@@ -144,7 +148,7 @@ def test_multiport_assignment_defaults_multiple_add():
     n.add("Bus", "bus2")
     n.add("Link", ["link"], bus0="bus", bus1="bus2")
     n.add("Link", ["link2"], bus0="bus", bus1="bus2", bus2="bus")
-    assert n.links.loc["link", "bus2"] == ""
+    assert n.c.links.static.loc["link", "bus2"] == ""
 
 
 @pytest.mark.skipif(not excel_installed, reason="openpyxl not installed")
@@ -161,7 +165,7 @@ def test_1268(tmpdir):
 
     n = pypsa.Network()
     n.import_from_excel(fn)
-    assert len(n.buses) == 1
+    assert len(n.c.buses.static) == 1
 
 
 def test_1319():
@@ -182,4 +186,4 @@ def test_1319():
     n.model.solver_model = None
     n_copy = n.copy()  # Should not raise an error
     assert n_copy is not n
-    assert len(n_copy.buses) == len(n.buses)
+    assert len(n_copy.buses) == len(n.c.buses.static)

--- a/test/test_bugs.py
+++ b/test/test_bugs.py
@@ -65,7 +65,7 @@ def test_331():
     n.optimize()
     n.add("Generator", "generator2", bus="bus", p_nom=5, marginal_cost=5)
     n.optimize()
-    assert "generator2" in n.generators_t.p
+    assert "generator2" in n.c.generators.dynamic.p
 
 
 def test_nomansland_bus(caplog):

--- a/test/test_collection_statistics.py
+++ b/test/test_collection_statistics.py
@@ -156,7 +156,7 @@ def test_network_collection_carrier_bus_carrier_grouper(
 def test_network_collection_country_grouper(simple_network):
     """Test country grouper with NetworkCollection."""
     # Add country information to buses
-    simple_network.buses["country"] = ["DE", "DE", "FR"]
+    simple_network.c.buses.static["country"] = ["DE", "DE", "FR"]
 
     nc = pypsa.NetworkCollection(
         [simple_network, simple_network.copy()],
@@ -176,7 +176,7 @@ def test_network_collection_country_grouper(simple_network):
 def test_network_collection_location_grouper(simple_network):
     """Test location grouper with NetworkCollection."""
     # Add location information to buses
-    simple_network.buses["location"] = ["Berlin", "Munich", "Paris"]
+    simple_network.c.buses.static["location"] = ["Berlin", "Munich", "Paris"]
 
     nc = pypsa.NetworkCollection(
         [simple_network, simple_network.copy()],
@@ -200,7 +200,7 @@ def test_network_collection_location_grouper(simple_network):
 def test_network_collection_unit_grouper(simple_network):
     """Test unit grouper with NetworkCollection."""
     # Add unit information to buses
-    simple_network.buses["unit"] = ["MW", "MW", "MVA"]
+    simple_network.c.buses.static["unit"] = ["MW", "MW", "MVA"]
 
     nc = pypsa.NetworkCollection(
         [simple_network, simple_network.copy()],

--- a/test/test_components_array.py
+++ b/test/test_components_array.py
@@ -13,10 +13,10 @@ def test_as_xarray_static(ac_dc_network):
 
     # Check coords
     assert list(da.coords) == ["name"]
-    assert np.array_equal(da.coords["name"], n.generators.index)
+    assert np.array_equal(da.coords["name"], n.c.generators.static.index)
 
     # Check data
-    assert np.array_equal(da.values, n.generators["bus"].values)
+    assert np.array_equal(da.values, n.c.generators.static["bus"].values)
 
 
 def test_as_xarray_dynamic(ac_dc_network):
@@ -28,13 +28,16 @@ def test_as_xarray_dynamic(ac_dc_network):
     # Check coords
     assert list(da.coords) == ["snapshot", "name"]
     assert np.array_equal(da.snapshot, n.snapshots)
-    assert np.array_equal(da.coords["name"], n.generators.index)
+    assert np.array_equal(da.coords["name"], n.c.generators.static.index)
 
     # Check data
-    non_dynamic_index = n.generators.index.difference(n.generators_t.p_max_pu.columns)
+    non_dynamic_index = n.c.generators.static.index.difference(
+        n.generators_t.p_max_pu.columns
+    )
     assert np.array_equal(
         da.sel(name=non_dynamic_index),
-        np.ones((10, 3)) * n.generators.loc[non_dynamic_index, "p_max_pu"].values,
+        np.ones((10, 3))
+        * n.c.generators.static.loc[non_dynamic_index, "p_max_pu"].values,
     )
     assert np.array_equal(
         da.sel(name=n.generators_t["p_max_pu"].columns),
@@ -57,10 +60,10 @@ def test_as_xarray_static_with_periods(ac_dc_network):
 
     # Check coords
     assert list(da.coords) == ["name"]
-    assert np.array_equal(da.coords["name"], n.generators.index)
+    assert np.array_equal(da.coords["name"], n.c.generators.static.index)
 
     # Check data
-    assert np.array_equal(da.values, n.generators["bus"].values)
+    assert np.array_equal(da.values, n.c.generators.static["bus"].values)
 
 
 def test_as_xarray_dynamic_with_periods(ac_dc_network):
@@ -77,13 +80,16 @@ def test_as_xarray_dynamic_with_periods(ac_dc_network):
     assert np.array_equal(da.snapshot, n.snapshots)
     assert np.array_equal(da.period.to_index().unique(), n.periods)
     assert np.array_equal(da.timestep.to_index().unique(), n.timesteps)
-    assert np.array_equal(da.coords["name"], n.generators.index)
+    assert np.array_equal(da.coords["name"], n.c.generators.static.index)
 
     # Check data
-    non_dynamic_index = n.generators.index.difference(n.generators_t.p_max_pu.columns)
+    non_dynamic_index = n.c.generators.static.index.difference(
+        n.generators_t.p_max_pu.columns
+    )
     assert np.array_equal(
         da.sel(name=non_dynamic_index),
-        np.ones((20, 3)) * n.generators.loc[non_dynamic_index, "p_max_pu"].values,
+        np.ones((20, 3))
+        * n.c.generators.static.loc[non_dynamic_index, "p_max_pu"].values,
     )
     assert np.array_equal(
         da.sel(name=n.generators_t["p_max_pu"].columns),
@@ -103,12 +109,12 @@ def test_as_xarray_static_with_scenarios(ac_dc_network):
     # Check coords
     assert list(da.coords) == ["scenario", "name"]
     assert np.array_equal(
-        da.coords["name"], n.generators.index.get_level_values("name").unique()
+        da.coords["name"], n.c.generators.static.index.get_level_values("name").unique()
     )
     assert np.array_equal(da.scenario, scenarios)
 
     # Check data
-    assert np.array_equal(da.values.flatten(), n.generators["bus"].values)
+    assert np.array_equal(da.values.flatten(), n.c.generators.static["bus"].values)
 
 
 def test_as_xarray_dynamic_with_scenarios(ac_dc_network):
@@ -124,12 +130,12 @@ def test_as_xarray_dynamic_with_scenarios(ac_dc_network):
     # Check coords
     assert np.array_equal(da.snapshot, n.snapshots)
     # assert np.array_equal(
-    #     da.coords["name"], n.generators.index.get_level_values("component").unique()
+    #     da.coords["name"], n.c.generators.static.index.get_level_values("component").unique()
     # ) # TODO sorting
     assert np.array_equal(da.scenario, scenarios)
 
     # Check data
-    # non_dynamic_index = n.generators.index.difference(n.generators_t.p_max_pu.columns)
+    # non_dynamic_index = n.c.generators.static.index.difference(n.generators_t.p_max_pu.columns)
     assert np.array_equal(
         da.sel(
             scenario=scenarios[0],

--- a/test/test_components_array.py
+++ b/test/test_components_array.py
@@ -32,7 +32,7 @@ def test_as_xarray_dynamic(ac_dc_network):
 
     # Check data
     non_dynamic_index = n.c.generators.static.index.difference(
-        n.generators_t.p_max_pu.columns
+        n.c.generators.dynamic.p_max_pu.columns
     )
     assert np.array_equal(
         da.sel(name=non_dynamic_index),
@@ -40,8 +40,8 @@ def test_as_xarray_dynamic(ac_dc_network):
         * n.c.generators.static.loc[non_dynamic_index, "p_max_pu"].values,
     )
     assert np.array_equal(
-        da.sel(name=n.generators_t["p_max_pu"].columns),
-        n.generators_t["p_max_pu"].values,
+        da.sel(name=n.c.generators.dynamic["p_max_pu"].columns),
+        n.c.generators.dynamic["p_max_pu"].values,
     )
 
 
@@ -84,7 +84,7 @@ def test_as_xarray_dynamic_with_periods(ac_dc_network):
 
     # Check data
     non_dynamic_index = n.c.generators.static.index.difference(
-        n.generators_t.p_max_pu.columns
+        n.c.generators.dynamic.p_max_pu.columns
     )
     assert np.array_equal(
         da.sel(name=non_dynamic_index),
@@ -92,8 +92,8 @@ def test_as_xarray_dynamic_with_periods(ac_dc_network):
         * n.c.generators.static.loc[non_dynamic_index, "p_max_pu"].values,
     )
     assert np.array_equal(
-        da.sel(name=n.generators_t["p_max_pu"].columns),
-        n.generators_t["p_max_pu"].values,
+        da.sel(name=n.c.generators.dynamic["p_max_pu"].columns),
+        n.c.generators.dynamic["p_max_pu"].values,
     )
 
 
@@ -135,13 +135,13 @@ def test_as_xarray_dynamic_with_scenarios(ac_dc_network):
     assert np.array_equal(da.scenario, scenarios)
 
     # Check data
-    # non_dynamic_index = n.c.generators.static.index.difference(n.generators_t.p_max_pu.columns)
+    # non_dynamic_index = n.c.generators.static.index.difference(n.c.generators.dynamic.p_max_pu.columns)
     assert np.array_equal(
         da.sel(
             scenario=scenarios[0],
-            name=n.generators_t.p_max_pu.columns.get_level_values(1).unique(),
+            name=n.c.generators.dynamic.p_max_pu.columns.get_level_values(1).unique(),
         ).values,
-        n.generators_t.p_max_pu[scenarios[0]].values,
+        n.c.generators.dynamic.p_max_pu[scenarios[0]].values,
     )
 
     # TODO add test for non_dynamic_index

--- a/test/test_descriptors.py
+++ b/test/test_descriptors.py
@@ -107,7 +107,7 @@ def test_additional_linkports():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-        ports = _additional_linkports(n, n.links.columns)
+        ports = _additional_linkports(n, n.c.links.static.columns)
     assert ports == ["2"]
     assert ports == n.c.links.additional_ports
 

--- a/test/test_descriptors.py
+++ b/test/test_descriptors.py
@@ -56,10 +56,10 @@ def test_allocate_series_dataframes(network):
 
     allocate_series_dataframes(n, {"Generator": ["p"], "Load": ["p"]})
 
-    assert "p" in n.generators_t
-    assert "p" in n.loads_t
-    assert n.generators_t.p.shape == (len(n.snapshots), 1)
-    assert n.loads_t.p.shape == (len(n.snapshots), 1)
+    assert "p" in n.c.generators.dynamic
+    assert "p" in n.c.loads.dynamic
+    assert n.c.generators.dynamic.p.shape == (len(n.snapshots), 1)
+    assert n.c.loads.dynamic.p.shape == (len(n.snapshots), 1)
 
 
 def test_get_extendable_i(network):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -3,27 +3,27 @@ import pypsa
 
 def test_ac_dc_meshed():
     n = pypsa.examples.ac_dc_meshed()
-    assert not n.buses.empty
+    assert not n.c.buses.static.empty
 
 
 def test_storage_hvdc():
     n = pypsa.examples.storage_hvdc()
-    assert not n.buses.empty
+    assert not n.c.buses.static.empty
 
 
 def test_scigrid_de():
     n = pypsa.examples.scigrid_de()
-    assert not n.buses.empty
+    assert not n.c.buses.static.empty
 
 
 def test_model_energy():
     n = pypsa.examples.model_energy()
-    assert not n.buses.empty
+    assert not n.c.buses.static.empty
 
 
 def test_carbon_management():
     n = pypsa.examples.carbon_management()
-    assert not n.buses.empty
+    assert not n.c.buses.static.empty
 
 
 def test_check_url_availability():

--- a/test/test_indices.py
+++ b/test/test_indices.py
@@ -53,10 +53,10 @@ def test_existing_value_casting(request, network_fixture):
     assert not isinstance(base_network.snapshots, pd.MultiIndex)
     snapshots = base_network.snapshots
     if isinstance(n.snapshots, pd.MultiIndex):
-        vals = n.generators_t.p_max_pu.xs(2015).loc[snapshots, :]
+        vals = n.c.generators.dynamic.p_max_pu.xs(2015).loc[snapshots, :]
     else:
-        vals = n.generators_t.p_max_pu.loc[snapshots, :]
-    assert vals.equals(base_network.generators_t.p_max_pu)
+        vals = n.c.generators.dynamic.p_max_pu.loc[snapshots, :]
+    assert vals.equals(base_network.c.generators.dynamic.p_max_pu)
 
 
 # @pytest.mark.parametrize("meta", [{"test": "test"}, {"test": {"test": "test"}}])

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -100,8 +100,8 @@ class TestCSVDir:
         ac_dc_periods.export_to_csv_folder(fn)
         m = pypsa.Network(fn)
         pd.testing.assert_frame_equal(
-            m.generators_t.p,
-            ac_dc_periods.generators_t.p,
+            m.c.generators.dynamic.p,
+            ac_dc_periods.c.generators.dynamic.p,
         )
 
     def test_csv_io_shapes(self, ac_dc_shapes, tmpdir):
@@ -194,8 +194,8 @@ class TestNetcdf:
         ac_dc_periods.export_to_netcdf(fn)
         m = pypsa.Network(fn)
         pd.testing.assert_frame_equal(
-            m.generators_t.p,
-            ac_dc_periods.generators_t.p,
+            m.c.generators.dynamic.p,
+            ac_dc_periods.c.generators.dynamic.p,
         )
         pd.testing.assert_frame_equal(
             m.snapshot_weightings,
@@ -235,7 +235,10 @@ class TestNetcdf:
         scipy_network.export_to_netcdf(fn, float32=False, compression=None)
         scipy_network_compressed = pypsa.Network(fn)
         assert (
-            (scipy_network.loads_t.p_set == scipy_network_compressed.loads_t.p_set)
+            (
+                scipy_network.c.loads.dynamic.p_set
+                == scipy_network_compressed.c.loads.dynamic.p_set
+            )
             .all()
             .all()
         )
@@ -249,7 +252,8 @@ class TestNetcdf:
         assert (
             (
                 (
-                    scipy_network.loads_t.p_set - scipy_network_compressed.loads_t.p_set
+                    scipy_network.c.loads.dynamic.p_set
+                    - scipy_network_compressed.c.loads.dynamic.p_set
                 ).abs()
                 < 1 / 10**digits
             )
@@ -320,8 +324,8 @@ class TestHDF5:
         ac_dc_periods.export_to_hdf5(fn)
         m = pypsa.Network(fn)
         pd.testing.assert_frame_equal(
-            m.generators_t.p,
-            ac_dc_periods.generators_t.p,
+            m.c.generators.dynamic.p,
+            ac_dc_periods.c.generators.dynamic.p,
         )
 
     def test_hdf5_io_shapes(self, ac_dc_shapes, tmpdir):
@@ -414,8 +418,8 @@ class TestExcelIO:
         ac_dc_periods.export_to_excel(fn)
         m = pypsa.Network(fn)
         pd.testing.assert_frame_equal(
-            m.generators_t.p,
-            ac_dc_periods.generators_t.p,
+            m.c.generators.dynamic.p,
+            ac_dc_periods.c.generators.dynamic.p,
         )
         pd.testing.assert_frame_equal(
             m.snapshot_weightings,
@@ -494,17 +498,24 @@ class TestExcelIO:
         fn = tmpdir / "network-time-eff.xlsx"
         n.export_to_excel(fn)
         m = pypsa.Network(fn)
-        assert not m.stores_t.standing_loss.empty
-        assert not m.storage_units_t.standing_loss.empty
-        assert not m.generators_t.efficiency.empty
-        assert not m.storage_units_t.efficiency_store.empty
-        assert not m.storage_units_t.efficiency_dispatch.empty
-        equal(m.stores_t.standing_loss, n.stores_t.standing_loss)
-        equal(m.storage_units_t.standing_loss, n.storage_units_t.standing_loss)
-        equal(m.generators_t.efficiency, n.generators_t.efficiency)
-        equal(m.storage_units_t.efficiency_store, n.storage_units_t.efficiency_store)
+        assert not m.c.stores.dynamic.standing_loss.empty
+        assert not m.c.storage_units.dynamic.standing_loss.empty
+        assert not m.c.generators.dynamic.efficiency.empty
+        assert not m.c.storage_units.dynamic.efficiency_store.empty
+        assert not m.c.storage_units.dynamic.efficiency_dispatch.empty
+        equal(m.c.stores.dynamic.standing_loss, n.c.stores.dynamic.standing_loss)
         equal(
-            m.storage_units_t.efficiency_dispatch, n.storage_units_t.efficiency_dispatch
+            m.c.storage_units.dynamic.standing_loss,
+            n.c.storage_units.dynamic.standing_loss,
+        )
+        equal(m.c.generators.dynamic.efficiency, n.c.generators.dynamic.efficiency)
+        equal(
+            m.c.storage_units.dynamic.efficiency_store,
+            n.c.storage_units.dynamic.efficiency_store,
+        )
+        equal(
+            m.c.storage_units.dynamic.efficiency_dispatch,
+            n.c.storage_units.dynamic.efficiency_dispatch,
         )
 
 
@@ -639,17 +650,25 @@ def test_io_time_dependent_efficiencies(tmpdir):
     n.export_to_netcdf(fn)
     m = pypsa.Network(fn)
 
-    assert not m.stores_t.standing_loss.empty
-    assert not m.storage_units_t.standing_loss.empty
-    assert not m.generators_t.efficiency.empty
-    assert not m.storage_units_t.efficiency_store.empty
-    assert not m.storage_units_t.efficiency_dispatch.empty
+    assert not m.c.stores.dynamic.standing_loss.empty
+    assert not m.c.storage_units.dynamic.standing_loss.empty
+    assert not m.c.generators.dynamic.efficiency.empty
+    assert not m.c.storage_units.dynamic.efficiency_store.empty
+    assert not m.c.storage_units.dynamic.efficiency_dispatch.empty
 
-    equal(m.stores_t.standing_loss, n.stores_t.standing_loss)
-    equal(m.storage_units_t.standing_loss, n.storage_units_t.standing_loss)
-    equal(m.generators_t.efficiency, n.generators_t.efficiency)
-    equal(m.storage_units_t.efficiency_store, n.storage_units_t.efficiency_store)
-    equal(m.storage_units_t.efficiency_dispatch, n.storage_units_t.efficiency_dispatch)
+    equal(m.c.stores.dynamic.standing_loss, n.c.stores.dynamic.standing_loss)
+    equal(
+        m.c.storage_units.dynamic.standing_loss, n.c.storage_units.dynamic.standing_loss
+    )
+    equal(m.c.generators.dynamic.efficiency, n.c.generators.dynamic.efficiency)
+    equal(
+        m.c.storage_units.dynamic.efficiency_store,
+        n.c.storage_units.dynamic.efficiency_store,
+    )
+    equal(
+        m.c.storage_units.dynamic.efficiency_dispatch,
+        n.c.storage_units.dynamic.efficiency_dispatch,
+    )
 
 
 def test_sort_attrs():

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -109,20 +109,20 @@ class TestCSVDir:
         ac_dc_shapes.export_to_csv_folder(fn)
         m = pypsa.Network(fn)
         assert_geodataframe_equal(
-            m.shapes,
-            ac_dc_shapes.shapes,
+            m.c.shapes.static,
+            ac_dc_shapes.c.shapes.static,
             check_less_precise=True,
         )
 
     def test_csv_io_shapes_with_missing(self, ac_dc_shapes, tmpdir):
         fn = tmpdir / "csv_export"
         n = ac_dc_shapes.copy()
-        n.shapes.loc["Manchester", "geometry"] = None
+        n.c.shapes.static.loc["Manchester", "geometry"] = None
         n.export_to_csv_folder(fn)
         m = pypsa.Network(fn)
         assert_geodataframe_equal(
-            m.shapes,
-            n.shapes,
+            m.c.shapes.static,
+            n.c.shapes.static,
             check_less_precise=True,
         )
 
@@ -209,20 +209,20 @@ class TestNetcdf:
         ac_dc_shapes.export_to_netcdf(fn)
         m = pypsa.Network(fn)
         assert_geodataframe_equal(
-            m.shapes,
-            ac_dc_shapes.shapes,
+            m.c.shapes.static,
+            ac_dc_shapes.c.shapes.static,
             check_less_precise=True,
         )
 
     def test_netcdf_io_shapes_with_missing(self, ac_dc_shapes, tmpdir):
         fn = tmpdir / "netcdf_export.nc"
         n = ac_dc_shapes.copy()
-        n.shapes.loc["Manchester", "geometry"] = None
+        n.c.shapes.static.loc["Manchester", "geometry"] = None
         n.export_to_netcdf(fn)
         m = pypsa.Network(fn)
         assert_geodataframe_equal(
-            m.shapes,
-            n.shapes,
+            m.c.shapes.static,
+            n.c.shapes.static,
             check_less_precise=True,
         )
 
@@ -329,20 +329,20 @@ class TestHDF5:
         ac_dc_shapes.export_to_hdf5(fn)
         m = pypsa.Network(fn)
         assert_geodataframe_equal(
-            m.shapes,
-            ac_dc_shapes.shapes,
+            m.c.shapes.static,
+            ac_dc_shapes.c.shapes.static,
             check_less_precise=True,
         )
 
     def test_hdf5_io_shapes_with_missing(self, ac_dc_shapes, tmpdir):
         fn = tmpdir / "hdf5_export.h5"
         n = ac_dc_shapes.copy()
-        n.shapes.loc["Manchester", "geometry"] = None
+        n.c.shapes.static.loc["Manchester", "geometry"] = None
         n.export_to_hdf5(fn)
         m = pypsa.Network(fn)
         assert_geodataframe_equal(
-            m.shapes,
-            n.shapes,
+            m.c.shapes.static,
+            n.c.shapes.static,
             check_less_precise=True,
         )
 
@@ -428,20 +428,20 @@ class TestExcelIO:
         ac_dc_shapes.export_to_excel(fn)
         m = pypsa.Network(fn)
         assert_geodataframe_equal(
-            m.shapes,
-            ac_dc_shapes.shapes,
+            m.c.shapes.static,
+            ac_dc_shapes.c.shapes.static,
             check_less_precise=True,
         )
 
     def test_excel_io_shapes_with_missing(self, ac_dc_shapes, tmpdir):
         fn = tmpdir / "excel_export.xlsx"
         n = ac_dc_shapes.copy()
-        n.shapes.loc["Manchester", "geometry"] = None
+        n.c.shapes.static.loc["Manchester", "geometry"] = None
         n.export_to_excel(fn)
         m = pypsa.Network(fn)
         assert_geodataframe_equal(
-            m.shapes,
-            n.shapes,
+            m.c.shapes.static,
+            n.c.shapes.static,
             check_less_precise=True,
         )
 
@@ -610,11 +610,13 @@ def test_import_from_pandapower_network(
             use_pandapower_index=use_pandapower_index,
             extra_line_data=extra_line_data,
         )
-        assert len(n.buses) == len(net.bus)
-        assert len(n.generators) == (len(net.gen) + len(net.sgen) + len(net.ext_grid))
+        assert len(n.c.buses.static) == len(net.bus)
+        assert len(n.c.generators.static) == (
+            len(net.gen) + len(net.sgen) + len(net.ext_grid)
+        )
         assert len(n.loads) == len(net.load)
-        assert len(n.transformers) == len(net.trafo)
-        assert len(n.shunt_impedances) == len(net.shunt)
+        assert len(n.c.transformers.static) == len(net.trafo)
+        assert len(n.c.shunt_impedances.static) == len(net.shunt)
 
 
 def test_io_time_dependent_efficiencies(tmpdir):

--- a/test/test_link_post_discretization.py
+++ b/test/test_link_post_discretization.py
@@ -93,7 +93,7 @@ def test_post_discretization():
 
     n = build_network(unit_size=unit_size)
 
-    n.links["p_nom"] = n.links.apply(
+    n.c.links.static["p_nom"] = n.c.links.static.apply(
         lambda row: discretized_capacity(
             nom_opt=row["p_nom_opt"],
             nom_max=row["p_nom_max"],
@@ -106,21 +106,21 @@ def test_post_discretization():
 
     # p_nom_opt   | p_nom_max | p_nom     | unit_size
     # 5           | 10        | 10        | 10
-    assert n.links.loc["Link0"].p_nom == unit_size
+    assert n.c.links.static.loc["Link0"].p_nom == unit_size
     # 15          | 20        | 20        | 10
-    assert n.links.loc["Link1"].p_nom == 2 * unit_size
+    assert n.c.links.static.loc["Link1"].p_nom == 2 * unit_size
     # 5           | 8         | 8         | 10
-    assert n.links.loc["Link2"].p_nom == 0.8 * unit_size
+    assert n.c.links.static.loc["Link2"].p_nom == 0.8 * unit_size
     # 13          | 15        | 15        | 10
-    assert n.links.loc["Link3"].p_nom == 1.5 * unit_size
+    assert n.c.links.static.loc["Link3"].p_nom == 1.5 * unit_size
     # 11          | 15        | 5         | 10
-    assert n.links.loc["Link4"].p_nom == unit_size
+    assert n.c.links.static.loc["Link4"].p_nom == unit_size
     # 15          | inf       | 20        | 10
-    assert n.links.loc["Link5"].p_nom == 2 * unit_size
+    assert n.c.links.static.loc["Link5"].p_nom == 2 * unit_size
 
     n = build_network(unit_size=unit_size)
 
-    n.links["p_nom"] = n.links.apply(
+    n.c.links.static["p_nom"] = n.c.links.static.apply(
         lambda row: discretized_capacity(
             nom_opt=row["p_nom_opt"],
             nom_max=row["p_nom_max"],
@@ -133,14 +133,14 @@ def test_post_discretization():
 
     # p_nom_opt   | p_nom_max | p_nom     | unit_size
     # 5           | 10        | 10        | 10
-    assert n.links.loc["Link0"].p_nom == unit_size
+    assert n.c.links.static.loc["Link0"].p_nom == unit_size
     # 15          | 20        | 20        | 10
-    assert n.links.loc["Link1"].p_nom == 2 * unit_size
+    assert n.c.links.static.loc["Link1"].p_nom == 2 * unit_size
     # 5           | 8         | 0         | 10
-    assert n.links.loc["Link2"].p_nom == 8
+    assert n.c.links.static.loc["Link2"].p_nom == 8
     # 13          | 15        | 10        | 10
-    assert n.links.loc["Link3"].p_nom == unit_size
+    assert n.c.links.static.loc["Link3"].p_nom == unit_size
     # 11          | 15        | 10        | 10
-    assert n.links.loc["Link4"].p_nom == unit_size
+    assert n.c.links.static.loc["Link4"].p_nom == unit_size
     # 15          | inf       | 20        | 10
-    assert n.links.loc["Link5"].p_nom == 2 * unit_size
+    assert n.c.links.static.loc["Link5"].p_nom == 2 * unit_size

--- a/test/test_lopf_ac_dc.py
+++ b/test/test_lopf_ac_dc.py
@@ -10,19 +10,19 @@ def test_optimize(ac_dc_network, ac_dc_network_r):
     assert status == "ok"
 
     equal(
-        n.generators_t.p.loc[:, n.c.generators.static.index],
-        n_r.generators_t.p.loc[:, n.c.generators.static.index],
+        n.c.generators.dynamic.p.loc[:, n.c.generators.static.index],
+        n_r.c.generators.dynamic.p.loc[:, n.c.generators.static.index],
         decimal=2,
     )
 
     equal(
         n.c.lines.dynamic.p0.loc[:, n.c.lines.static.index],
-        n_r.lines_t.p0.loc[:, n.c.lines.static.index],
+        n_r.c.lines.dynamic.p0.loc[:, n.c.lines.static.index],
         decimal=2,
     )
 
     equal(
-        n.links_t.p0.loc[:, n.c.links.static.index],
-        n_r.links_t.p0.loc[:, n.c.links.static.index],
+        n.c.links.dynamic.p0.loc[:, n.c.links.static.index],
+        n_r.c.links.dynamic.p0.loc[:, n.c.links.static.index],
         decimal=2,
     )

--- a/test/test_lopf_ac_dc.py
+++ b/test/test_lopf_ac_dc.py
@@ -10,19 +10,19 @@ def test_optimize(ac_dc_network, ac_dc_network_r):
     assert status == "ok"
 
     equal(
-        n.generators_t.p.loc[:, n.generators.index],
-        n_r.generators_t.p.loc[:, n.generators.index],
+        n.generators_t.p.loc[:, n.c.generators.static.index],
+        n_r.generators_t.p.loc[:, n.c.generators.static.index],
         decimal=2,
     )
 
     equal(
-        n.lines_t.p0.loc[:, n.lines.index],
-        n_r.lines_t.p0.loc[:, n.lines.index],
+        n.c.lines.dynamic.p0.loc[:, n.c.lines.static.index],
+        n_r.lines_t.p0.loc[:, n.c.lines.static.index],
         decimal=2,
     )
 
     equal(
-        n.links_t.p0.loc[:, n.links.index],
-        n_r.links_t.p0.loc[:, n.links.index],
+        n.links_t.p0.loc[:, n.c.links.static.index],
+        n_r.links_t.p0.loc[:, n.c.links.static.index],
         decimal=2,
     )

--- a/test/test_lopf_activity_mask.py
+++ b/test/test_lopf_activity_mask.py
@@ -10,7 +10,7 @@ def test_optimize(ac_dc_network):
 
     inactive_links = ["DC link"]
 
-    n.links.loc[inactive_links, "active"] = False
+    n.c.links.static.loc[inactive_links, "active"] = False
 
     status, _ = n.optimize(snapshots=n.snapshots)
 
@@ -50,8 +50,8 @@ def test_optimize_with_power_flow(scipy_network):
     @pytest.mark.parametrize("line_active", [True, False])
     def test_scenario(line_active):
         n = scipy_network.copy()
-        switchable_lines = n.lines.index[100]
-        n.lines.loc[switchable_lines, "active"] = line_active
+        switchable_lines = n.c.lines.static.index[100]
+        n.c.lines.static.loc[switchable_lines, "active"] = line_active
 
         # Test optimization and non-linear power flow
         res = n.optimize.optimize_and_run_non_linear_powerflow(
@@ -62,7 +62,7 @@ def test_optimize_with_power_flow(scipy_network):
         assert res["converged"].all().all(), "Non-linear power flow did not converge"
 
         expected_flow = (
-            not np.isclose(n.lines_t.p0.loc[:, switchable_lines], 0).all().all()
+            not np.isclose(n.c.lines.dynamic.p0.loc[:, switchable_lines], 0).all().all()
         )
         msg = f"'active' attribute not respected in optimization/non-linear power flow: expected {'non-zero' if line_active else 'zero'} flow"
         assert expected_flow == line_active, msg
@@ -70,13 +70,13 @@ def test_optimize_with_power_flow(scipy_network):
         # Test linear power flow
         n.lpf()
         expected_flow = (
-            not np.isclose(n.lines_t.p0.loc[:, switchable_lines], 0).all().all()
+            not np.isclose(n.c.lines.dynamic.p0.loc[:, switchable_lines], 0).all().all()
         )
         msg = f"'active' attribute not respected in linear power flow: expected {'non-zero' if line_active else 'zero'} flow"
         assert expected_flow == line_active, msg
 
         msg = "Power balance not maintained"
-        assert np.isclose(n.buses_t.p.sum().sum(), 0, atol=1e-5), msg
+        assert np.isclose(n.c.buses.dynamic.p.sum().sum(), 0, atol=1e-5), msg
 
     test_scenario(True)
     test_scenario(False)

--- a/test/test_lopf_activity_mask.py
+++ b/test/test_lopf_activity_mask.py
@@ -16,7 +16,7 @@ def test_optimize(ac_dc_network):
 
     assert status == "ok"
 
-    assert n.links_t.p0.loc[:, inactive_links].eq(0).all().all()
+    assert n.c.links.dynamic.p0.loc[:, inactive_links].eq(0).all().all()
 
     assert "Bremen Converter" in n.model.variables["Link-p_nom"].coords["name"]
     assert "DC link" not in n.model.variables["Link-p_nom"].coords["name"]
@@ -113,7 +113,7 @@ def test_generators_with_active_attribute():
     assert status == "ok"
 
     # Inactive generator should have zero output
-    assert (n.generators_t.p["gen_inactive"] == 0).all()
+    assert (n.c.generators.dynamic.p["gen_inactive"] == 0).all()
 
     # Inactive generator should not be in model variables
     assert "gen_inactive" not in n.model.variables["Generator-p"].coords["name"]
@@ -166,7 +166,7 @@ def test_stores_with_active_attribute():
     assert status == "ok"
 
     # Inactive store should have zero flow
-    assert (n.stores_t.p["store_inactive"] == 0).all()
+    assert (n.c.stores.dynamic.p["store_inactive"] == 0).all()
 
     # Inactive store should not be in model variables
     assert "store_inactive" not in n.model.variables["Store-p"].coords["name"]
@@ -257,9 +257,9 @@ def test_mixed_components_with_active_attribute():
     assert status == "ok"
 
     # Test inactive components have zero flows
-    assert (n.generators_t.p["gen_inactive"] == 0).all()
-    assert (n.links_t.p0["link_inactive"] == 0).all()
-    assert (n.stores_t.p["store_inactive"] == 0).all()
+    assert (n.c.generators.dynamic.p["gen_inactive"] == 0).all()
+    assert (n.c.links.dynamic.p0["link_inactive"] == 0).all()
+    assert (n.c.stores.dynamic.p["store_inactive"] == 0).all()
 
     # Test inactive components not in model variables
     assert "gen_inactive" not in n.model.variables["Generator-p"].coords["name"]
@@ -325,7 +325,7 @@ def test_inactive_stores_with_global_operational_limit():
     assert status == "ok"
 
     # Test inactive store has zero flow
-    assert (n.stores_t.p["store_inactive"] == 0).all()
+    assert (n.c.stores.dynamic.p["store_inactive"] == 0).all()
 
     # Test inactive store is not in model variables
     assert "store_inactive" not in n.model.variables["Store-p"].coords["name"]

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -257,9 +257,9 @@ def test_define_generator_constraints_static():
 
     n.optimize()
 
-    assert n.generators_t.p["gen0"].eq(0).all()
-    assert n.generators_t.p["gen1"].eq(0).all()
-    assert n.generators_t.p["gen2"].eq(10).all()
+    assert n.c.generators.dynamic.p["gen0"].eq(0).all()
+    assert n.c.generators.dynamic.p["gen1"].eq(0).all()
+    assert n.c.generators.dynamic.p["gen2"].eq(10).all()
 
 
 def test_define_generator_constraints():
@@ -310,10 +310,16 @@ def test_define_generator_constraints():
 
     n.optimize()
 
-    assert n.snapshot_weightings.generators @ n.generators_t.p["gen0"] == 10 * eh
-    assert n.generators_t.p["gen1"].eq(0).all()
-    assert n.snapshot_weightings.generators @ n.generators_t.p["gen2"] == e_sum_min
-    assert n.snapshot_weightings.generators @ n.generators_t.p["gen3"] == e_sum_max
+    assert (
+        n.snapshot_weightings.generators @ n.c.generators.dynamic.p["gen0"] == 10 * eh
+    )
+    assert n.c.generators.dynamic.p["gen1"].eq(0).all()
+    assert (
+        n.snapshot_weightings.generators @ n.c.generators.dynamic.p["gen2"] == e_sum_min
+    )
+    assert (
+        n.snapshot_weightings.generators @ n.c.generators.dynamic.p["gen3"] == e_sum_max
+    )
 
 
 def test_define_fixed_operational_constraints_positive():
@@ -327,12 +333,12 @@ def test_define_fixed_operational_constraints_positive():
     n.add("Generator", "gen1", bus="bus0", p_nom=5, marginal_cost=5)
     n.add("Generator", "gen2", bus="bus0", p_nom=10, marginal_cost=9)
 
-    n.generators_t.p_set["gen2"] = 10
+    n.c.generators.dynamic.p_set["gen2"] = 10
 
     n.optimize()
 
-    assert n.generators_t.p["gen2"].eq(10).all()
-    assert n.generators_t.p["gen0"].eq(0).all()
+    assert n.c.generators.dynamic.p["gen2"].eq(10).all()
+    assert n.c.generators.dynamic.p["gen0"].eq(0).all()
 
 
 def test_define_fixed_operational_constraints_zero():
@@ -346,13 +352,13 @@ def test_define_fixed_operational_constraints_zero():
     n.add("Generator", "gen1", bus="bus0", p_nom=5, marginal_cost=5)
     n.add("Generator", "gen2", bus="bus0", p_nom=10, marginal_cost=9)
 
-    n.generators_t.p_set["gen0"] = 0
+    n.c.generators.dynamic.p_set["gen0"] = 0
 
     n.optimize()
 
-    assert n.generators_t.p["gen0"].eq(0).all()
-    assert n.generators_t.p["gen1"].eq(5).all()
-    assert n.generators_t.p["gen2"].eq(5).all()
+    assert n.c.generators.dynamic.p["gen0"].eq(0).all()
+    assert n.c.generators.dynamic.p["gen1"].eq(5).all()
+    assert n.c.generators.dynamic.p["gen2"].eq(5).all()
 
 
 def test_define_fixed_operational_constraints_extendable():
@@ -387,10 +393,10 @@ def test_define_fixed_operational_constraints_extendable():
         marginal_cost=9,
     )
 
-    n.generators_t.p_set["gen1"] = 5
+    n.c.generators.dynamic.p_set["gen1"] = 5
 
     n.optimize()
 
-    assert n.generators_t.p["gen0"].eq(5).all()
-    assert n.generators_t.p["gen1"].eq(5).all()
-    assert n.generators_t.p["gen2"].eq(0).all()
+    assert n.c.generators.dynamic.p["gen0"].eq(5).all()
+    assert n.c.generators.dynamic.p["gen1"].eq(5).all()
+    assert n.c.generators.dynamic.p["gen2"].eq(0).all()

--- a/test/test_lopf_global_constraints.py
+++ b/test/test_lopf_global_constraints.py
@@ -49,7 +49,7 @@ def test_operational_limit_storage_hvdc(storage_hvdc_network):
 
     soc_diff = (
         n.c.storage_units.static.state_of_charge_initial.sum()
-        - n.storage_units_t.state_of_charge.sum(1).iloc[-1]
+        - n.c.storage_units.dynamic.state_of_charge.sum(1).iloc[-1]
     )
     assert soc_diff.round(3) == limit
 
@@ -74,7 +74,7 @@ def test_assign_all_duals(ac_dc_network, assign):
     n.optimize.solve_model(assign_all_duals=assign)
 
     assert ("generation_limit" in n.c.global_constraints.static.index) == assign
-    assert ("mu_generation_limit_dynamic" in n.global_constraints_t) == assign
+    assert ("mu_generation_limit_dynamic" in n.c.global_constraints.dynamic) == assign
 
 
 def test_assign_duals_noname(ac_dc_network):

--- a/test/test_lopf_iteratively.py
+++ b/test/test_lopf_iteratively.py
@@ -37,9 +37,11 @@ def test_optimize_post_discretization():
     )
 
     assert status == "ok"
-    assert all(n.lines.query("s_nom_extendable").s_nom_opt % line_unit_size == 0.0)
     assert all(
-        n.links.query("p_nom_extendable and carrier == 'HVDC'").p_nom_opt
+        n.c.lines.static.query("s_nom_extendable").s_nom_opt % line_unit_size == 0.0
+    )
+    assert all(
+        n.c.links.static.query("p_nom_extendable and carrier == 'HVDC'").p_nom_opt
         % link_unit_size["HVDC"]
         == 0.0
     )

--- a/test/test_lopf_losses.py
+++ b/test/test_lopf_losses.py
@@ -4,8 +4,8 @@ import pytest
 @pytest.mark.parametrize("transmission_losses", [1, 2])
 def test_optimize_losses(scipy_network, transmission_losses):
     n = scipy_network
-    n.lines.s_max_pu = 0.7
-    n.lines.loc[["316", "527", "602"], "s_nom"] = 1715
+    n.c.lines.static.s_max_pu = 0.7
+    n.c.lines.static.loc[["316", "527", "602"], "s_nom"] = 1715
 
     n.optimize(
         snapshots=n.snapshots[0],

--- a/test/test_lopf_losses.py
+++ b/test/test_lopf_losses.py
@@ -12,8 +12,11 @@ def test_optimize_losses(scipy_network, transmission_losses):
         transmission_losses=transmission_losses,
     )
 
-    gen = n.generators_t.p.iloc[0].sum() + n.storage_units_t.p.iloc[0].sum()
-    dem = n.loads_t.p_set.iloc[0].sum()
+    gen = (
+        n.c.generators.dynamic.p.iloc[0].sum()
+        + n.c.storage_units.dynamic.p.iloc[0].sum()
+    )
+    dem = n.c.loads.dynamic.p_set.iloc[0].sum()
 
     assert gen > 1.01 * dem, "For this example, losses should be greater than 1%"
     assert gen < 1.05 * dem, "For this example, losses should be lower than 5%"

--- a/test/test_lopf_mga.py
+++ b/test/test_lopf_mga.py
@@ -35,14 +35,14 @@ def test_mga():
 
     n.optimize()
 
-    opt_capacity = n.generators.p_nom_opt
+    opt_capacity = n.c.generators.static.p_nom_opt
     opt_cost = (n.statistics.capex() + n.statistics.opex()).sum()
 
     weights = {"Generator": {"p_nom": {"coal": 1}}}
     slack = 0.05
     n.optimize.optimize_mga(slack=0.05, weights=weights)
 
-    mga_capacity = n.generators.p_nom_opt
+    mga_capacity = n.c.generators.static.p_nom_opt
     mga_cost = (n.statistics.capex() + n.statistics.opex()).sum()
 
     assert mga_capacity["coal"] <= opt_capacity["coal"]
@@ -95,7 +95,10 @@ def test_mga_in_direction():
     }
 
     # Assert that the capacity of gen1 is less than gen2
-    assert n.generators.p_nom_opt["gen1"] < n.generators.p_nom_opt["gen2"]
+    assert (
+        n.c.generators.static.p_nom_opt["gen1"]
+        < n.c.generators.static.p_nom_opt["gen2"]
+    )
 
     # Test error before solving network
     n_unsolved = pypsa.Network()

--- a/test/test_lopf_modularity.py
+++ b/test/test_lopf_modularity.py
@@ -44,5 +44,5 @@ def test_modular_components():
     expected_p_nom_opt_gen = np.array([5000], dtype=float).T
     expected_e_nom_opt_store = np.array([1000], dtype=float).T
 
-    equal(n.generators.p_nom_opt, expected_p_nom_opt_gen)
-    equal(n.stores.e_nom_opt, expected_e_nom_opt_store)
+    equal(n.c.generators.static.p_nom_opt, expected_p_nom_opt_gen)
+    equal(n.c.stores.static.e_nom_opt, expected_e_nom_opt_store)

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -66,8 +66,8 @@ def n():
 def n_sus(n):
     # only keep generators which are getting more expensiv and push generator
     # capital cost, so that sus are activated
-    n.remove("Generator", n.generators.query('bus == "1"').index)
-    n.generators.capital_cost *= 5
+    n.remove("Generator", n.c.generators.static.query('bus == "1"').index)
+    n.c.generators.static.capital_cost *= 5
 
     for i, period in enumerate(n.investment_periods):
         factor = (10 + i) / 10
@@ -88,8 +88,8 @@ def n_sus(n):
 def n_sts(n):
     # only keep generators which are getting more expensiv and push generator
     # capital cost, so that sus are activated
-    n.remove("Generator", n.generators.query('bus == "1"').index)
-    n.generators.capital_cost *= 5
+    n.remove("Generator", n.c.generators.static.query('bus == "1"').index)
+    n.c.generators.static.capital_cost *= 5
 
     n.add("Bus", "1 battery")
 
@@ -171,7 +171,7 @@ def test_tiny_with_default():
     n.add("Load", 1, bus=1, p_set=100)
     status, _ = n.optimize(**kwargs)
     assert status == "ok"
-    assert n.generators.p_nom_opt.item() == 100
+    assert n.c.generators.static.p_nom_opt.item() == 100
 
 
 def test_tiny_with_build_year():
@@ -184,7 +184,7 @@ def test_tiny_with_build_year():
     n.add("Load", 1, bus=1, p_set=100)
     status, _ = n.optimize(**kwargs)
     assert status == "ok"
-    assert n.generators.p_nom_opt.item() == 100
+    assert n.c.generators.static.p_nom_opt.item() == 100
 
 
 def test_tiny_infeasible():
@@ -207,7 +207,7 @@ def test_simple_network(n):
     assert (n.generators_t.p.loc[[2020, 2030, 2040], "gen1-2050"] == 0).all()
     assert (n.generators_t.p.loc[[2050], "gen1-2020"] == 0).all()
 
-    assert (n.lines_t.p0.loc[[2020, 2030, 2040], "line-2050"] == 0).all()
+    assert (n.c.lines.dynamic.p0.loc[[2020, 2030, 2040], "line-2050"] == 0).all()
 
 
 def test_simple_network_snapshot_subset(n):
@@ -218,13 +218,13 @@ def test_simple_network_snapshot_subset(n):
     assert (n.generators_t.p.loc[[2020, 2030, 2040], "gen1-2050"] == 0).all()
     assert (n.generators_t.p.loc[[2050], "gen1-2020"] == 0).all()
 
-    assert (n.lines_t.p0.loc[[2020, 2030, 2040], "line-2050"] == 0).all()
+    assert (n.c.lines.dynamic.p0.loc[[2020, 2030, 2040], "line-2050"] == 0).all()
 
 
 def test_simple_network_storage_noncyclic(n_sus):
-    n_sus.storage_units["state_of_charge_initial"] = 200
-    n_sus.storage_units["cyclic_state_of_charge"] = False
-    n_sus.storage_units["state_of_charge_initial_per_period"] = False
+    n_sus.c.storage_units.static["state_of_charge_initial"] = 200
+    n_sus.c.storage_units.static["cyclic_state_of_charge"] = False
+    n_sus.c.storage_units.static["state_of_charge_initial_per_period"] = False
 
     status, cond = n_sus.optimize(**kwargs)
     assert status == "ok"
@@ -237,9 +237,9 @@ def test_simple_network_storage_noncyclic(n_sus):
 
 
 def test_simple_network_storage_noncyclic_per_period(n_sus):
-    n_sus.storage_units["state_of_charge_initial"] = 200
-    n_sus.storage_units["cyclic_state_of_charge"] = False
-    n_sus.storage_units["state_of_charge_initial_per_period"] = True
+    n_sus.c.storage_units.static["state_of_charge_initial"] = 200
+    n_sus.c.storage_units.static["cyclic_state_of_charge"] = False
+    n_sus.c.storage_units.static["state_of_charge_initial_per_period"] = True
 
     status, cond = n_sus.optimize(**kwargs)
     assert status == "ok"
@@ -258,8 +258,8 @@ def test_simple_network_storage_noncyclic_per_period(n_sus):
 
 
 def test_simple_network_storage_cyclic(n_sus):
-    n_sus.storage_units["cyclic_state_of_charge"] = True
-    n_sus.storage_units["cyclic_state_of_charge_per_period"] = False
+    n_sus.c.storage_units.static["cyclic_state_of_charge"] = True
+    n_sus.c.storage_units.static["cyclic_state_of_charge_per_period"] = False
 
     status, cond = n_sus.optimize(**kwargs)
     assert status == "ok"
@@ -277,8 +277,8 @@ def test_simple_network_storage_cyclic(n_sus):
 
 def test_simple_network_storage_cyclic_per_period(n_sus):
     # Watch out breaks with xarray version 2022.06.00 !
-    n_sus.storage_units["cyclic_state_of_charge"] = True
-    n_sus.storage_units["cyclic_state_of_charge_per_period"] = True
+    n_sus.c.storage_units.static["cyclic_state_of_charge"] = True
+    n_sus.c.storage_units.static["cyclic_state_of_charge_per_period"] = True
 
     status, cond = n_sus.optimize(**kwargs)
     assert status == "ok"
@@ -292,8 +292,8 @@ def test_simple_network_storage_cyclic_per_period(n_sus):
 
 
 def test_simple_network_store_noncyclic(n_sts):
-    n_sts.stores["e_cyclic"] = False
-    n_sts.stores["e_initial_per_period"] = False
+    n_sts.c.stores.static["e_cyclic"] = False
+    n_sts.c.stores.static["e_initial_per_period"] = False
 
     status, cond = n_sts.optimize(**kwargs)
     assert status == "ok"
@@ -307,8 +307,8 @@ def test_simple_network_store_noncyclic(n_sts):
 
 
 def test_simple_network_store_noncyclic_per_period(n_sts):
-    n_sts.stores["e_cyclic"] = False
-    n_sts.stores["e_initial_per_period"] = True
+    n_sts.c.stores.static["e_cyclic"] = False
+    n_sts.c.stores.static["e_initial_per_period"] = True
 
     status, cond = n_sts.optimize(**kwargs)
     assert status == "ok"
@@ -326,8 +326,8 @@ def test_simple_network_store_noncyclic_per_period(n_sts):
 
 
 def test_simple_network_store_cyclic(n_sts):
-    n_sts.stores["e_cyclic"] = True
-    n_sts.stores["e_cyclic_per_period"] = False
+    n_sts.c.stores.static["e_cyclic"] = True
+    n_sts.c.stores.static["e_cyclic_per_period"] = False
 
     status, cond = n_sts.optimize(**kwargs)
     assert status == "ok"
@@ -342,8 +342,8 @@ def test_simple_network_store_cyclic(n_sts):
 
 def test_simple_network_store_cyclic_per_period(n_sts):
     # Watch out breaks with xarray version 2022.06.00 !
-    n_sts.stores["e_cyclic"] = True
-    n_sts.stores["e_cyclic_per_period"] = True
+    n_sts.c.stores.static["e_cyclic"] = True
+    n_sts.c.stores.static["e_cyclic_per_period"] = True
 
     status, cond = n_sts.optimize(**kwargs)
     assert status == "ok"
@@ -371,7 +371,7 @@ def test_global_constraint_primary_energy_storage(n_sus):
     active = get_activity_mask(n_sus, c)
     soc_end = n_sus.dynamic(c).state_of_charge.where(active).ffill().iloc[-1]
     soc_diff = n_sus.static(c).state_of_charge_initial - soc_end
-    emissions = n_sus.static(c).carrier.map(n_sus.carriers.co2_emissions)
+    emissions = n_sus.static(c).carrier.map(n_sus.c.carriers.static.co2_emissions)
     assert round(soc_diff @ emissions, 0) == 3000
 
 
@@ -382,7 +382,7 @@ def test_global_constraint_primary_energy_store(n_sts):
     n_sts.static(c)["e_cyclic"] = False
     n_sts.static(c)["e_initial_per_period"] = False
 
-    n_sts.buses.loc["1 battery", "carrier"] = "emitting_carrier"
+    n_sts.c.buses.static.loc["1 battery", "carrier"] = "emitting_carrier"
 
     n_sts.add("GlobalConstraint", name="co2limit", type="primary_energy", constant=3000)
 
@@ -391,7 +391,7 @@ def test_global_constraint_primary_energy_store(n_sts):
     active = get_activity_mask(n_sts, c)
     soc_end = n_sts.dynamic(c).e.where(active).ffill().iloc[-1]
     soc_diff = n_sts.static(c).e_initial - soc_end
-    emissions = n_sts.static(c).carrier.map(n_sts.carriers.co2_emissions)
+    emissions = n_sts.static(c).carrier.map(n_sts.c.carriers.static.co2_emissions)
     assert round(soc_diff @ emissions, 0) == 3000
 
 
@@ -430,16 +430,16 @@ def test_global_constraint_transmission_expansion_limit(n):
     )
 
     status, cond = n.optimize(**kwargs)
-    assert n.lines.s_nom_opt.sum() == 100
+    assert n.c.lines.static.s_nom_opt.sum() == 100
 
     # when only optimizing the first 10 snapshots the contraint must hold for
     # the 2020 period
     status, cond = n.optimize(n.snapshots[:10], **kwargs)
-    assert n.lines.loc["line-2020", "s_nom_opt"] == 100
+    assert n.c.lines.static.loc["line-2020", "s_nom_opt"] == 100
 
-    n.global_constraints["investment_period"] = 2030
+    n.c.global_constraints.static["investment_period"] = 2030
     status, cond = n.optimize(**kwargs)
-    assert n.lines.s_nom_opt[["line-2020", "line-2030"]].sum() == 100
+    assert n.c.lines.static.s_nom_opt[["line-2020", "line-2030"]].sum() == 100
 
 
 def test_global_constraint_transmission_cost_limit(n):
@@ -462,16 +462,22 @@ def test_global_constraint_transmission_cost_limit(n):
     weight = active @ n.investment_period_weightings.objective
 
     status, cond = n.optimize(**kwargs)
-    assert round((weight * n.lines.eval("s_nom_opt * capital_cost")).sum(), 2) == 1000
+    assert (
+        round((weight * n.c.lines.static.eval("s_nom_opt * capital_cost")).sum(), 2)
+        == 1000
+    )
 
     # when only optimizing the first 10 snapshots the contraint must hold for
     # the 2020 period
     status, cond = n.optimize(n.snapshots[:10], **kwargs)
-    assert round(n.lines.eval("s_nom_opt * capital_cost")["line-2020"].sum(), 2) == 1000
+    assert (
+        round(n.c.lines.static.eval("s_nom_opt * capital_cost")["line-2020"].sum(), 2)
+        == 1000
+    )
 
-    n.global_constraints["investment_period"] = 2030
+    n.c.global_constraints.static["investment_period"] = 2030
     status, cond = n.optimize(**kwargs)
-    lines = n.lines.loc[["line-2020", "line-2030"]]
+    lines = n.c.lines.static.loc[["line-2020", "line-2030"]]
     assert round(lines.eval("s_nom_opt * capital_cost").sum(), 2) == 1000
 
 
@@ -487,38 +493,41 @@ def test_global_constraint_bus_tech_limit(n):
     )
 
     status, cond = n.optimize(**kwargs)
-    assert round(n.generators.p_nom_opt[["gen1-2020", "gen2-2020"]], 1).sum() == 300
+    assert (
+        round(n.c.generators.static.p_nom_opt[["gen1-2020", "gen2-2020"]], 1).sum()
+        == 300
+    )
 
-    n.global_constraints["bus"] = 1
+    n.c.global_constraints.static["bus"] = 1
     status, cond = n.optimize(**kwargs)
-    assert n.generators.at["gen1-2020", "p_nom_opt"] == 300
+    assert n.c.generators.static.at["gen1-2020", "p_nom_opt"] == 300
 
     # make the constraint non-binding and check that the shadow price is zero
-    n.global_constraints.sense = "<="
+    n.c.global_constraints.static.sense = "<="
     status, cond = n.optimize(**kwargs)
-    assert n.global_constraints.at["expansion_limit", "mu"] == 0
+    assert n.c.global_constraints.static.at["expansion_limit", "mu"] == 0
 
 
 def test_nominal_constraint_bus_carrier_expansion_limit(n):
-    n.buses.at["1", "nom_max_gencarrier"] = 100
+    n.c.buses.static.at["1", "nom_max_gencarrier"] = 100
     with pytest.warns(
         DeprecationWarning, match="Nominal constraints per bus carrier are deprecated"
     ):
         status, cond = n.optimize(**kwargs)
     gen1s = [f"gen1-{period}" for period in n.investment_periods]
-    assert round(n.generators.p_nom_opt[gen1s], 0).sum() == 100
-    n.buses.drop(["nom_max_gencarrier"], inplace=True, axis=1)
+    assert round(n.c.generators.static.p_nom_opt[gen1s], 0).sum() == 100
+    n.c.buses.static.drop(["nom_max_gencarrier"], inplace=True, axis=1)
 
-    n.buses.at["1", "nom_max_gencarrier_2020"] = 100
+    n.c.buses.static.at["1", "nom_max_gencarrier_2020"] = 100
     with pytest.warns(
         DeprecationWarning, match="Nominal constraints per bus carrier are deprecated"
     ):
         status, cond = n.optimize(**kwargs)
-    assert n.generators.at["gen1-2020", "p_nom_opt"] == 100
-    n.buses.drop(["nom_max_gencarrier_2020"], inplace=True, axis=1)
+    assert n.c.generators.static.at["gen1-2020", "p_nom_opt"] == 100
+    n.c.buses.static.drop(["nom_max_gencarrier_2020"], inplace=True, axis=1)
 
     # make the constraint non-binding and check that the shadow price is zero
-    n.buses.at["1", "nom_min_gencarrier_2020"] = 100
+    n.c.buses.static.at["1", "nom_min_gencarrier_2020"] = 100
     with pytest.warns(
         DeprecationWarning, match="Nominal constraints per bus carrier are deprecated"
     ):
@@ -528,17 +537,22 @@ def test_nominal_constraint_bus_carrier_expansion_limit(n):
 
 def test_max_growth_constraint(n):
     # test generator grow limit
-    gen_carrier = n.generators.carrier.unique()[0]
-    n.carriers.at[gen_carrier, "max_growth"] = 218
+    gen_carrier = n.c.generators.static.carrier.unique()[0]
+    n.c.carriers.static.at[gen_carrier, "max_growth"] = 218
     status, cond = n.optimize(**kwargs)
-    assert all(n.generators.p_nom_opt.groupby(n.generators.build_year).sum() <= 218)
+    assert all(
+        n.c.generators.static.p_nom_opt.groupby(n.c.generators.static.build_year).sum()
+        <= 218
+    )
 
 
 def test_max_relative_growth_constraint(n):
     # test generator relative grow limit
-    gen_carrier = n.generators.carrier.unique()[0]
-    n.carriers.at[gen_carrier, "max_growth"] = 218
-    n.carriers.at[gen_carrier, "max_relative_growth"] = 1.5
+    gen_carrier = n.c.generators.static.carrier.unique()[0]
+    n.c.carriers.static.at[gen_carrier, "max_growth"] = 218
+    n.c.carriers.static.at[gen_carrier, "max_relative_growth"] = 1.5
     status, cond = n.optimize(**kwargs)
-    built_per_period = n.generators.p_nom_opt.groupby(n.generators.build_year).sum()
+    built_per_period = n.c.generators.static.p_nom_opt.groupby(
+        n.c.generators.static.build_year
+    ).sum()
     assert all(built_per_period - built_per_period.shift(fill_value=0) * 1.5 <= 218)

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -204,8 +204,8 @@ def test_simple_network(n):
     assert status == "ok"
     assert cond == "optimal"
 
-    assert (n.generators_t.p.loc[[2020, 2030, 2040], "gen1-2050"] == 0).all()
-    assert (n.generators_t.p.loc[[2050], "gen1-2020"] == 0).all()
+    assert (n.c.generators.dynamic.p.loc[[2020, 2030, 2040], "gen1-2050"] == 0).all()
+    assert (n.c.generators.dynamic.p.loc[[2050], "gen1-2020"] == 0).all()
 
     assert (n.c.lines.dynamic.p0.loc[[2020, 2030, 2040], "line-2050"] == 0).all()
 
@@ -215,8 +215,8 @@ def test_simple_network_snapshot_subset(n):
     assert status == "ok"
     assert cond == "optimal"
 
-    assert (n.generators_t.p.loc[[2020, 2030, 2040], "gen1-2050"] == 0).all()
-    assert (n.generators_t.p.loc[[2050], "gen1-2020"] == 0).all()
+    assert (n.c.generators.dynamic.p.loc[[2020, 2030, 2040], "gen1-2050"] == 0).all()
+    assert (n.c.generators.dynamic.p.loc[[2050], "gen1-2020"] == 0).all()
 
     assert (n.c.lines.dynamic.p0.loc[[2020, 2030, 2040], "line-2050"] == 0).all()
 
@@ -230,8 +230,8 @@ def test_simple_network_storage_noncyclic(n_sus):
     assert status == "ok"
     assert cond == "optimal"
 
-    soc = n_sus.storage_units_t.state_of_charge
-    p = n_sus.storage_units_t.p
+    soc = n_sus.c.storage_units.dynamic.state_of_charge
+    p = n_sus.c.storage_units.dynamic.p
     assert round((soc + p).loc[idx[2020, 0], "sto1-2020"], 4) == 200
     assert soc.loc[idx[2040, 9], "sto1-2020"] == 0
 
@@ -245,12 +245,14 @@ def test_simple_network_storage_noncyclic_per_period(n_sus):
     assert status == "ok"
     assert cond == "optimal"
 
-    assert (n_sus.storage_units_t.p.loc[[2020, 2030, 2040], "sto1-2050"] == 0).all()
-    assert (n_sus.storage_units_t.p.loc[[2050], "sto1-2020"] == 0).all()
+    assert (
+        n_sus.c.storage_units.dynamic.p.loc[[2020, 2030, 2040], "sto1-2050"] == 0
+    ).all()
+    assert (n_sus.c.storage_units.dynamic.p.loc[[2050], "sto1-2020"] == 0).all()
 
-    soc_initial = (n_sus.storage_units_t.state_of_charge + n_sus.storage_units_t.p).loc[
-        idx[:, 0], :
-    ]
+    soc_initial = (
+        n_sus.c.storage_units.dynamic.state_of_charge + n_sus.c.storage_units.dynamic.p
+    ).loc[idx[:, 0], :]
     soc_initial = soc_initial.droplevel("timestep")
     assert soc_initial.loc[2020, "sto1-2020"] == 200
     assert soc_initial.loc[2030, "sto1-2020"] == 200
@@ -265,8 +267,8 @@ def test_simple_network_storage_cyclic(n_sus):
     assert status == "ok"
     assert cond == "optimal"
 
-    soc = n_sus.storage_units_t.state_of_charge
-    p = n_sus.storage_units_t.p
+    soc = n_sus.c.storage_units.dynamic.state_of_charge
+    p = n_sus.c.storage_units.dynamic.p
     assert (
         soc.loc[idx[2040, 9], "sto1-2020"] == (soc + p).loc[idx[2020, 0], "sto1-2020"]
     )
@@ -284,8 +286,8 @@ def test_simple_network_storage_cyclic_per_period(n_sus):
     assert status == "ok"
     assert cond == "optimal"
 
-    soc = n_sus.storage_units_t.state_of_charge
-    p = n_sus.storage_units_t.p
+    soc = n_sus.c.storage_units.dynamic.state_of_charge
+    p = n_sus.c.storage_units.dynamic.p
     assert (
         soc.loc[idx[2020, 9], "sto1-2020"] == (soc + p).loc[idx[2020, 0], "sto1-2020"]
     )
@@ -299,9 +301,9 @@ def test_simple_network_store_noncyclic(n_sts):
     assert status == "ok"
     assert cond == "optimal"
 
-    assert (n_sts.stores_t.p.loc[[2050], "sto1-2020"] == 0).all()
+    assert (n_sts.c.stores.dynamic.p.loc[[2050], "sto1-2020"] == 0).all()
 
-    e_initial = (n_sts.stores_t.e + n_sts.stores_t.p).loc[idx[:, 0], :]
+    e_initial = (n_sts.c.stores.dynamic.e + n_sts.c.stores.dynamic.p).loc[idx[:, 0], :]
     e_initial = e_initial.droplevel("timestep")
     assert e_initial.loc[2020, "sto1-2020"] == 20
 
@@ -314,9 +316,9 @@ def test_simple_network_store_noncyclic_per_period(n_sts):
     assert status == "ok"
     assert cond == "optimal"
 
-    assert (n_sts.stores_t.p.loc[[2050], "sto1-2020"] == 0).all()
+    assert (n_sts.c.stores.dynamic.p.loc[[2050], "sto1-2020"] == 0).all()
 
-    e_initial = (n_sts.stores_t.e + n_sts.stores_t.p).loc[idx[:, 0], :]
+    e_initial = (n_sts.c.stores.dynamic.e + n_sts.c.stores.dynamic.p).loc[idx[:, 0], :]
     e_initial = e_initial.droplevel("timestep")
     assert e_initial.loc[2020, "sto1-2020"] == 20
     assert e_initial.loc[2030, "sto1-2020"] == 20
@@ -333,10 +335,10 @@ def test_simple_network_store_cyclic(n_sts):
     assert status == "ok"
     assert cond == "optimal"
 
-    assert (n_sts.stores_t.p.loc[[2050], "sto1-2020"] == 0).all()
+    assert (n_sts.c.stores.dynamic.p.loc[[2050], "sto1-2020"] == 0).all()
 
-    e = n_sts.stores_t.e
-    p = n_sts.stores_t.p
+    e = n_sts.c.stores.dynamic.e
+    p = n_sts.c.stores.dynamic.p
     assert e.loc[idx[2040, 9], "sto1-2020"] == (e + p).loc[idx[2020, 0], "sto1-2020"]
 
 
@@ -349,10 +351,10 @@ def test_simple_network_store_cyclic_per_period(n_sts):
     assert status == "ok"
     assert cond == "optimal"
 
-    assert (n_sts.stores_t.p.loc[[2050], "sto1-2020"] == 0).all()
+    assert (n_sts.c.stores.dynamic.p.loc[[2050], "sto1-2020"] == 0).all()
 
-    e = n_sts.stores_t.e
-    p = n_sts.stores_t.p
+    e = n_sts.c.stores.dynamic.e
+    p = n_sts.c.stores.dynamic.p
     assert e.loc[idx[2020, 9], "sto1-2020"] == (e + p).loc[idx[2020, 0], "sto1-2020"]
 
 

--- a/test/test_lopf_quadratic_costs.py
+++ b/test/test_lopf_quadratic_costs.py
@@ -10,12 +10,12 @@ def test_optimize_quadratic(ac_dc_network):
 
     assert status == "ok"
 
-    gas_i = n.generators.index[n.generators.carrier == "gas"]
+    gas_i = n.c.generators.static.index[n.c.generators.static.carrier == "gas"]
 
     objective_linear = n.objective
 
     # quadratic costs
-    n.generators.loc[gas_i, "marginal_cost_quadratic"] = 2
+    n.c.generators.static.loc[gas_i, "marginal_cost_quadratic"] = 2
     status, _ = n.optimize(solver_name="gurobi")
 
     assert status == "ok"

--- a/test/test_lopf_rolling_horizon.py
+++ b/test/test_lopf_rolling_horizon.py
@@ -52,7 +52,7 @@ def test_rolling_horizon(committable):
         status, condition = n.optimize(snapshots=sns)
         assert status == "ok"
 
-    ramping = n.generators_t.p.diff().fillna(0)
+    ramping = n.c.generators.dynamic.p.diff().fillna(0)
     assert (
         (ramping <= n.c.generators.static.eval("ramp_limit_up * p_nom_opt")).all().all()
     )
@@ -76,7 +76,7 @@ def test_rolling_horizon_integrated(committable):
     )
 
     n.optimize.optimize_with_rolling_horizon(horizon=3)
-    ramping = n.generators_t.p.diff().fillna(0)
+    ramping = n.c.generators.dynamic.p.diff().fillna(0)
     assert (
         (ramping <= n.c.generators.static.eval("ramp_limit_up * p_nom_opt")).all().all()
     )
@@ -102,7 +102,7 @@ def test_rolling_horizon_integrated_overlap():
         n.optimize.optimize_with_rolling_horizon(horizon=1, overlap=2)
 
     n.optimize.optimize_with_rolling_horizon(horizon=3, overlap=1)
-    ramping = n.generators_t.p.diff().fillna(0)
+    ramping = n.c.generators.dynamic.p.diff().fillna(0)
     assert (
         (ramping <= n.c.generators.static.eval("ramp_limit_up * p_nom_opt")).all().all()
     )

--- a/test/test_lopf_rolling_horizon.py
+++ b/test/test_lopf_rolling_horizon.py
@@ -53,8 +53,14 @@ def test_rolling_horizon(committable):
         assert status == "ok"
 
     ramping = n.generators_t.p.diff().fillna(0)
-    assert (ramping <= n.generators.eval("ramp_limit_up * p_nom_opt")).all().all()
-    assert (ramping >= -n.generators.eval("ramp_limit_down * p_nom_opt")).all().all()
+    assert (
+        (ramping <= n.c.generators.static.eval("ramp_limit_up * p_nom_opt")).all().all()
+    )
+    assert (
+        (ramping >= -n.c.generators.static.eval("ramp_limit_down * p_nom_opt"))
+        .all()
+        .all()
+    )
 
 
 @pytest.mark.parametrize("committable", [True, False])
@@ -71,8 +77,14 @@ def test_rolling_horizon_integrated(committable):
 
     n.optimize.optimize_with_rolling_horizon(horizon=3)
     ramping = n.generators_t.p.diff().fillna(0)
-    assert (ramping <= n.generators.eval("ramp_limit_up * p_nom_opt")).all().all()
-    assert (ramping >= -n.generators.eval("ramp_limit_down * p_nom_opt")).all().all()
+    assert (
+        (ramping <= n.c.generators.static.eval("ramp_limit_up * p_nom_opt")).all().all()
+    )
+    assert (
+        (ramping >= -n.c.generators.static.eval("ramp_limit_down * p_nom_opt"))
+        .all()
+        .all()
+    )
 
 
 def test_rolling_horizon_integrated_overlap():
@@ -91,5 +103,11 @@ def test_rolling_horizon_integrated_overlap():
 
     n.optimize.optimize_with_rolling_horizon(horizon=3, overlap=1)
     ramping = n.generators_t.p.diff().fillna(0)
-    assert (ramping <= n.generators.eval("ramp_limit_up * p_nom_opt")).all().all()
-    assert (ramping >= -n.generators.eval("ramp_limit_down * p_nom_opt")).all().all()
+    assert (
+        (ramping <= n.c.generators.static.eval("ramp_limit_up * p_nom_opt")).all().all()
+    )
+    assert (
+        (ramping >= -n.c.generators.static.eval("ramp_limit_down * p_nom_opt"))
+        .all()
+        .all()
+    )

--- a/test/test_lopf_storage.py
+++ b/test/test_lopf_storage.py
@@ -91,7 +91,7 @@ def test_spill_cost():
         overlap = 2
         for i in range(sets_of_snapshots):
             if i == 1:
-                n.storage_units.state_of_charge_initial = (
+                n.c.storage_units.static.state_of_charge_initial = (
                     n.storage_units_t.state_of_charge.loc[n.snapshots[4]]
                 )
             n.optimize(

--- a/test/test_lopf_storage.py
+++ b/test/test_lopf_storage.py
@@ -22,7 +22,7 @@ def target_gen_p():
 def test_optimize(storage_hvdc_network, target_gen_p):
     n = storage_hvdc_network
     n.optimize()
-    equal(n.generators_t.p.reindex_like(target_gen_p), target_gen_p, decimal=2)
+    equal(n.c.generators.dynamic.p.reindex_like(target_gen_p), target_gen_p, decimal=2)
 
 
 def test_storage_energy_marginal_cost():
@@ -92,13 +92,13 @@ def test_spill_cost():
         for i in range(sets_of_snapshots):
             if i == 1:
                 n.c.storage_units.static.state_of_charge_initial = (
-                    n.storage_units_t.state_of_charge.loc[n.snapshots[4]]
+                    n.c.storage_units.dynamic.state_of_charge.loc[n.snapshots[4]]
                 )
             n.optimize(
                 n.snapshots[i * len(p_set) : (i + 1) * len(p_set) + overlap],
             )
 
-        spill = n.storage_units_t["spill"].loc[:, "hydro"]
+        spill = n.c.storage_units.dynamic["spill"].loc[:, "hydro"]
         total_spill = spill.sum()
 
         if has_spill_cost:

--- a/test/test_lopf_unit_commitment.py
+++ b/test/test_lopf_unit_commitment.py
@@ -44,11 +44,11 @@ def test_unit_commitment():
 
     expected_status = np.array([[1, 1, 1, 0], [0, 0, 0, 1]], dtype=float).T
 
-    equal(n.generators_t.status.values, expected_status)
+    equal(n.c.generators.dynamic.status.values, expected_status)
 
     expected_dispatch = np.array([[4000, 6000, 5000, 0], [0, 0, 0, 800]], dtype=float).T
 
-    equal(n.generators_t.p.values, expected_dispatch)
+    equal(n.c.generators.dynamic.p.values, expected_dispatch)
 
 
 def test_minimum_up_time():
@@ -92,13 +92,13 @@ def test_minimum_up_time():
 
     expected_status = np.array([[1, 0, 1, 1], [1, 1, 1, 0]], dtype=float).T
 
-    equal(n.generators_t.status.values, expected_status)
+    equal(n.c.generators.dynamic.status.values, expected_status)
 
     expected_dispatch = np.array(
         [[3900, 0, 4900, 3000], [100, 800, 100, 0]], dtype=float
     ).T
 
-    equal(n.generators_t.p.values, expected_dispatch)
+    equal(n.c.generators.dynamic.p.values, expected_dispatch)
 
 
 def test_minimum_up_time_up_time_before():
@@ -142,13 +142,13 @@ def test_minimum_up_time_up_time_before():
 
     expected_status = np.array([[1, 0, 1, 1], [1, 1, 1, 0]], dtype=float).T
 
-    equal(n.generators_t.status.values, expected_status)
+    equal(n.c.generators.dynamic.status.values, expected_status)
 
     expected_dispatch = np.array(
         [[3900, 0, 4900, 3000], [100, 800, 100, 0]], dtype=float
     ).T
 
-    equal(n.generators_t.p.values, expected_dispatch)
+    equal(n.c.generators.dynamic.p.values, expected_dispatch)
 
 
 def test_minimum_down_time():
@@ -190,11 +190,11 @@ def test_minimum_down_time():
 
     expected_status = np.array([[0, 0, 1, 1], [1, 1, 0, 0]], dtype=float).T
 
-    equal(n.generators_t.status.values, expected_status)
+    equal(n.c.generators.dynamic.status.values, expected_status)
 
     expected_dispatch = np.array([[0, 0, 3000, 8000], [3000, 800, 0, 0]], dtype=float).T
 
-    equal(n.generators_t.p.values, expected_dispatch)
+    equal(n.c.generators.dynamic.p.values, expected_dispatch)
 
 
 def test_minimum_down_time_up_time_before():
@@ -237,11 +237,11 @@ def test_minimum_down_time_up_time_before():
 
     expected_status = np.array([[0, 0, 1, 1], [1, 1, 0, 0]], dtype=float).T
 
-    equal(n.generators_t.status.values, expected_status)
+    equal(n.c.generators.dynamic.status.values, expected_status)
 
     expected_dispatch = np.array([[0, 0, 3000, 8000], [3000, 800, 0, 0]], dtype=float).T
 
-    equal(n.generators_t.p.values, expected_dispatch)
+    equal(n.c.generators.dynamic.p.values, expected_dispatch)
 
 
 def test_start_up_costs():
@@ -358,13 +358,13 @@ def test_unit_commitment_rolling_horizon():
     expected_status = np.array(
         [[1, 1, 0, 0, 0, 0, 0], [0, 0, 1, 1, 1, 1, 1]], dtype=float
     ).T
-    equal(n.generators_t.status.values, expected_status)
+    equal(n.c.generators.dynamic.status.values, expected_status)
 
     expected_dispatch = np.array(
         [[4000, 6000, 0, 0, 0, 0, 0], [0, 0, 800, 5000, 3000, 950, 800]]
     ).T
 
-    equal(n.generators_t.p.values, expected_dispatch)
+    equal(n.c.generators.dynamic.p.values, expected_dispatch)
 
 
 def test_linearized_unit_commitment():
@@ -456,11 +456,11 @@ def test_link_unit_commitment():
 
     expected_status = [1.0, 1.0, 1.0, 1.0]
 
-    equal(n.links_t.status["OCGT"].values, expected_status)
+    equal(n.c.links.dynamic.status["OCGT"].values, expected_status)
 
     expected_dispatch = [3200.0, 5200.0, 600.0, 4200.0]
 
-    equal(-n.links_t.p1["OCGT"].values, expected_dispatch)
+    equal(-n.c.links.dynamic.p1["OCGT"].values, expected_dispatch)
 
     assert round(n.objective, 1) == 267333.0
 
@@ -501,10 +501,10 @@ def test_dynamic_ramp_rates():
 
     n.optimize()
 
-    assert (n.generators_t.p.diff().loc[0:6, "gen1"]).max() <= 0.5 * 80
-    assert (n.generators_t.p.diff().loc[0:6, "gen1"]).min() >= -0.5 * 100
-    assert (n.generators_t.p.diff().loc[6:, "gen1"]).max() <= 80
-    assert (n.generators_t.p.diff().loc[6:, "gen1"]).min() >= -100
+    assert (n.c.generators.dynamic.p.diff().loc[0:6, "gen1"]).max() <= 0.5 * 80
+    assert (n.c.generators.dynamic.p.diff().loc[0:6, "gen1"]).min() >= -0.5 * 100
+    assert (n.c.generators.dynamic.p.diff().loc[6:, "gen1"]).max() <= 80
+    assert (n.c.generators.dynamic.p.diff().loc[6:, "gen1"]).min() >= -100
 
 
 def test_dynamic_start_up_rates_for_commitables():
@@ -545,8 +545,8 @@ def test_dynamic_start_up_rates_for_commitables():
     assert status == "ok"
 
     # Check that ramp_limit_start_up constraint is respected
-    gen1_status = n.generators_t.status["gen1"]
-    gen1_p = n.generators_t.p["gen1"]
+    gen1_status = n.c.generators.dynamic.status["gen1"]
+    gen1_p = n.c.generators.dynamic.p["gen1"]
 
     # Find startup events (status changes from 0 to 1)
     startup_snapshots = gen1_status[

--- a/test/test_lopf_varying_inputs.py
+++ b/test/test_lopf_varying_inputs.py
@@ -42,7 +42,7 @@ def test_time_dependent_standing_losses_storage_units():
     )
     status, _ = n.optimize()
     assert status == "ok"
-    equal(n.storage_units_t.state_of_charge.su.values, [1.0, 0.9, 0.72])
+    equal(n.c.storage_units.dynamic.state_of_charge.su.values, [1.0, 0.9, 0.72])
 
 
 def test_time_dependent_standing_losses_stores():
@@ -61,4 +61,4 @@ def test_time_dependent_standing_losses_stores():
     )
     status, _ = n.optimize()
     assert status == "ok"
-    equal(n.stores_t.e.sto.values, [1.0, 0.9, 0.72])
+    equal(n.c.stores.dynamic.e.sto.values, [1.0, 0.9, 0.72])

--- a/test/test_lpf_ac_dc.py
+++ b/test/test_lpf_ac_dc.py
@@ -15,35 +15,41 @@ def ac_dc_network_r():
 def test_lpf(ac_dc_network, ac_dc_network_r):
     n = ac_dc_network
     n_r = ac_dc_network_r
-    n.links_t.p_set = n_r.links_t.p_set
+    n.c.links.dynamic.p_set = n_r.c.links.dynamic.p_set
 
     n.lpf(snapshots=n.snapshots)
 
     equal(
-        n.generators_t.p[n.c.generators.static.index],
-        n_r.generators_t.p[n.c.generators.static.index],
+        n.c.generators.dynamic.p[n.c.generators.static.index],
+        n_r.c.generators.dynamic.p[n.c.generators.static.index],
     )
     equal(
         n.c.lines.dynamic.p0[n.c.lines.static.index],
-        n_r.lines_t.p0[n.c.lines.static.index],
+        n_r.c.lines.dynamic.p0[n.c.lines.static.index],
     )
-    equal(n.links_t.p0[n.c.links.static.index], n_r.links_t.p0[n.c.links.static.index])
+    equal(
+        n.c.links.dynamic.p0[n.c.links.static.index],
+        n_r.c.links.dynamic.p0[n.c.links.static.index],
+    )
 
 
 def test_lpf_chunks(ac_dc_network, ac_dc_network_r):
     n = ac_dc_network
     n_r = ac_dc_network_r
-    n.links_t.p_set = n_r.links_t.p_set
+    n.c.links.dynamic.p_set = n_r.c.links.dynamic.p_set
 
     for snapshot in n.snapshots:
         n.lpf(snapshot)
 
     equal(
-        n.generators_t.p[n.c.generators.static.index],
-        n_r.generators_t.p[n.c.generators.static.index],
+        n.c.generators.dynamic.p[n.c.generators.static.index],
+        n_r.c.generators.dynamic.p[n.c.generators.static.index],
     )
     equal(
         n.c.lines.dynamic.p0[n.c.lines.static.index],
-        n_r.lines_t.p0[n.c.lines.static.index],
+        n_r.c.lines.dynamic.p0[n.c.lines.static.index],
     )
-    equal(n.links_t.p0[n.c.links.static.index], n_r.links_t.p0[n.c.links.static.index])
+    equal(
+        n.c.links.dynamic.p0[n.c.links.static.index],
+        n_r.c.links.dynamic.p0[n.c.links.static.index],
+    )

--- a/test/test_lpf_ac_dc.py
+++ b/test/test_lpf_ac_dc.py
@@ -19,9 +19,15 @@ def test_lpf(ac_dc_network, ac_dc_network_r):
 
     n.lpf(snapshots=n.snapshots)
 
-    equal(n.generators_t.p[n.generators.index], n_r.generators_t.p[n.generators.index])
-    equal(n.lines_t.p0[n.lines.index], n_r.lines_t.p0[n.lines.index])
-    equal(n.links_t.p0[n.links.index], n_r.links_t.p0[n.links.index])
+    equal(
+        n.generators_t.p[n.c.generators.static.index],
+        n_r.generators_t.p[n.c.generators.static.index],
+    )
+    equal(
+        n.c.lines.dynamic.p0[n.c.lines.static.index],
+        n_r.lines_t.p0[n.c.lines.static.index],
+    )
+    equal(n.links_t.p0[n.c.links.static.index], n_r.links_t.p0[n.c.links.static.index])
 
 
 def test_lpf_chunks(ac_dc_network, ac_dc_network_r):
@@ -32,6 +38,12 @@ def test_lpf_chunks(ac_dc_network, ac_dc_network_r):
     for snapshot in n.snapshots:
         n.lpf(snapshot)
 
-    equal(n.generators_t.p[n.generators.index], n_r.generators_t.p[n.generators.index])
-    equal(n.lines_t.p0[n.lines.index], n_r.lines_t.p0[n.lines.index])
-    equal(n.links_t.p0[n.links.index], n_r.links_t.p0[n.links.index])
+    equal(
+        n.generators_t.p[n.c.generators.static.index],
+        n_r.generators_t.p[n.c.generators.static.index],
+    )
+    equal(
+        n.c.lines.dynamic.p0[n.c.lines.static.index],
+        n_r.lines_t.p0[n.c.lines.static.index],
+    )
+    equal(n.links_t.p0[n.c.links.static.index], n_r.links_t.p0[n.c.links.static.index])

--- a/test/test_lpf_against_pypower.py
+++ b/test/test_lpf_against_pypower.py
@@ -96,7 +96,7 @@ def test_pypower_case():
     n.lpf()
 
     # compare generator dispatch
-    p_pypsa = n.generators_t.p.loc[DEFAULT_TIMESTAMP].values
+    p_pypsa = n.c.generators.dynamic.p.loc[DEFAULT_TIMESTAMP].values
     p_pypower = results_df["gen"]["p"].values
 
     equal(p_pypsa, p_pypower)

--- a/test/test_lpf_against_pypower.py
+++ b/test/test_lpf_against_pypower.py
@@ -103,8 +103,8 @@ def test_pypower_case():
 
     # compare branch flows
     for item in ["lines", "transformers"]:
-        df = getattr(n, item)
-        dynamic = getattr(n, item + "_t")
+        df = getattr(n.c, item).static
+        dynamic = getattr(n.c, item).dynamic
 
         for si in ["p0", "p1"]:
             si_pypsa = getattr(dynamic, si).loc[DEFAULT_TIMESTAMP].values

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -556,15 +556,15 @@ def test_components_repr(ac_dc_network):
     assert len(repr(n)) > len(str(n))
 
 
-@pytest.mark.parametrize("legacy_components", [True, False])
-def test_api_components_legacy(legacy_components):
+@pytest.mark.parametrize("new_components_api", [True, False])
+def test_api_components_legacy(new_components_api):
     """
     Test the API of the components module.
     """
-    with pypsa.option_context("api.legacy_components", legacy_components):
+    with pypsa.option_context("api.new_components_api", new_components_api):
         n = pypsa.examples.ac_dc_meshed()
 
-        if legacy_components:
+        if not new_components_api:
             assert n.buses is n.components.buses.static
             assert n.buses_t is n.components.buses.dynamic
             assert n.lines is n.components.lines.static
@@ -583,15 +583,15 @@ def test_api_components_legacy(legacy_components):
                 assert n.generators_t is n.components.generators.dynamic
 
 
-@pytest.mark.parametrize("legacy_components", [True, False])
-def test_api_legacy_components(component_name, legacy_components):
+@pytest.mark.parametrize("new_components_api", [True, False])
+def test_api_new_components_api(component_name, new_components_api):
     """
     Test the API of the components module.
     """
 
-    with pypsa.option_context("api.legacy_components", legacy_components):
+    with pypsa.option_context("api.new_components_api", new_components_api):
         n = pypsa.examples.ac_dc_meshed()
-        if legacy_components:
+        if not new_components_api:
             assert n.static(component_name) is n.c[component_name].static
             assert n.dynamic(component_name) is n.c[component_name].dynamic
 

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -62,7 +62,7 @@ def test_remove(ac_dc_network):
 
     n.remove("Generator", generators)
 
-    assert not generators.issubset(n.generators.index)
+    assert not generators.issubset(n.c.generators.static.index)
     assert not generators.issubset(n.generators_t.p_max_pu.columns)
 
 
@@ -117,7 +117,7 @@ def test_add_duplicated_names(n_5bus):
 
 @pytest.mark.parametrize("slicer", [0, slice(0, 1), slice(None, None)])
 def test_add_static(n_5bus, slicer):
-    buses = n_5bus.buses.index[slicer]
+    buses = n_5bus.c.buses.static.index[slicer]
 
     load_names = "load_" + buses
 
@@ -126,11 +126,11 @@ def test_add_static(n_5bus, slicer):
     if slicer == 0:
         load_names = pd.Index([load_names])
 
-    assert len(n_5bus.loads) == len(load_names)
-    assert n_5bus.loads.index.name == "name"
-    assert n_5bus.loads.index.equals(load_names)
-    assert (n_5bus.loads.bus == buses).all()
-    assert (n_5bus.loads.p_set == 3).all()
+    assert len(n_5bus.c.loads.static) == len(load_names)
+    assert n_5bus.c.loads.static.index.name == "name"
+    assert n_5bus.c.loads.static.index.equals(load_names)
+    assert (n_5bus.c.loads.static.bus == buses).all()
+    assert (n_5bus.c.loads.static.p_set == 3).all()
 
     if slicer == slice(None, None):
         # Test different names shape
@@ -140,7 +140,7 @@ def test_add_static(n_5bus, slicer):
 
 @pytest.mark.parametrize("slicer", [slice(0, 1), slice(None, None)])
 def test_add_static_with_index(n_5bus, slicer):
-    buses = n_5bus.buses.index[slicer]
+    buses = n_5bus.c.buses.static.index[slicer]
 
     load_names = "load_" + buses
     buses = pd.Series(buses, index=load_names)
@@ -152,11 +152,11 @@ def test_add_static_with_index(n_5bus, slicer):
         p_set=3,
     )
 
-    assert len(n_5bus.loads) == len(load_names)
-    assert n_5bus.loads.index.name == "name"
-    assert n_5bus.loads.index.equals(load_names)
-    assert (n_5bus.loads.bus == buses).all()
-    assert (n_5bus.loads.p_set == 3).all()
+    assert len(n_5bus.c.loads.static) == len(load_names)
+    assert n_5bus.c.loads.static.index.name == "name"
+    assert n_5bus.c.loads.static.index.equals(load_names)
+    assert (n_5bus.c.loads.static.bus == buses).all()
+    assert (n_5bus.c.loads.static.p_set == 3).all()
 
     if len(buses) > 1:
         # Test unaligned names index
@@ -165,7 +165,7 @@ def test_add_static_with_index(n_5bus, slicer):
 
 
 def test_add_varying_single(n_5bus_7sn):
-    buses = n_5bus_7sn.buses.index
+    buses = n_5bus_7sn.c.buses.static.index
 
     # Add load component at every bus with time-dependent attribute p_set.
     p_set = rng.random(size=(len(n_5bus_7sn.snapshots)))
@@ -176,12 +176,14 @@ def test_add_varying_single(n_5bus_7sn):
         p_set=p_set,
     )
 
-    assert len(n_5bus_7sn.loads) == 1
-    assert n_5bus_7sn.loads.index.name == "name"
-    assert (n_5bus_7sn.loads.index == "load_1").all()
-    assert (n_5bus_7sn.loads.bus == buses[0]).all()
+    assert len(n_5bus_7sn.c.loads.static) == 1
+    assert n_5bus_7sn.c.loads.static.index.name == "name"
+    assert (n_5bus_7sn.c.loads.static.index == "load_1").all()
+    assert (n_5bus_7sn.c.loads.static.bus == buses[0]).all()
     assert (p_set == n_5bus_7sn.loads_t.p_set.T).all().all()
-    assert (n_5bus_7sn.loads.p_set == 0).all()  # Assert that default value is set
+    assert (
+        n_5bus_7sn.c.loads.static.p_set == 0
+    ).all()  # Assert that default value is set
 
     # Test different snapshots shape
     with pytest.raises(ValueError, match="for each snapshot"):
@@ -194,7 +196,7 @@ def test_add_varying_single(n_5bus_7sn):
 
 @pytest.mark.parametrize("slicer", [slice(0, 1), slice(None, None)])
 def test_add_varying_multiple(n_5bus_7sn, slicer):
-    buses = n_5bus_7sn.buses.index[slicer]
+    buses = n_5bus_7sn.c.buses.static.index[slicer]
 
     # Add load component at every bus with time-dependent attribute p_set.
     load_names = "load_" + buses
@@ -206,12 +208,14 @@ def test_add_varying_multiple(n_5bus_7sn, slicer):
         p_set=p_set,
     )
 
-    assert len(n_5bus_7sn.loads) == len(load_names)
-    assert n_5bus_7sn.loads.index.name == "name"
-    assert n_5bus_7sn.loads.index.equals(load_names)
-    assert (n_5bus_7sn.loads.bus == buses).all()
+    assert len(n_5bus_7sn.c.loads.static) == len(load_names)
+    assert n_5bus_7sn.c.loads.static.index.name == "name"
+    assert n_5bus_7sn.c.loads.static.index.equals(load_names)
+    assert (n_5bus_7sn.c.loads.static.bus == buses).all()
     assert (n_5bus_7sn.loads_t.p_set == p_set).all().all()
-    assert (n_5bus_7sn.loads.p_set == 0).all()  # Assert that default value is set
+    assert (
+        n_5bus_7sn.c.loads.static.p_set == 0
+    ).all()  # Assert that default value is set
 
     if len(buses) > 1:
         # Test different names shape
@@ -224,7 +228,7 @@ def test_add_varying_multiple(n_5bus_7sn, slicer):
 
 
 def test_add_varying_multiple_with_index(n_5bus_7sn):
-    buses = n_5bus_7sn.buses.index
+    buses = n_5bus_7sn.c.buses.static.index
 
     # Add load component at every bus with time-dependent attribute p_set.
     load_names = "load_" + buses
@@ -241,12 +245,14 @@ def test_add_varying_multiple_with_index(n_5bus_7sn):
         p_set=p_set,
     )
 
-    assert len(n_5bus_7sn.loads) == len(load_names)
-    assert n_5bus_7sn.loads.index.name == "name"
-    assert n_5bus_7sn.loads.index.equals(load_names)
-    assert (n_5bus_7sn.loads.bus == buses).all()
+    assert len(n_5bus_7sn.c.loads.static) == len(load_names)
+    assert n_5bus_7sn.c.loads.static.index.name == "name"
+    assert n_5bus_7sn.c.loads.static.index.equals(load_names)
+    assert (n_5bus_7sn.c.loads.static.bus == buses).all()
     assert (n_5bus_7sn.loads_t.p_set == p_set).all().all()
-    assert (n_5bus_7sn.loads.p_set == 0).all()  # Assert that default value is set
+    assert (
+        n_5bus_7sn.c.loads.static.p_set == 0
+    ).all()  # Assert that default value is set
 
     # Test different names shape
     with pytest.raises(ValueError, match="index which does not align"):
@@ -268,12 +274,12 @@ def test_add_varying_multiple_with_index(n_5bus_7sn):
 def test_add_overwrite_static(n_5bus, caplog):
     n_5bus.add("Bus", [f"bus_{i} " for i in range(6)], x=1)
 
-    assert (n_5bus.buses.iloc[:5].x == 0).all()
-    assert (n_5bus.buses.iloc[5].x == 1).all()
+    assert (n_5bus.c.buses.static.iloc[:5].x == 0).all()
+    assert (n_5bus.c.buses.static.iloc[5].x == 1).all()
     assert caplog.records[-1].levelname == "WARNING"
 
     n_5bus.add("Bus", [f"bus_{i} " for i in range(5)], x=1, overwrite=True)
-    assert (n_5bus.buses.x == 1).all()
+    assert (n_5bus.c.buses.static.x == 1).all()
 
 
 def test_add_overwrite_varying(n_5bus_7sn, caplog):
@@ -344,12 +350,12 @@ def test_multiple_add_defaults(n_5bus):
 
     # TODO: Improve tests since component is the same now
     assert (
-        n_5bus.generators.loc[gen_names[0], "control"]
+        n_5bus.c.generators.static.loc[gen_names[0], "control"]
         == n_5bus.components.Generator.attrs.loc["control", "default"]
     )
 
     assert (
-        n_5bus.loads.loc[line_names[0], "p_set"]
+        n_5bus.c.loads.static.loc[line_names[0], "p_set"]
         == n_5bus.components.Load.attrs.loc["p_set", "default"]
     )
 
@@ -465,8 +471,8 @@ def test_single_add_network_static(ac_dc_network, n_5bus):
     also the buses in the second network
     """
     n = ac_dc_network.merge(n_5bus, with_time=False)
-    new_buses = set(n.buses.index)
-    assert new_buses.issuperset(n_5bus.buses.index)
+    new_buses = set(n.c.buses.static.index)
+    assert new_buses.issuperset(n_5bus.c.buses.static.index)
 
 
 def test_single_add_network_with_time(ac_dc_network, n_5bus):
@@ -484,30 +490,32 @@ def test_single_add_network_with_time(ac_dc_network, n_5bus):
 
     n_5bus.set_snapshots(ac_dc_network.snapshots)
     n = ac_dc_network.merge(n_5bus, with_time=True)
-    new_buses = set(n.buses.index)
-    assert new_buses.issuperset(n_5bus.buses.index)
+    new_buses = set(n.c.buses.static.index)
+    assert new_buses.issuperset(n_5bus.c.buses.static.index)
 
 
 def test_shape_reprojection(ac_dc_shapes):
     n = ac_dc_shapes
 
     with pytest.warns(UserWarning):  # noqa
-        area_before = n.shapes.geometry.area.sum()
-    x, y = n.buses.x.values, n.buses.y.values
+        area_before = n.c.shapes.static.geometry.area.sum()
+    x, y = n.c.buses.static.x.values, n.c.buses.static.y.values
 
     n.to_crs("epsg:3035")
 
-    assert n.shapes.crs == "epsg:3035"
+    assert n.c.shapes.static.crs == "epsg:3035"
     assert n.crs == "epsg:3035"
-    assert area_before != n.shapes.geometry.area.sum()
-    assert not np.allclose(x, n.buses.x.values)
-    assert not np.allclose(y, n.buses.y.values)
+    assert area_before != n.c.shapes.static.geometry.area.sum()
+    assert not np.allclose(x, n.c.buses.static.x.values)
+    assert not np.allclose(y, n.c.buses.static.y.values)
 
 
 def test_components_referencing(ac_dc_network):
-    assert id(ac_dc_network.buses) == id(ac_dc_network.components.buses.static)
-    assert id(ac_dc_network.buses_t) == id(ac_dc_network.components.buses.dynamic)
-    assert id(ac_dc_network.components.buses) == id(ac_dc_network.components.Bus)
+    with pypsa.option_context("api.new_components_api", False):
+        ac_dc_network = pypsa.examples.ac_dc_meshed()
+        assert id(ac_dc_network.buses) == id(ac_dc_network.components.buses.static)
+        assert id(ac_dc_network.buses_t) == id(ac_dc_network.components.buses.dynamic)
+        assert id(ac_dc_network.components.buses) == id(ac_dc_network.components.Bus)
 
 
 @pytest.mark.parametrize("use_component", [True, False])

--- a/test/test_network_cycles.py
+++ b/test/test_network_cycles.py
@@ -301,7 +301,7 @@ def test_weighted_cycles() -> None:
         line_idx = ("Line", line)
         if not (cycles_weighted.loc[line_idx] == 0).all():
             # For AC networks, weight should be the per-unit effective reactance
-            x_value = n.lines.at[line, "x_pu_eff"]
+            x_value = n.c.lines.static.at[line, "x_pu_eff"]
             # Find the column where this line has a non-zero value
             col = cycles_weighted.columns[(cycles_weighted.loc[line_idx] != 0).values][
                 0
@@ -353,6 +353,6 @@ def test_weighted_cycles_dc_network() -> None:
             unweighted_val = cycles_unweighted.loc[line_idx, col]
 
             # For DC, weighted value should be r_value * unweighted_val
-            r_value = n.lines.at[line, "r_pu_eff"]
+            r_value = n.c.lines.static.at[line, "r_pu_eff"]
             weighted_val = cycles_weighted.loc[line_idx, col]
             assert np.isclose(weighted_val, r_value * unweighted_val)

--- a/test/test_optimization_expressions.py
+++ b/test/test_optimization_expressions.py
@@ -29,8 +29,10 @@ AGGREGRATE_TIME_PARAMETERS = ["sum", "mean", None]
 def prepared_network(ac_dc_network):
     n = ac_dc_network.copy()
     n.optimize.create_model()
-    n.lines["carrier"] = n.lines.bus0.map(n.buses.carrier)
-    n.generators.loc[n.generators.index[0], "p_nom_extendable"] = False
+    n.c.lines.static["carrier"] = n.c.lines.static.bus0.map(n.c.buses.static.carrier)
+    n.c.generators.static.loc[n.c.generators.static.index[0], "p_nom_extendable"] = (
+        False
+    )
     return n
 
 
@@ -38,8 +40,10 @@ def prepared_network(ac_dc_network):
 def prepared_network_with_snapshot_subset(ac_dc_network):
     n = ac_dc_network.copy()
     n.optimize.create_model(snapshots=n.snapshots[:2])
-    n.lines["carrier"] = n.lines.bus0.map(n.buses.carrier)
-    n.generators.loc[n.generators.index[0], "p_nom_extendable"] = False
+    n.c.lines.static["carrier"] = n.c.lines.static.bus0.map(n.c.buses.static.carrier)
+    n.c.generators.static.loc[n.c.generators.static.index[0], "p_nom_extendable"] = (
+        False
+    )
     return n
 
 

--- a/test/test_pf_activity_mask.py
+++ b/test/test_pf_activity_mask.py
@@ -4,14 +4,14 @@ import pytest
 @pytest.fixture
 def sub_network_full(scipy_network):
     n = scipy_network.copy()
-    return n.sub_networks.obj.iloc[0]
+    return n.c.sub_networks.static.obj.iloc[0]
 
 
 @pytest.fixture
 def sub_network_filtered(scipy_network):
     n = scipy_network.copy()
-    n.lines.loc["2", "active"] = False
-    return n.sub_networks.obj.iloc[0]
+    n.c.lines.static.loc["2", "active"] = False
+    return n.c.sub_networks.static.obj.iloc[0]
 
 
 def test_different_shape_incidence_matrix(sub_network_full, sub_network_filtered):
@@ -29,4 +29,4 @@ def test_subnetwork_full_pf(sub_network_full):
 def test_subnetwork_filtered_pf(sub_network_filtered):
     sub_network_filtered.pf(sub_network_filtered.snapshots[:3])
     n = sub_network_filtered.n
-    assert n.lines_t.p0.loc[:, ~n.lines.active].eq(0).all().all()
+    assert n.c.lines.dynamic.p0.loc[:, ~n.c.lines.static.active].eq(0).all().all()

--- a/test/test_pf_against_pandapower.py
+++ b/test/test_pf_against_pandapower.py
@@ -35,22 +35,25 @@ def test_pandapower_custom_case(
     net.res_line.index = net.line.name.values
 
     # compare bus angles
-    equal(n.buses_t.v_ang.loc[DEFAULT_TIMESTAMP] * 180 / np.pi, net.res_bus.va_degree)
+    equal(
+        n.c.buses.dynamic.v_ang.loc[DEFAULT_TIMESTAMP] * 180 / np.pi,
+        net.res_bus.va_degree,
+    )
 
     # compare bus voltage magnitudes
-    equal(n.buses_t.v_mag_pu.loc[DEFAULT_TIMESTAMP], net.res_bus.vm_pu)
+    equal(n.c.buses.dynamic.v_mag_pu.loc[DEFAULT_TIMESTAMP], net.res_bus.vm_pu)
 
     # compare bus active power (NB: pandapower uses load signs)
-    equal(n.buses_t.p.loc[DEFAULT_TIMESTAMP], -net.res_bus.p_mw)
+    equal(n.c.buses.dynamic.p.loc[DEFAULT_TIMESTAMP], -net.res_bus.p_mw)
 
     # compare bus active power (NB: pandapower uses load signs)
-    equal(n.buses_t.q.loc[DEFAULT_TIMESTAMP], -net.res_bus.q_mvar)
+    equal(n.c.buses.dynamic.q.loc[DEFAULT_TIMESTAMP], -net.res_bus.q_mvar)
 
     # compare branch flows
-    equal(n.lines_t.p0.loc[DEFAULT_TIMESTAMP], net.res_line.p_from_mw)
-    equal(n.lines_t.p1.loc[DEFAULT_TIMESTAMP], net.res_line.p_to_mw)
-    equal(n.lines_t.q0.loc[DEFAULT_TIMESTAMP], net.res_line.q_from_mvar)
-    equal(n.lines_t.q1.loc[DEFAULT_TIMESTAMP], net.res_line.q_to_mvar)
+    equal(n.c.lines.dynamic.p0.loc[DEFAULT_TIMESTAMP], net.res_line.p_from_mw)
+    equal(n.c.lines.dynamic.p1.loc[DEFAULT_TIMESTAMP], net.res_line.p_to_mw)
+    equal(n.c.lines.dynamic.q0.loc[DEFAULT_TIMESTAMP], net.res_line.q_from_mvar)
+    equal(n.c.lines.dynamic.q1.loc[DEFAULT_TIMESTAMP], net.res_line.q_to_mvar)
 
     equal(n.transformers_t.p0.loc[DEFAULT_TIMESTAMP], net.res_trafo.p_hv_mw)
     equal(n.transformers_t.p1.loc[DEFAULT_TIMESTAMP], net.res_trafo.p_lv_mw)

--- a/test/test_pf_against_pandapower.py
+++ b/test/test_pf_against_pandapower.py
@@ -55,7 +55,7 @@ def test_pandapower_custom_case(
     equal(n.c.lines.dynamic.q0.loc[DEFAULT_TIMESTAMP], net.res_line.q_from_mvar)
     equal(n.c.lines.dynamic.q1.loc[DEFAULT_TIMESTAMP], net.res_line.q_to_mvar)
 
-    equal(n.transformers_t.p0.loc[DEFAULT_TIMESTAMP], net.res_trafo.p_hv_mw)
-    equal(n.transformers_t.p1.loc[DEFAULT_TIMESTAMP], net.res_trafo.p_lv_mw)
-    equal(n.transformers_t.q0.loc[DEFAULT_TIMESTAMP], net.res_trafo.q_hv_mvar)
-    equal(n.transformers_t.q1.loc[DEFAULT_TIMESTAMP], net.res_trafo.q_lv_mvar)
+    equal(n.c.transformers.dynamic.p0.loc[DEFAULT_TIMESTAMP], net.res_trafo.p_hv_mw)
+    equal(n.c.transformers.dynamic.p1.loc[DEFAULT_TIMESTAMP], net.res_trafo.p_lv_mw)
+    equal(n.c.transformers.dynamic.q0.loc[DEFAULT_TIMESTAMP], net.res_trafo.q_hv_mvar)
+    equal(n.c.transformers.dynamic.q1.loc[DEFAULT_TIMESTAMP], net.res_trafo.q_lv_mvar)

--- a/test/test_pf_against_pypower.py
+++ b/test/test_pf_against_pypower.py
@@ -95,7 +95,7 @@ def test_pypower_case():
 
     # PYPOWER uses PI model for transformers, whereas PyPSA defaults to
     # T since version 0.8.0
-    n.transformers.model = "pi"
+    n.c.transformers.static.model = "pi"
 
     n.pf()
 
@@ -113,12 +113,12 @@ def test_pypower_case():
         equal(s_pypsa, s_pypower)
 
     # compare voltages
-    v_mag_pypsa = n.buses_t.v_mag_pu.loc[DEFAULT_TIMESTAMP]
+    v_mag_pypsa = n.c.buses.dynamic.v_mag_pu.loc[DEFAULT_TIMESTAMP]
     v_mag_pypower = results_df["bus"]["v_mag_pu"]
 
     equal(v_mag_pypsa, v_mag_pypower)
 
-    v_ang_pypsa = n.buses_t.v_ang.loc[DEFAULT_TIMESTAMP]
+    v_ang_pypsa = n.c.buses.dynamic.v_ang.loc[DEFAULT_TIMESTAMP]
     pypower_slack_angle = results_df["bus"]["v_ang"][
         results_df["bus"]["type"] == 3
     ].values[0]

--- a/test/test_pf_against_pypower.py
+++ b/test/test_pf_against_pypower.py
@@ -108,7 +108,7 @@ def test_pypower_case():
 
     # compare generator dispatch
     for s in ["p", "q"]:
-        s_pypsa = getattr(n.generators_t, s).loc[DEFAULT_TIMESTAMP].values
+        s_pypsa = getattr(n.c.generators.dynamic, s).loc[DEFAULT_TIMESTAMP].values
         s_pypower = results_df["gen"][s].values
         equal(s_pypsa, s_pypower)
 

--- a/test/test_pf_distributed_slack.py
+++ b/test/test_pf_distributed_slack.py
@@ -17,8 +17,8 @@ def test_pf_distributed_slack(scipy_network):
     n.optimize(n.snapshots)
 
     # For the PF, set the P to the optimised P
-    n.generators_t.p_set = n.generators_t.p
-    n.storage_units_t.p_set = n.storage_units_t.p
+    n.c.generators.dynamic.p_set = n.c.generators.dynamic.p
+    n.c.storage_units.dynamic.p_set = n.c.storage_units.dynamic.p
 
     # set all buses to PV, since we don't know what Q set points are
     n.c.generators.static.control = "PV"
@@ -30,16 +30,16 @@ def test_pf_distributed_slack(scipy_network):
     n.pf(distribute_slack=True, slack_weights="p_set")
 
     equal(
-        n.generators_t.p_set.apply(normed, axis=1),
-        (n.generators_t.p - n.generators_t.p_set).apply(normed, axis=1),
+        n.c.generators.dynamic.p_set.apply(normed, axis=1),
+        (n.c.generators.dynamic.p - n.c.generators.dynamic.p_set).apply(normed, axis=1),
     )
 
     # by capacity
     n.pf(distribute_slack=True, slack_weights="p_nom")
 
-    slack_shares_by_capacity = (n.generators_t.p - n.generators_t.p_set).apply(
-        normed, axis=1
-    )
+    slack_shares_by_capacity = (
+        n.c.generators.dynamic.p - n.c.generators.dynamic.p_set
+    ).apply(normed, axis=1)
 
     for _, row in slack_shares_by_capacity.iterrows():
         equal(n.c.generators.static.p_nom.pipe(normed).fillna(0.0), row)
@@ -61,7 +61,7 @@ def test_pf_distributed_slack(scipy_network):
 
     equal(
         slack_shares_by_capacity,
-        (n.generators_t.p - n.generators_t.p_set).apply(normed, axis=1),
+        (n.c.generators.dynamic.p - n.c.generators.dynamic.p_set).apply(normed, axis=1),
     )
 
     custom_weights = {
@@ -72,5 +72,5 @@ def test_pf_distributed_slack(scipy_network):
 
     equal(
         slack_shares_by_capacity,
-        (n.generators_t.p - n.generators_t.p_set).apply(normed, axis=1),
+        (n.c.generators.dynamic.p - n.c.generators.dynamic.p_set).apply(normed, axis=1),
     )

--- a/test/test_sclopf_scigrid.py
+++ b/test/test_sclopf_scigrid.py
@@ -33,8 +33,8 @@ def test_optimize_security_constrained(scipy_network):
     )
 
     # For the PF, set the P to the optimised P
-    n.generators_t.p_set = n.generators_t.p.copy()
-    n.storage_units_t.p_set = n.storage_units_t.p.copy()
+    n.c.generators.dynamic.p_set = n.c.generators.dynamic.p.copy()
+    n.c.storage_units.dynamic.p_set = n.c.storage_units.dynamic.p.copy()
 
     # Check no lines are overloaded with the linear contingency analysis
     p0_test = n.lpf_contingency(n.snapshots[0], branch_outages=branch_outages)

--- a/test/test_sclopf_scigrid.py
+++ b/test/test_sclopf_scigrid.py
@@ -9,10 +9,10 @@ def test_optimize_security_constrained(scipy_network):
 
     # There are some infeasibilities without line extensions
     for line_name in ["316", "527", "602"]:
-        n.lines.loc[line_name, "s_nom"] = 1200
+        n.c.lines.static.loc[line_name, "s_nom"] = 1200
 
     # Choose the contingencies
-    branch_outages = n.lines.index[:2]
+    branch_outages = n.c.lines.static.index[:2]
 
     # # Run security-constrained optimization with dual assignment
     # # Fight numerical instability using https://ergo-code.github.io/HiGHS/
@@ -50,11 +50,17 @@ def test_optimize_security_constrained(scipy_network):
     # === Dual variable assignment checks ===
 
     # Verify that marginal prices are assigned (nodal balance duals)
-    assert hasattr(n.buses_t, "marginal_price"), "Marginal prices should be assigned"
-    assert not n.buses_t.marginal_price.empty, "Marginal prices should not be empty"
+    assert hasattr(n.c.buses.dynamic, "marginal_price"), (
+        "Marginal prices should be assigned"
+    )
+    assert not n.c.buses.dynamic.marginal_price.empty, (
+        "Marginal prices should not be empty"
+    )
 
-    # Check that line constraint duals are assigned to n.lines_t.mu_*
-    line_dual_attrs = [attr for attr in n.lines_t.keys() if attr.startswith("mu_")]
+    # Check that line constraint duals are assigned to n.c.lines.dynamic.mu_*
+    line_dual_attrs = [
+        attr for attr in n.c.lines.dynamic.keys() if attr.startswith("mu_")
+    ]
 
     # Verify that standard line duals are assigned
     assert "mu_lower" in line_dual_attrs, "mu_lower should be assigned"

--- a/test/test_spatial_clustering.py
+++ b/test/test_spatial_clustering.py
@@ -36,7 +36,7 @@ def test_aggregate_generators(ac_dc_network):
     )
     assert np.allclose(
         dynamic["p_max_pu"]["all wind"],
-        (n.generators_t.p_max_pu * capacity_norm).sum(axis=1),
+        (n.c.generators.dynamic.p_max_pu * capacity_norm).sum(axis=1),
     )
     assert np.allclose(
         df.loc["all wind", "marginal_cost"],
@@ -66,7 +66,7 @@ def test_aggregate_generators_custom_strategies(ac_dc_network):
         == n.c.generators.static.loc["Frankfurt Wind", "p_nom_max"] * 3
     )
     assert np.allclose(
-        dynamic["p_max_pu"]["all wind"], n.generators_t.p_max_pu.max(axis=1)
+        dynamic["p_max_pu"]["all wind"], n.c.generators.dynamic.p_max_pu.max(axis=1)
     )
 
 

--- a/test/test_spatial_clustering.py
+++ b/test/test_spatial_clustering.py
@@ -19,47 +19,51 @@ from pypsa.clustering.spatial import (
 
 def test_aggregate_generators(ac_dc_network):
     n = ac_dc_network
-    busmap = pd.Series("all", n.buses.index)
+    busmap = pd.Series("all", n.c.buses.static.index)
     df, dynamic = aggregateoneport(n, busmap, "Generator")
 
     assert (
-        df.loc["all gas", "p_nom"] == n.generators.query("carrier == 'gas'").p_nom.sum()
+        df.loc["all gas", "p_nom"]
+        == n.c.generators.static.query("carrier == 'gas'").p_nom.sum()
     )
     assert (
         df.loc["all wind", "p_nom"]
-        == n.generators.query("carrier == 'wind'").p_nom.sum()
+        == n.c.generators.static.query("carrier == 'wind'").p_nom.sum()
     )
 
-    capacity_norm = normed_or_uniform(n.generators.query("carrier == 'wind'").p_nom)
+    capacity_norm = normed_or_uniform(
+        n.c.generators.static.query("carrier == 'wind'").p_nom
+    )
     assert np.allclose(
         dynamic["p_max_pu"]["all wind"],
         (n.generators_t.p_max_pu * capacity_norm).sum(axis=1),
     )
     assert np.allclose(
         df.loc["all wind", "marginal_cost"],
-        (n.generators.marginal_cost * capacity_norm).sum(),
+        (n.c.generators.static.marginal_cost * capacity_norm).sum(),
     )
 
 
 def test_aggregate_generators_custom_strategies(ac_dc_network):
     n = ac_dc_network
-    n.generators.loc["Frankfurt Wind", "p_nom_max"] = 100
+    n.c.generators.static.loc["Frankfurt Wind", "p_nom_max"] = 100
 
-    busmap = pd.Series("all", n.buses.index)
+    busmap = pd.Series("all", n.c.buses.static.index)
 
     strategies = {"p_max_pu": "max", "p_nom_max": "weighted_min"}
     df, dynamic = aggregateoneport(n, busmap, "Generator", custom_strategies=strategies)
 
     assert (
-        df.loc["all gas", "p_nom"] == n.generators.query("carrier == 'gas'").p_nom.sum()
+        df.loc["all gas", "p_nom"]
+        == n.c.generators.static.query("carrier == 'gas'").p_nom.sum()
     )
     assert (
         df.loc["all wind", "p_nom"]
-        == n.generators.query("carrier == 'wind'").p_nom.sum()
+        == n.c.generators.static.query("carrier == 'wind'").p_nom.sum()
     )
     assert (
         df["p_nom_max"]["all wind"]
-        == n.generators.loc["Frankfurt Wind", "p_nom_max"] * 3
+        == n.c.generators.static.loc["Frankfurt Wind", "p_nom_max"] * 3
     )
     assert np.allclose(
         dynamic["p_max_pu"]["all wind"], n.generators_t.p_max_pu.max(axis=1)
@@ -76,7 +80,7 @@ def test_aggregate_generators_consent_error(ac_dc_network):
         p_nom_extendable=False,
     )
 
-    busmap = pd.Series("all", n.buses.index)
+    busmap = pd.Series("all", n.c.buses.static.index)
 
     with pytest.raises(ValueError):
         df, dynamic = aggregateoneport(n, busmap, "Generator")
@@ -106,21 +110,24 @@ def test_aggregate_storage_units(ac_dc_network):
         capital_cost=50,
     )
 
-    busmap = pd.Series("all", n.buses.index)
+    busmap = pd.Series("all", n.c.buses.static.index)
     df, dynamic = aggregateoneport(n, busmap, "StorageUnit")
-    capacity_norm = normed_or_uniform(n.storage_units.p_nom)
+    capacity_norm = normed_or_uniform(n.c.storage_units.static.p_nom)
 
-    assert df.loc["all", "p_nom"] == n.storage_units.p_nom.sum()
-    assert df.loc["all", "p_nom_extendable"] == n.storage_units.p_nom_extendable.all()
-    assert df.loc["all", "p_nom_min"] == n.storage_units.p_nom_min.sum()
-    assert df.loc["all", "p_nom_max"] == n.storage_units.p_nom_max.sum()
+    assert df.loc["all", "p_nom"] == n.c.storage_units.static.p_nom.sum()
+    assert (
+        df.loc["all", "p_nom_extendable"]
+        == n.c.storage_units.static.p_nom_extendable.all()
+    )
+    assert df.loc["all", "p_nom_min"] == n.c.storage_units.static.p_nom_min.sum()
+    assert df.loc["all", "p_nom_max"] == n.c.storage_units.static.p_nom_max.sum()
     assert (
         df.loc["all", "marginal_cost"]
-        == (n.storage_units.marginal_cost * capacity_norm).sum()
+        == (n.c.storage_units.static.marginal_cost * capacity_norm).sum()
     )
     assert (
         df.loc["all", "capital_cost"]
-        == (n.storage_units.capital_cost * capacity_norm).sum()
+        == (n.c.storage_units.static.capital_cost * capacity_norm).sum()
     )
 
 
@@ -130,16 +137,20 @@ def test_aggregate_storage_units_consent_error(ac_dc_network):
 
 
 def prepare_network_for_aggregation(n):
-    n.lines = n.lines.reindex(columns=n.components["Line"]["attrs"].index[1:])
-    n.lines["type"] = np.nan
-    n.buses = n.buses.reindex(columns=n.components["Bus"]["attrs"].index[1:])
-    n.buses["frequency"] = 50
+    n.c.lines.static = n.c.lines.static.reindex(
+        columns=n.components["Line"]["attrs"].index[1:]
+    )
+    n.c.lines.static["type"] = np.nan
+    n.c.buses.static = n.c.buses.static.reindex(
+        columns=n.components["Bus"]["attrs"].index[1:]
+    )
+    n.c.buses.static["frequency"] = 50
 
 
 def test_default_clustering_k_means(scipy_network):
     n = scipy_network
     prepare_network_for_aggregation(n)
-    weighting = pd.Series(1, n.buses.index)
+    weighting = pd.Series(1, n.c.buses.static.index)
     busmap = busmap_by_kmeans(n, bus_weightings=weighting, n_clusters=50)
     C = get_clustering_from_busmap(n, busmap)
     nc = C.n
@@ -159,7 +170,7 @@ def test_cluster_accessor(scipy_network):
     n = scipy_network
     prepare_network_for_aggregation(n)
 
-    weighting = pd.Series(1, n.buses.index)
+    weighting = pd.Series(1, n.c.buses.static.index)
     busmap = n.cluster.busmap_by_kmeans(
         bus_weightings=weighting, n_clusters=50, random_state=42
     )
@@ -175,12 +186,14 @@ def test_custom_line_groupers(scipy_network):
     n = scipy_network
     random_build_years = [1900, 2000]
     rng = np.random.default_rng()
-    n.lines.loc[:, "build_year"] = rng.choice(random_build_years, size=len(n.lines))
+    n.c.lines.static.loc[:, "build_year"] = rng.choice(
+        random_build_years, size=len(n.c.lines.static)
+    )
     prepare_network_for_aggregation(n)
-    weighting = pd.Series(1, n.buses.index)
+    weighting = pd.Series(1, n.c.buses.static.index)
     busmap = busmap_by_kmeans(n, bus_weightings=weighting, n_clusters=20)
     C = get_clustering_from_busmap(n, busmap, custom_line_groupers=["build_year"])
     linemap = C.linemap
     nc = C.n
     assert len(nc.buses) == 20
-    assert (n.lines.groupby(linemap).build_year.nunique() == 1).all()
+    assert (n.c.lines.static.groupby(linemap).build_year.nunique() == 1).all()

--- a/test/test_stand_by_cost.py
+++ b/test/test_stand_by_cost.py
@@ -43,9 +43,9 @@ def test_stand_by_cost():
     n.optimize()
 
     cost = (
-        n.generators_t.p * n.c.generators.static.marginal_cost
+        n.c.generators.dynamic.p * n.c.generators.static.marginal_cost
         + (
-            n.generators_t.status.reindex(
+            n.c.generators.dynamic.status.reindex(
                 columns=n.c.generators.static.index, fill_value=0
             )
             * n.c.generators.static.stand_by_cost

--- a/test/test_stand_by_cost.py
+++ b/test/test_stand_by_cost.py
@@ -43,10 +43,12 @@ def test_stand_by_cost():
     n.optimize()
 
     cost = (
-        n.generators_t.p * n.generators.marginal_cost
+        n.generators_t.p * n.c.generators.static.marginal_cost
         + (
-            n.generators_t.status.reindex(columns=n.generators.index, fill_value=0)
-            * n.generators.stand_by_cost
+            n.generators_t.status.reindex(
+                columns=n.c.generators.static.index, fill_value=0
+            )
+            * n.c.generators.static.stand_by_cost
         )
     ).mul(n.snapshot_weightings.objective, axis=0)
 

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -165,11 +165,11 @@ def test_opex():
     assert opex.loc["Generator", "gen"] == 2 * 2 * 5 + 2 * 0.2 * 5**2
     assert opex.loc["StorageUnit", "su"] == 2 * 20 * 2
 
-    n.generators.marginal_cost_quadratic = 0
-    n.generators.committable = True
-    n.generators.start_up_cost = 4
-    n.generators.shut_down_cost = 5
-    n.generators.stand_by_cost = 9
+    n.c.generators.static.marginal_cost_quadratic = 0
+    n.c.generators.static.committable = True
+    n.c.generators.static.start_up_cost = 4
+    n.c.generators.static.shut_down_cost = 5
+    n.c.generators.static.stand_by_cost = 9
 
     n.optimize()
 
@@ -292,16 +292,16 @@ def test_inactive_exclusion_in_static(ac_dc_network_r):
     df = n.statistics()
     assert "Line" in df.index.unique(0)
 
-    n.lines["active"] = False
+    n.c.lines.static["active"] = False
     df = n.statistics()
     assert "Line" not in df.index.unique(0)
 
-    n.lines["active"] = True
+    n.c.lines.static["active"] = True
 
 
 def test_transmission_carriers(ac_dc_network_r):
     n = ac_dc_network_r
-    n.lines["carrier"] = "AC"
+    n.c.lines.static["carrier"] = "AC"
     df = pypsa.statistics.get_transmission_carriers(ac_dc_network_r)
     assert "AC" in df.unique(1)
 

--- a/test/test_statistics_plot.py
+++ b/test/test_statistics_plot.py
@@ -189,7 +189,7 @@ def test_consistency_checks(ac_dc_network_r):
     plotter = ChartGenerator(ac_dc_network_r)
     n = ac_dc_network_r.copy()
     plotter = ChartGenerator(n)
-    n.carriers.color = pd.Series()
+    n.c.carriers.static.color = pd.Series()
     # Test with missing carrier colors
     with pytest.raises(ConsistencyError):
         plotter.plot(data=pd.DataFrame(), kind="area", x="carrier", y="value")

--- a/test/test_statistics_plot_interactive.py
+++ b/test/test_statistics_plot_interactive.py
@@ -111,9 +111,9 @@ def test_iplot_stacked_parameter(ac_dc_network_r, stacked):
 def test_iplot_category_orders(ac_dc_network_r):
     """Test creating a plot with specified category orders."""
     # Create plot with specified orders if applicable columns exist
-    carriers = ac_dc_network_r.carriers.index.unique().tolist()
-    buses = ac_dc_network_r.buses.index.unique().tolist()
-    countries = ac_dc_network_r.buses.country.unique().tolist()
+    carriers = ac_dc_network_r.c.carriers.static.index.unique().tolist()
+    buses = ac_dc_network_r.c.buses.static.index.unique().tolist()
+    countries = ac_dc_network_r.c.buses.static.country.unique().tolist()
 
     # Create plot with the available orders
     fig = ac_dc_network_r.statistics.installed_capacity.iplot.bar(

--- a/test/test_subnetwork.py
+++ b/test/test_subnetwork.py
@@ -8,22 +8,22 @@ from pypsa import Network, SubNetwork
 def scipy_subnetwork(scipy_network: Network) -> SubNetwork:
     n = scipy_network
     n.determine_network_topology()
-    return n.sub_networks.obj.iloc[0]
+    return n.c.sub_networks.static.obj.iloc[0]
 
 
 @pytest.fixture
 def ac_dc_subnetwork(ac_dc_network: Network) -> SubNetwork:
     n = ac_dc_network
     n.determine_network_topology()
-    return n.sub_networks.obj.iloc[1]
+    return n.c.sub_networks.static.obj.iloc[1]
 
 
 @pytest.fixture
 def ac_dc_subnetwork_inactive(ac_dc_network: Network) -> SubNetwork:
     n = ac_dc_network
-    n.lines.loc["2", "active"] = False
+    n.c.lines.static.loc["2", "active"] = False
     n.determine_network_topology()
-    return n.sub_networks.obj.iloc[1]
+    return n.c.sub_networks.static.obj.iloc[1]
 
 
 def test_network(scipy_subnetwork: SubNetwork) -> None:
@@ -59,7 +59,7 @@ def test_investment_period_weightings(scipy_subnetwork: SubNetwork) -> None:
 def test_df(scipy_subnetwork: SubNetwork) -> None:
     buses = scipy_subnetwork.static("Bus")
     assert not buses.empty
-    assert buses.index.isin(scipy_subnetwork.n.buses.index).all()
+    assert buses.index.isin(scipy_subnetwork.n.c.buses.static.index).all()
 
     component_names = ["Line", "Transformer", "Generator", "Load"]
     for c_name in component_names:

--- a/test/test_z_docs.py
+++ b/test/test_z_docs.py
@@ -16,6 +16,8 @@ try:
 except ImportError:
     cartopy_available = False
 
+new_api = pypsa.options.api.new_components_api
+
 sub_network_parent = pypsa.examples.ac_dc_meshed().determine_network_topology()
 # Warning: Keep in sync with settings in doc/conf.py
 n = pypsa.examples.ac_dc_meshed()
@@ -28,7 +30,7 @@ doctest_globals = {
     "n": n,
     "c": pypsa.examples.ac_dc_meshed().components.generators,
     "sub_network_parent": pypsa.examples.ac_dc_meshed().determine_network_topology(),
-    "sub_network": sub_network_parent.sub_networks.loc["0", "obj"],
+    "sub_network": sub_network_parent.c.sub_networks.static.loc["0", "obj"],
 }
 
 modules = [
@@ -42,6 +44,7 @@ modules = [
     sys.version_info[:2] == (3, 10),
     reason="Doctest fail until linopy supports numpy 2 on all python versions",
 )
+@pytest.mark.skipif(new_api, reason="New components API not yet shown in docs")
 @pytest.mark.skipif(not cartopy_available, reason="Cartopy not available")
 @pytest.mark.parametrize("module", modules)
 def test_doctest(module):


### PR DESCRIPTION
Follow up on #1235

## Changes proposed in this Pull Request
Let's hope this is one of the last PRs with quite a diff. But this time not very intrusive.

To support both the new and old components APIs, this PR introduces to not using either of them, but rather the never changing class reference in the ComponentsStore.

E.g. PyPSA and all tests work now with
`n.generators` -> Components class
as well as 
`n.generators` -> static df
by just using everywhere:
`n.c.generators` 

Also another Ubuntu CI job is added which runs all tests with the new API
