### PR TITLE
Bugfix: Handle alphanumeric versions (like "1.0.0rc1")

### DIFF
--- a/pypsa/version.py
+++ b/pypsa/version.py
@@ -31,17 +31,58 @@ def check_pypsa_version(version_string: str) -> None:
         )
 
 
+def parse_version_tuple(version_str: str) -> tuple[int | str, ...]:
+    """Parse a semantic version string into a tuple of integers and an optional suffix.
+
+    The function assumes the version string follows a simplified semantic
+    versioning scheme with an optional pre-release suffix (e.g. ``rc1``, ``a2``,
+    ``b3``). It splits the version into its numeric components and, if present,
+    appends the suffix as a string.
+
+    Parameters
+    ----------
+    version_str : str
+        A version string such as ``"1.0.0"``, ``"1.0.0rc1"``, or ``"2.1a2"``.
+
+    Returns
+    -------
+    tuple[int | str, ...]
+        A tuple of integers for the numeric parts, and optionally a string
+        suffix as the last element.
+
+    Examples
+    --------
+    >>> parse_version_tuple("1.0.0")
+    (1, 0, 0)
+    >>> parse_version_tuple("1.0.0rc1")
+    (1, 0, 0, 'rc1')
+    >>> parse_version_tuple("2.1a2")
+    (2, 1, 'a2')
+
+    """
+    # Split into numeric core + optional suffix (rc1, a1, b2, etc.)
+    parts = re.split(r"([a-z]+\d*)", version_str, maxsplit=1)
+
+    # Convert the numeric part into ints
+    numbers = tuple(map(int, parts[0].split(".")))
+
+    # Add suffix back if present
+    if len(parts) > 1 and parts[1]:
+        return numbers + (parts[1],)
+    return numbers
+
+
 # e.g. "0.17.1" or "0.17.1.dev4+ga3890dc0" (if installed from git)
 __version__ = version("pypsa")
 
 # e.g. "0.17.0"
-match = re.match(r"(\d+\.\d+(\.\d+)?)", __version__)
+match = re.match(r"(\d+\.\d+(?:\.\d+)?(?:[a-z]+\d*)?)", __version__)
 if not match:
     msg = f"Could not determine release_version of pypsa: {__version__}"
     raise ValueError(msg)
 
 __version_semver__ = match.group(0)
-__version_semver_tuple__ = tuple(map(int, __version_semver__.split(".")))
+__version_semver_tuple__ = parse_version_tuple(__version_semver__)
 # e.g. "0.17"
 match = re.match(r"(\d+\.\d+)", __version__)
 

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,9 +1,27 @@
-from pypsa.version import check_pypsa_version
+import pytest
+
+from pypsa.version import check_pypsa_version, parse_version_tuple
 
 
 def test_version_check(caplog):
+    caplog.clear()
     check_pypsa_version("0.20.0")
     assert caplog.text == ""
 
+    caplog.clear()
     check_pypsa_version("0.0")
     assert "The correct version of PyPSA could not be resolved" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("version_str", "expected"),
+    [
+        ("1.0.0", (1, 0, 0)),
+        ("1.0.0rc1", (1, 0, 0, "rc1")),
+        ("2.1a2", (2, 1, "a2")),
+        ("0.34.0", (0, 34, 0)),
+        ("0.34.0b1", (0, 34, 0, "b1")),
+    ],
+)
+def test_parse_version_tuple(version_str, expected):
+    assert parse_version_tuple(version_str) == expected


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Making __version_semver__ compatible with alphanumeric versions like `1.0.0rc1` as introduced with latest master.
- Previously, some built-in URLs did not resolve correctly, e.g. `n.examples.scigrid_de()` would be pointing to a URL based on `1.0.0` (which does not exist - yet) instead of `1.0.0rc1` where the actual resources reside.
- Extended unit tests for `test_version.py`

## Checklist
- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [X] Unit tests for new features were added (if applicable).
- [X] I consent to the release of this PR's code under the MIT license.
