### PR TITLE
refactor: resolve deprecations and make components iter compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,7 @@ include = ["pypsa"]
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    # Activate again with final 1.0 release
-    # "error::DeprecationWarning", # Raise all DeprecationWarnings as errors
+    "error::DeprecationWarning", # Raise all DeprecationWarnings as errors
     # "error::FutureWarning",      # Raise all FutureWarnings as errors # TODO Add again
     # "error:RuntimeWarning",
     # "error:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,12 +98,16 @@ include = ["pypsa"]
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    "error::DeprecationWarning", # Raise all DeprecationWarnings as errors
-    # "error::FutureWarning",      # Raise all FutureWarnings as errors # TODO Add again
+    # Raise warnings as errors
+    "error::DeprecationWarning", 
+    # "error::FutureWarning", 
     # "error:RuntimeWarning",
     # "error:UserWarning",
+    
     "ignore::matplotlib._api.deprecation.MatplotlibDeprecationWarning:pydev",
     # See https://github.com/microsoft/debugpy/issues/1623
+    # "ignore:Using merge without specifying the class is deprecated:DeprecationWarning:linopy.*",
+    "ignore::DeprecationWarning:linopy.*",
 ]
 markers = [
     "mpl_image_compare",

--- a/pypsa/collection.py
+++ b/pypsa/collection.py
@@ -340,6 +340,7 @@ def _get_method_patterns() -> dict[str, str]:
         "vertical_concat": rf"^("
         rf"({_all_components if not new_api else ''})|"
         rf"({_component_classes}.static)|"
+        rf"({_component_classes}.get_active_assets)|"
         rf"static|"
         rf"get_active_assets"
         rf")$",

--- a/pypsa/components/store.py
+++ b/pypsa/components/store.py
@@ -166,8 +166,15 @@ class ComponentsStore(dict):
         return dict_keys + obj_attrs
 
     def __iter__(self) -> Any:
-        """Value iterator over components in store."""
-        return iter(self.values())
+        """Value iterator over components in store.
+
+        Filters out empty components to maintain backward compatibility with
+        n.iterate_components() behavior. For accessing all components including
+        empty ones, use n.components.values() directly instead of iterating over the
+        store.
+        """
+        # Filter to only return non-empty components (same behavior as iterate_components)
+        return iter(c for c in self.values() if not c.empty)
 
     def __contains__(self, item: Any) -> bool:
         """Check if component is in store."""

--- a/pypsa/components/transform.py
+++ b/pypsa/components/transform.py
@@ -201,7 +201,7 @@ class ComponentsTransformMixin:
 
         # Rename cross references in network (if attached to one)
         if self.attached:
-            for component in self.n_save.components.values():
+            for component in self.n_save.components:
                 col_name = self.name.lower()  # TODO: Generalize
                 cols = [f"{col_name}{port}" for port in component.ports]
                 if cols and not component.static.empty:

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -278,10 +278,10 @@ def _update_linkports_component_attrs(
             .apply(_update_linkports_doc_changes, args=("1", i))
         )
         # Also update container for varying attributes
-        if attr in ["efficiency", "p"] and target not in n.dynamic(c):
+        if attr in ["efficiency", "p"] and target not in n.c[c].dynamic:
             df = pd.DataFrame(
                 index=n.snapshots, columns=n.c.links.static.index[:0], dtype=float
             )
-            n.dynamic(c)[target] = df
-        elif attr == "bus" and target not in n.static(c).columns:
-            n.static(c)[target] = n.components[c]["attrs"].loc[target, "default"]
+            n.c[c].dynamic[target] = df
+        elif attr == "bus" and target not in n.c[c].static.columns:
+            n.c[c].static[target] = n.components[c]["attrs"].loc[target, "default"]

--- a/pypsa/examples.py
+++ b/pypsa/examples.py
@@ -208,7 +208,9 @@ def carbon_management() -> Network:
     https://doi.org/10.1038/s41560-025-01752-6
 
     """
-    primary_url = "https://tubcloud.tu-berlin.de/s/3qZPGxW3r4HF9Hn/download?path=%2F&files=carbon-management.nc"
+    primary_url = (
+        "https://tubcloud.tu-berlin.de/s/b37rfZrBymTFpZ4/download/carbon-management.nc"
+    )
 
     if _check_url_availability(primary_url):
         return Network(primary_url)

--- a/pypsa/network/descriptors.py
+++ b/pypsa/network/descriptors.py
@@ -171,8 +171,8 @@ class NetworkDescriptorsMixin(_NetworkABC):
         dtype: float64
 
         """
-        static = self.static(component)
-        dynamic = self.dynamic(component)
+        static = self.c[component].static
+        dynamic = self.c[component].dynamic
 
         index = static.index
         varying_i = dynamic[attr].columns

--- a/pypsa/network/index.py
+++ b/pypsa/network/index.py
@@ -115,7 +115,7 @@ class NetworkIndexMixin(_NetworkABC):
             )
 
         for component in self.all_components:
-            dynamic = self.dynamic(component)
+            dynamic = self.c[component].dynamic
             attrs = self.components[component]["attrs"]
 
             for k in dynamic:
@@ -331,7 +331,7 @@ class NetworkIndexMixin(_NetworkABC):
             )
             names = ["period", "timestep"]
             for component in self.all_components:
-                dynamic = self.dynamic(component)
+                dynamic = self.c[component].dynamic
 
                 for k in dynamic:
                     dynamic[k] = pd.concat(
@@ -714,7 +714,7 @@ class NetworkIndexMixin(_NetworkABC):
         scenarios_.index = scenarios_.index.astype(str)
         scenarios_.index.name = "scenario"
 
-        for c in self.components.values():
+        for c in self.components.values():  # Loop all components, not just empty ones
             c.static = pd.concat(
                 dict.fromkeys(scenarios_.index, c.static), names=["scenario"]
             )

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -219,7 +219,7 @@ class Network(
         header = f"{self}\n" + "-" * len(str(self))  # + "\n"
         comps = {
             c.name: f" - {c.name}: {len(c.static)}"
-            for c in self.iterate_components()
+            for c in self.components
             if "Type" not in c.name and len(c.static)
         }
         content = "\nComponents:"
@@ -594,8 +594,8 @@ class Network(
         [pypsa.Network.shapes][] : Geometries of the network
 
         """
-        self.components.shapes.static.set_crs(new)
-        self._crs = self.components.shapes.static.crs
+        self.c.shapes.static.set_crs(new)
+        self._crs = self.c.shapes.static.crs
 
     def to_crs(self, new: int | str | pyproj.CRS) -> None:
         """Convert the network's geometries and bus coordinates to a new crs.
@@ -739,8 +739,9 @@ class Network(
 
         # Copy components
         other_comps = sorted(self.all_components - {"Bus", "Carrier"})
-        # Needs to copy buses and carriers first, since there are dependencies on them
-        for component in self.iterate_components(["Bus", "Carrier"] + other_comps):
+        for component in self.components:
+            if component.name not in ["Bus", "Carrier"] + other_comps:
+                continue
             # Drop the standard types to avoid them being read in twice
             if (
                 not ignore_standard_types
@@ -839,21 +840,25 @@ class Network(
             - self.branch_components
         )
         for c in rest_components - {"Bus", "SubNetwork"}:
-            n.add(c, pd.DataFrame(self.static(c)).index, **pd.DataFrame(self.static(c)))
+            n.add(
+                c,
+                pd.DataFrame(self.c[c].static).index,
+                **pd.DataFrame(self.c[c].static),
+            )
 
         for c in self.standard_type_components:
             static = pd.DataFrame(
-                self.static(c).drop(self.components[c]["standard_types"].index)
+                self.c[c].static.drop(self.components[c]["standard_types"].index)
             )
             n.add(c, static.index, **static)
 
         for c in self.one_port_components:
-            static = pd.DataFrame(self.static(c).loc[lambda df: df.bus.isin(buses_i)])
+            static = pd.DataFrame(self.c[c].static.loc[lambda df: df.bus.isin(buses_i)])
             n.add(c, static.index, **static)
 
         for c in self.branch_components:
             static = pd.DataFrame(
-                self.static(c).loc[
+                self.c[c].static.loc[
                     lambda df: df.bus0.isin(buses_i) & df.bus1.isin(buses_i)
                 ]
             )
@@ -861,10 +866,10 @@ class Network(
 
         n.set_snapshots(self.snapshots[time_i])
         for c in self.all_components:
-            i = n.static(c).index
+            i = n.c[c].static.index
             try:
-                ndynamic = n.dynamic(c)
-                dynamic = self.dynamic(c)
+                ndynamic = n.c[c].dynamic
+                dynamic = self.c[c].dynamic
 
                 for k in dynamic:
                     ndynamic[k] = dynamic[k].loc[
@@ -892,7 +897,7 @@ class Network(
             List of empty components.
 
         """
-        return [c.name for c in self.iterate_components() if c.empty]
+        return [c.name for c in self.components if c.empty]
 
     def branches(self) -> pd.DataFrame:
         """Get branches.
@@ -936,7 +941,7 @@ class Network(
             else ["component", "name"]
         )
         return pd.concat(
-            (self.static(c) for c in comps),
+            (self.c[c].static for c in comps),
             keys=comps,
             sort=True,
             names=names,
@@ -976,7 +981,7 @@ class Network(
             else ["component", "name"]
         )
         return pd.concat(
-            (self.static(c) for c in comps),
+            (self.c[c].static for c in comps),
             keys=comps,
             sort=True,
             names=names,
@@ -1021,7 +1026,7 @@ class Network(
             else ["component", "name"]
         )
         return pd.concat(
-            (self.static(c) for c in comps),
+            (self.c[c].static for c in comps),
             keys=comps,
             sort=True,
             names=names,
@@ -1110,11 +1115,13 @@ class Network(
             sub_network_map, "name"
         )[self.c.buses.static.columns]
 
-        for c in self.iterate_components(self.passive_branch_components):
+        for c in self.components:
+            if c.name not in self.passive_branch_components:
+                continue
             c.static["sub_network"] = c.static.bus0.map(sub_network_map)
 
             if investment_period is not None:
-                active = self.get_active_assets(c.name, investment_period)
+                active = c.get_active_assets(investment_period)
                 # set non active assets to NaN
                 c.static.loc[~active, "sub_network"] = np.nan
 
@@ -1212,14 +1219,6 @@ class Network(
         !!! warning "Deprecated in v1.0"
             Use `n.components.<component>` or `n.components[component_name]` instead.
 
-        Examples
-        --------
-        >>> n.component("Bus")
-        'Bus' Components
-        ----------------
-        Attached to PyPSA Network 'AC-DC-Meshed'
-        Components: 9
-
         """
         return self.components[c_name]
 
@@ -1244,9 +1243,9 @@ class Network(
             components = self.all_components
 
         return (
-            self.component(c_name)
+            self.c[c_name]
             for c_name in components
-            if not (skip_empty and self.static(c_name).empty)
+            if not (skip_empty and self.c[c_name].static.empty)
         )
 
 
@@ -1343,14 +1342,14 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
                 if c.name in {"Bus"} | self.n.passive_branch_components:
                     return value[value.sub_network == self.name]
                 if c.name in self.n.one_port_components:
-                    buses = self.buses_i().unique("name")
+                    buses = self.c.buses.static.index.unique("name")
                     return value[value.bus.isin(buses)]
                 msg = f"Component {c.name} not supported for sub-networks"
                 raise ValueError(msg)
             if key == "dynamic":
                 dynamic = Dict()
-                index = self.static(c.name).index
-                for k, v in self.n.dynamic(c.name).items():
+                index = c.static.index
+                for k, v in c.dynamic.items():
                     dynamic[k] = v[index.intersection(v.columns)]
                 return dynamic
             return value
@@ -1467,7 +1466,9 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         """
         types = []
         names = []
-        for c in self.iterate_components(self.n.passive_branch_components):
+        for c in self.components:
+            if c.name not in self.n.passive_branch_components:
+                continue
             static = c.static
             idx = static.query("active").index if active_only else static.index
             types += len(idx) * [c.name]
@@ -1515,7 +1516,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.static][]
 
         """
-        return self.static(c_name)
+        return self.c[c_name].static
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.<c_name>.static` instead.",
@@ -1547,7 +1548,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.dynamic][]
 
         """
-        return self.dynamic(c_name)
+        return self.c[c_name].dynamic
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.<c_name>.dynamic` instead.",
@@ -1579,7 +1580,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.buses][]
 
         """
-        return self.components.buses.static.index
+        return self.c.buses.static.index
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.lines.static.index` instead.",
@@ -1595,7 +1596,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.lines][]
 
         """
-        return self.components.lines.static.index
+        return self.c.lines.static.index
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.transformers.static.index` instead.",
@@ -1611,7 +1612,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.transformers][]
 
         """
-        return self.components.transformers.static.index
+        return self.c.transformers.static.index
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.generators.static.index` instead.",
@@ -1627,7 +1628,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.generators][]
 
         """
-        return self.components.generators.static.index
+        return self.c.generators.static.index
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.loads.static.index` instead.",
@@ -1643,7 +1644,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.loads][]
 
         """
-        return self.components.loads.static.index
+        return self.c.loads.static.index
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.shunt_impedances.static.index` instead.",
@@ -1659,7 +1660,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.shunt_impedances][]
 
         """
-        return self.components.shunt_impedances.static.index
+        return self.c.shunt_impedances.static.index
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.storage_units.static.index` instead.",
@@ -1675,7 +1676,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.storage_units][]
 
         """
-        return self.components.storage_units.static.index
+        return self.c.storage_units.static.index
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.stores.index.static` instead.",
@@ -1691,7 +1692,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.stores][]
 
         """
-        return self.components.stores.static.index
+        return self.c.stores.static.index
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.buses.static` instead.",
@@ -1707,7 +1708,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.buses][]
 
         """
-        return self.components.buses.static
+        return self.c.buses.static
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.generators.static` instead.",
@@ -1723,7 +1724,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.generators][]
 
         """
-        return self.components.generators.static
+        return self.c.generators.static
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.loads.static` instead.",
@@ -1739,7 +1740,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.loads][]
 
         """
-        return self.components.loads.static
+        return self.c.loads.static
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.shunt_impedances.static` instead.",
@@ -1755,7 +1756,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.shunt_impedances][]
 
         """
-        return self.components.shunt_impedances.static
+        return self.c.shunt_impedances.static
 
     @deprecated_in_next_major(
         details="Use `sub_network.components.storage_units.static` instead.",
@@ -1771,7 +1772,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         [pypsa.Network.storage_units][]
 
         """
-        return self.components.storage_units.static
+        return self.c.storage_units.static
 
     @deprecated_in_next_major(
         details="Use `!!! deprecated.components.stores.static` instead.",
@@ -1782,7 +1783,7 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         !!! warning "Deprecated in v1.0"
             Use `sub_network.components.stores.static` instead.
         """
-        return self.components.stores.static
+        return self.c.stores.static
 
     @deprecated_in_next_major(details="Use `self.components` instead.")
     # Deprecate: Use `self.iterate_components` instead
@@ -1816,5 +1817,5 @@ class SubNetwork(NetworkGraphMixin, SubNetworkPowerFlowMixin):
         return (
             self.components[c_name]
             for c_name in components
-            if not (skip_empty and self.static(c_name).empty)
+            if not (skip_empty and self.c[c_name].static.empty)
         )

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -597,16 +597,16 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
             return {"status": status, "terminantion_condition": condition}
 
         for c in n.one_port_components:
-            n.dynamic(c)["p_set"] = n.dynamic(c)["p"]
+            n.c[c].dynamic["p_set"] = n.c[c].dynamic["p"]
         for c in ("Link",):
-            n.dynamic(c)["p_set"] = n.dynamic(c)["p0"]
+            n.c[c].dynamic["p_set"] = n.c[c].dynamic["p0"]
 
         n.c.generators.static.control = "PV"
         for sub_network in n.c.sub_networks.static.obj:
             n.c.generators.static.loc[sub_network.slack_generator, "control"] = "Slack"
         # Need some PQ buses so that Jacobian doesn't break
         for sub_network in n.c.sub_networks.static.obj:
-            generators = sub_network.generators_i()
+            generators = sub_network.c.generators.static.index
             other_generators = generators.difference([sub_network.slack_generator])
             if not other_generators.empty:
                 n.c.generators.static.loc[other_generators[0], "control"] = "PQ"

--- a/pypsa/optimization/common.py
+++ b/pypsa/optimization/common.py
@@ -73,12 +73,7 @@ def get_strongly_meshed_buses(n: Network, threshold: int = 45) -> pd.Series:
 
     """
     all_buses = pd.Series(
-        hstack(
-            [
-                ravel(c.static.filter(regex=RE_PORTS.pattern))
-                for c in n.iterate_components()
-            ]
-        )
+        hstack([ravel(c.static.filter(regex=RE_PORTS.pattern)) for c in n.components])
     )
     all_buses = all_buses[all_buses != ""]
     counts = all_buses.value_counts()

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -883,7 +883,7 @@ def define_nodal_balance_constraints(
     ]
 
     if not links.empty:
-        for i in n.components.links.additional_ports:
+        for i in n.c.links.additional_ports:
             eff_attr = f"efficiency{i}" if i != "1" else "efficiency"
             eff = links.da[eff_attr].sel(snapshot=sns)
             args.append(["Link", "p", f"bus{i}", eff])
@@ -1076,11 +1076,11 @@ def define_fixed_nominal_constraints(n: Network, component: str, attr: str) -> N
     values in their '{attr}_set' attribute.
 
     """
-    if attr + "_set" not in n.static(component):
+    if attr + "_set" not in n.c[component].static:
         return
 
     dim = f"{component}-{attr}_set_i"
-    fix = n.static(component)[attr + "_set"].dropna().rename_axis(dim)
+    fix = n.c[component].static[attr + "_set"].dropna().rename_axis(dim)
 
     if fix.empty:
         return

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -65,7 +65,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
         elif isinstance(by, pd.Series):
             grouper = by.to_frame()
         elif groupby is False:
-            grouper = pd.DataFrame(index=n.df(c).index)
+            grouper = pd.DataFrame(index=n.c[c].static.index)
         else:
             grouper = by
 
@@ -190,8 +190,8 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             capacity = m.variables[f"{c}-{nominal_attrs[c]}"]
             if include_non_extendable:
                 query = f"~{nominal_attrs[c]}_extendable"
-                capacity = capacity + n.df(c).query(query)["p_nom"]
-            costs = n.df(c)[cost_attribute][capacity.indexes["name"]]
+                capacity = capacity + n.c[c].static.query(query)["p_nom"]
+            costs = n.c[c].static[cost_attribute][capacity.indexes["name"]]
             return capacity * costs
 
         return self._aggregate_components(
@@ -242,7 +242,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             capacity = m.variables[f"{c}-{nominal_attrs[c]}"]
             if include_non_extendable:
                 query = f"~{attr}_extendable"
-                capacity = capacity + n.df(c).query(query)[attr]
+                capacity = capacity + n.c[c].static.query(query)[attr]
             efficiency = port_efficiency(n, c, port=port)[capacity.indexes["name"]]
             if not at_port:
                 efficiency = abs(efficiency)
@@ -425,7 +425,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             efficiency = port_efficiency(n, c, port=port, dynamic=True)
             if isinstance(efficiency, pd.DataFrame):
                 efficiency = efficiency.loc[sns]
-            sign = n.df(c).get("sign", 1.0)
+            sign = n.c[c].static.get("sign", 1.0)
             weights = n.snapshot_weightings.generators.loc[sns]
             coeffs = DataArray(efficiency * sign)
             if kind == "supply":
@@ -564,7 +564,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             attr = nominal_attrs[c]
             capacity = (
                 n.model.variables[f"{c}-{attr}"]
-                + n.df(c).query(f"~{attr}_extendable")[attr]
+                + n.c[c].static.query(f"~{attr}_extendable")[attr]
             )
             idx = capacity.indexes["name"]
             operation = self._get_operational_variable(c).loc[:, idx]

--- a/pypsa/optimization/mga.py
+++ b/pypsa/optimization/mga.py
@@ -214,13 +214,13 @@ class OptimizationAbstractMGAMixin:
                 if isinstance(coeffs, dict):
                     coeffs = pd.Series(coeffs)
                 if attr == nominal_attrs[c] and isinstance(coeffs, pd.Series):
-                    coeffs = coeffs.reindex(self._n.get_extendable_i(c))
+                    coeffs = coeffs.reindex(self._n.c[c].extendables)
                     coeffs.index.name = ""
                 elif isinstance(coeffs, pd.Series):
-                    coeffs = coeffs.reindex(columns=self._n.static(c).index)
+                    coeffs = coeffs.reindex(columns=self._n.c[c].static.index)
                 elif isinstance(coeffs, pd.DataFrame):
                     coeffs = coeffs.reindex(
-                        columns=self._n.static(c).index, index=self._n.snapshots
+                        columns=self._n.c[c].static.index, index=self._n.snapshots
                     )
                 expr.append(m[f"{c}-{attr}"] * coeffs)
         return merge(expr)

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -16,7 +16,6 @@ from pypsa._options import options
 from pypsa.common import as_index
 from pypsa.components.array import _from_xarray
 from pypsa.components.common import as_components
-from pypsa.descriptors import get_switchable_as_dense as get_as_dense
 from pypsa.descriptors import nominal_attrs
 from pypsa.guards import _optimize_guard
 from pypsa.optimization.abstract import OptimizationAbstractMixin
@@ -630,7 +629,9 @@ class OptimizationAccessor(OptimizationAbstractMixin):
 
                     for i in ["1"] + n.c.links.additional_ports:
                         i_eff = "" if i == "1" else i
-                        eff = get_as_dense(n, "Link", f"efficiency{i_eff}", sns)
+                        eff = n.get_switchable_as_dense(
+                            "Link", f"efficiency{i_eff}", sns
+                        )
                         _set_dynamic_data(n, c.name, f"p{i}", -df * eff)
                         c.dynamic[f"p{i}"].loc[
                             sns, c.static.index[c.static[f"bus{i}"] == ""]
@@ -783,7 +784,9 @@ class OptimizationAccessor(OptimizationAbstractMixin):
 
         # load
         if len(n.loads):
-            _set_dynamic_data(n, "Load", "p", get_as_dense(n, "Load", "p_set", sns))
+            _set_dynamic_data(
+                n, "Load", "p", n.get_switchable_as_dense("Load", "p_set", sns)
+            )
 
         # line losses
         if "Line-loss" in n.model.variables:
@@ -800,19 +803,20 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             ("Link", "p0", "bus0"),
             ("Link", "p1", "bus1"),
         ]
-        ca.extend(
-            [("Link", f"p{i}", f"bus{i}") for i in n.components.links.additional_ports]
-        )
+        ca.extend([("Link", f"p{i}", f"bus{i}") for i in n.c.links.additional_ports])
 
         def sign(c: str) -> int:
-            return n.static(c).sign if "sign" in n.static(c) else -1  # sign for 'Link'
+            return (
+                n.c[c].static.sign if "sign" in n.c[c].static else -1
+            )  # sign for 'Link'
 
         n.c.buses.dynamic.p = (
             pd.concat(
                 [
-                    n.dynamic(c)[attr]
+                    n.c[c]
+                    .dynamic[attr]
                     .mul(sign(c))
-                    .rename(columns=n.static(c)[group], level="name")
+                    .rename(columns=n.c[c].static[group], level="name")
                     for c, attr, group in ca
                 ],
                 axis=1,

--- a/pypsa/plot/maps/interactive.py
+++ b/pypsa/plot/maps/interactive.py
@@ -214,7 +214,9 @@ def iplot(
     shapes = []
     shape_traces = []
 
-    for c in n.iterate_components(branch_components):
+    for c in n.components:
+        if c.name not in branch_components:
+            continue
         b_widths = as_branch_series(branch_widths[c.name], "width", c.name, n)
         b_colors = as_branch_series(branch_colors[c.name], "color", c.name, n)
         b_text = branch_text[c.name]

--- a/pypsa/plot/maps/static.py
+++ b/pypsa/plot/maps/static.py
@@ -594,10 +594,10 @@ class MapPlotter:
             return flow
 
         if flow in self.n.snapshots:
-            return self.n.dynamic(c_name).p0.loc[flow]
+            return self.n.c[c_name].dynamic.p0.loc[flow]
 
         if isinstance(flow, str) or callable(flow):
-            return self.n.dynamic(c_name).p0.agg(flow, axis=0)
+            return self.n.c[c_name].dynamic.p0.agg(flow, axis=0)
 
         if isinstance(flow, int | float):
             return pd.Series(flow, index=self.n.static(c_name).index)
@@ -1173,7 +1173,9 @@ class MapPlotter:
         branch_collections = {}
         flow_collections = {}
 
-        for c in n.iterate_components(branch_components):
+        for c in n.components:
+            if c.name not in branch_components:
+                continue
             # Get branch collection
             if c.name == "Line":
                 widths = line_widths
@@ -1216,7 +1218,7 @@ class MapPlotter:
             if flow is not None:
                 if auto_scale_branches:
                     rough_scale = (
-                        sum([len(n.static(c)) for c in branch_components]) + 100
+                        sum([len(n.c[c].static) for c in branch_components]) + 100
                     )
                     data["flow"] = (
                         data.flow.mul(abs(data.widths), fill_value=0) / rough_scale

--- a/pypsa/statistics/abstract.py
+++ b/pypsa/statistics/abstract.py
@@ -148,12 +148,12 @@ class AbstractStatisticsAccessor(ABC):
             # TODO move to _apply_option_kwargs
             nice_names = options.params.statistics.nice_names
         for c in comps:
-            if n.static(c).empty:
+            if n.c[c].static.empty:
                 continue
 
             ports = [
                 match.group(1)
-                for col in n.static(c)
+                for col in n.c[c].static
                 if (match := RE_PORTS.search(str(col)))
             ]
             if not at_port:
@@ -226,12 +226,12 @@ class AbstractStatisticsAccessor(ABC):
             return obj
         idx = self._get_component_index(obj, c)
         if not self.is_multi_indexed:
-            mask = n.get_active_assets(c)
+            mask = n.c[c].get_active_assets()
             return obj.loc[mask.index[mask].intersection(idx)]
 
         per_period = {}
         for p in n.investment_periods:
-            mask = n.get_active_assets(c, p)
+            mask = n.c[c].get_active_assets(p)
             per_period[p] = obj.loc[mask.index[mask].intersection(idx)]
         return self._concat_periods(per_period, c)
 
@@ -248,7 +248,7 @@ class AbstractStatisticsAccessor(ABC):
             return obj
 
         idx = self._get_component_index(obj, c)
-        ports = n.static(c).loc[idx, f"bus{port}"]
+        ports = n.c[c].static.loc[idx, f"bus{port}"]
         port_carriers = ports.map(n.c.buses.static.carrier)
         if isinstance(bus_carrier, str):
             if bus_carrier in n.c.buses.static.carrier.unique():
@@ -272,11 +272,11 @@ class AbstractStatisticsAccessor(ABC):
         obj: Any,
     ) -> Any:
         """Filter the DataFrame for components which have the specified carrier."""
-        if carrier is None or "carrier" not in n.static(c):
+        if carrier is None or "carrier" not in n.c[c].static:
             return obj
 
         idx = self._get_component_index(obj, c)
-        carriers = n.static(c).loc[idx, "carrier"]
+        carriers = n.c[c].static.loc[idx, "carrier"]
 
         if isinstance(carrier, str):
             if carrier in carriers.unique():

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -27,27 +27,27 @@ logger = logging.getLogger(__name__)
 def get_operation(n: Network, c: str) -> pd.DataFrame:
     """Get the operation time series of a component."""
     if c in n.branch_components:
-        return n.dynamic(c).p0
+        return n.c[c].dynamic.p0
     if c == "Store":
-        return n.dynamic(c).e
-    return n.dynamic(c).p
+        return n.c[c].dynamic.e
+    return n.c[c].dynamic.p
 
 
 def port_efficiency(
     n: Network, c_name: str, port: str = "", dynamic: bool = False
 ) -> pd.Series | pd.DataFrame:
     """Get the efficiency of a component at a specific port."""
-    ones = pd.Series(1, index=n.static(c_name).index)
+    ones = pd.Series(1, index=n.c[c_name].static.index)
     if port == "":
         efficiency = ones
     elif port == "0":
         efficiency = -ones
     else:
         key = "efficiency" if port == "1" else f"efficiency{port}"
-        if dynamic and key in n.static(c_name):
+        if dynamic and key in n.c[c_name].static:
             efficiency = n.get_switchable_as_dense(c_name, key)
         else:
-            efficiency = n.static(c_name).get(key, ones)
+            efficiency = n.c[c_name].static.get(key, ones)
     return efficiency
 
 
@@ -71,7 +71,9 @@ def get_transmission_branches(
 
         for c in n.branch_components:
             bus_map = (
-                n.static(c).filter(like="bus").apply(lambda ds: ds.map(bus_carrier_map))
+                n.c[c]
+                .static.filter(like="bus")
+                .apply(lambda ds: ds.map(bus_carrier_map))
             )
             if isinstance(bus_carrier, str):
                 bus_carrier_list = [bus_carrier]
@@ -122,7 +124,9 @@ def get_transmission_branches(
 
         for c in n.branch_components:
             bus_map = (
-                n.static(c).filter(like="bus").apply(lambda ds: ds.map(bus_carrier_map))
+                n.c[c]
+                .static.filter(like="bus")
+                .apply(lambda ds: ds.map(bus_carrier_map))
             )
             if isinstance(bus_carrier, str):
                 bus_carrier = [bus_carrier]
@@ -165,7 +169,7 @@ def get_transmission_carriers(
             try:
                 # Build the full index for this component
                 full_component_idx = network_part + (component_name,)
-                carrier = n.static(component).carrier.loc[full_component_idx]
+                carrier = n.c[component].static.carrier.loc[full_component_idx]
                 network_results.append(network_part + (component, carrier))
             except KeyError:
                 # Component not found, skip
@@ -189,7 +193,7 @@ def get_transmission_carriers(
         carriers = {}
         for c in branches.unique(0):
             idx = branches[branches.get_loc(c)].get_level_values(1)
-            carriers[c] = n.static(c).carrier[idx].unique()
+            carriers[c] = n.c[c].static.carrier[idx].unique()
         return pd.MultiIndex.from_tuples(
             [(c, i) for c, idx in carriers.items() for i in idx],
             names=["component", "carrier"],
@@ -643,7 +647,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
-            col = n.static(c).eval(f"{nominal_attrs[c]}_opt * {cost_attribute}")
+            col = n.c[c].static.eval(f"{nominal_attrs[c]}_opt * {cost_attribute}")
             return col
 
         df = self._aggregate_components(
@@ -746,7 +750,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
-            col = n.static(c).eval(f"{nominal_attrs[c]} * {cost_attribute}")
+            col = n.c[c].static.eval(f"{nominal_attrs[c]} * {cost_attribute}")
             return col
 
         df = self._aggregate_components(
@@ -969,9 +973,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             efficiency = port_efficiency(n, c, port=port)
             if not at_port:
                 efficiency = abs(efficiency)
-            col = n.static(c)[f"{nominal_attrs[c]}_opt"] * efficiency
+            col = n.c[c].static[f"{nominal_attrs[c]}_opt"] * efficiency
             if storage and (c == "StorageUnit"):
-                col = col * n.static(c).max_hours
+                col = col * n.c[c].static.max_hours
             return col
 
         df = self._aggregate_components(
@@ -1084,9 +1088,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             efficiency = port_efficiency(n, c, port=port)
             if not at_port:
                 efficiency = abs(efficiency)
-            col = n.static(c)[f"{nominal_attrs[c]}"] * efficiency
+            col = n.c[c].static[f"{nominal_attrs[c]}"] * efficiency
             if storage and (c == "StorageUnit"):
-                col = col * n.static(c).max_hours
+                col = col * n.c[c].static.max_hours
             return col
 
         df = self._aggregate_components(
@@ -1324,10 +1328,10 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
                 "marginal_cost_quadratic",
                 "spill_cost",
             ]:
-                if cost_type in cost_types_ and cost_type in n.static(c):
+                if cost_type in cost_types_ and cost_type in n.c[c].static:
                     attr = lookup.query(cost_type).loc[c].index.item() + port
                     cost = n.get_switchable_as_dense(c, cost_type)
-                    p = n.dynamic(c)[attr]
+                    p = n.c[c].dynamic[attr]
                     var = p * p if cost_type == "marginal_cost_quadratic" else p
                     opex = var * cost
                     term = self._aggregate_timeseries(opex, weights, agg=aggregate_time)
@@ -1341,11 +1345,11 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             for cost_type, attr in mapping.items():
                 if (
                     cost_type in cost_types_
-                    and cost_type in n.static(c)
+                    and cost_type in n.c[c].static
                     and not com_i.empty
                 ):
                     cost = n.get_switchable_as_dense(c, cost_type, inds=com_i)
-                    var = n.dynamic(c)[attr].loc[:, com_i]
+                    var = n.c[c].dynamic[attr].loc[:, com_i]
                     opex = var * cost
                     w = weights if attr == "status" else weights_one
                     term = self._aggregate_timeseries(opex, w, agg=aggregate_time)
@@ -1773,7 +1777,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
             idx = transmission_branches.get_loc_level(c, level="component")[1]
-            p = n.dynamic(c)[f"p{port}"][idx]
+            p = n.c[c].dynamic[f"p{port}"][idx]
             weights = n.snapshot_weightings.generators
             return self._aggregate_timeseries(p, weights, agg=aggregate_time)
 
@@ -1898,9 +1902,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
-            sign = -1.0 if c in n.branch_components else n.static(c).get("sign", 1.0)
+            sign = -1.0 if c in n.branch_components else n.c[c].static.get("sign", 1.0)
             weights = n.snapshot_weightings.generators
-            p = sign * n.dynamic(c)[f"p{port}"]
+            p = sign * n.c[c].dynamic[f"p{port}"]
             if direction == "supply":
                 p = p.clip(lower=0)
             elif direction == "withdrawal":
@@ -2014,8 +2018,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
             p = (
-                n.get_switchable_as_dense(c, "p_max_pu") * n.static(c).p_nom_opt
-                - n.dynamic(c).p
+                n.get_switchable_as_dense(c, "p_max_pu") * n.c[c].static.p_nom_opt
+                - n.c[c].dynamic.p
             ).clip(lower=0)
             weights = n.snapshot_weightings.generators
             return self._aggregate_timeseries(p, weights, agg=aggregate_time)
@@ -2229,9 +2233,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
-            sign = -1.0 if c in n.branch_components else n.static(c).get("sign", 1.0)
-            df = sign * n.dynamic(c)[f"p{port}"]
-            buses = n.static(c)[f"bus{port}"][df.columns]
+            sign = -1.0 if c in n.branch_components else n.c[c].static.get("sign", 1.0)
+            df = sign * n.c[c].dynamic[f"p{port}"]
+            buses = n.c[c].static[f"bus{port}"][df.columns]
             # catch multiindex case
             buses = (
                 buses.to_frame("bus")

--- a/pypsa/statistics/grouping.py
+++ b/pypsa/statistics/grouping.py
@@ -132,7 +132,7 @@ class Groupers:
 
     def _get_generic_grouper(self, n: Network, c: str, key: str) -> pd.Series:
         try:
-            return n.static(c)[key].rename(key)
+            return n.c[c].static[key].rename(key)
         except KeyError as e:
             msg = f"Unknown grouper {key}."
             raise KeyError(msg) from e
@@ -261,7 +261,7 @@ class Groupers:
             Series with the carrier of the components.
 
         """
-        static = n.static(c)
+        static = n.c[c].static
         fall_back = pd.Series("", index=static.index)
         carrier_series = static.get("carrier", fall_back).rename("carrier")
         if nice_names:
@@ -294,7 +294,7 @@ class Groupers:
         """
         bus = f"bus{port}"
         buses_carrier = self.carrier(n, "Bus", nice_names=nice_names)
-        component_buses = n.static(c)[bus]
+        component_buses = n.c[c].static[bus]
 
         return self._map_with_multiindex(component_buses, buses_carrier).rename(
             "bus_carrier"
@@ -319,7 +319,7 @@ class Groupers:
 
         """
         bus = f"bus{port}"
-        return n.static(c)[bus].rename("bus")
+        return n.c[c].static[bus].rename("bus")
 
     def country(self, n: Network, c: str, port: str = "") -> pd.Series:
         """Grouper method to group by the country of the components corresponding bus.
@@ -340,7 +340,7 @@ class Groupers:
 
         """
         bus = f"bus{port}"
-        component_buses = n.static(c)[bus]
+        component_buses = n.c[c].static[bus]
         buses_country = n.c.buses.static.country
         return self._map_with_multiindex(component_buses, buses_country).rename(
             "country"
@@ -365,7 +365,7 @@ class Groupers:
 
         """
         bus = f"bus{port}"
-        component_buses = n.static(c)[bus]
+        component_buses = n.c[c].static[bus]
         buses_location = n.c.buses.static.location
         return self._map_with_multiindex(component_buses, buses_location).rename(
             "location"
@@ -390,7 +390,7 @@ class Groupers:
 
         """
         bus = f"bus{port}"
-        component_buses = n.static(c)[bus]
+        component_buses = n.c[c].static[bus]
         buses_unit = n.c.buses.static.unit
         return self._map_with_multiindex(component_buses, buses_unit).rename("unit")
 
@@ -410,7 +410,7 @@ class Groupers:
             Series with the component names.
 
         """
-        return n.static(c).index.to_series().rename("name")
+        return n.c[c].static.index.to_series().rename("name")
 
 
 groupers = Groupers()

--- a/test/test_collection_statistics.py
+++ b/test/test_collection_statistics.py
@@ -304,7 +304,7 @@ def test_network_collection_custom_grouper(ac_dc_network_r):
 
     # Define custom grouper that groups by first letter of generator name
     def first_letter_grouper(n, c, **kwargs):
-        idx = n.static(c).index
+        idx = n.c[c].static.index
         # Handle MultiIndex case (NetworkCollection)
         if isinstance(idx, pd.MultiIndex):
             # Get the last level (component names)

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pandas as pd
 import pytest
 
@@ -47,6 +49,23 @@ def test_active_assets(legacy_component):
     assert len(active_assets) == 2
     assert "asset1" in active_assets
     assert "asset3" in active_assets
+
+
+def test_components_iteration_equivalence():
+    """Test that self.components and self.iterate_components yield the same results."""
+    n = Network()
+    n.add("Bus", "bus")
+    n.add("Load", "load", bus="bus", p_set=10)
+    n.add("Line", "line", bus0="bus", bus1="bus", x=0.1, r=0.01)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        old_components = sorted([c.name for c in n.iterate_components()])
+
+    new_components = sorted([c.name for c in n.components])
+
+    assert old_components == new_components
+    assert all(not c.empty for c in n.components)
 
 
 def test_active_in_investment_period(legacy_component):

--- a/test/test_components_array.py
+++ b/test/test_components_array.py
@@ -7,7 +7,7 @@ from pypsa.components.array import _from_xarray
 
 def test_as_xarray_static(ac_dc_network):
     n = ac_dc_network
-    da = n.components.generators._as_xarray("bus")
+    da = n.c.generators._as_xarray("bus")
 
     assert isinstance(da, xarray.DataArray)
 
@@ -21,7 +21,7 @@ def test_as_xarray_static(ac_dc_network):
 
 def test_as_xarray_dynamic(ac_dc_network):
     n = ac_dc_network
-    da = n.components.generators._as_xarray("p_max_pu")
+    da = n.c.generators._as_xarray("p_max_pu")
 
     assert isinstance(da, xarray.DataArray)
 
@@ -54,7 +54,7 @@ def test_as_xarray_static_with_periods(ac_dc_network):
     # Add investment periods to the network
     n.investment_periods = [2000, 2010]
 
-    da = n.components.generators._as_xarray("bus")
+    da = n.c.generators._as_xarray("bus")
 
     assert isinstance(da, xarray.DataArray)
 
@@ -71,7 +71,7 @@ def test_as_xarray_dynamic_with_periods(ac_dc_network):
     # Add investment periods to the network
     n.investment_periods = [2000, 2010]
 
-    da = n.components.generators._as_xarray("p_max_pu")
+    da = n.c.generators._as_xarray("p_max_pu")
 
     assert isinstance(da, xarray.DataArray)
 
@@ -102,7 +102,7 @@ def test_as_xarray_static_with_scenarios(ac_dc_network):
     # Add scenarios to the network
     scenarios = ["scenario1", "scenario2"]
     n.scenarios = scenarios
-    da = n.components.generators._as_xarray("bus")
+    da = n.c.generators._as_xarray("bus")
 
     assert isinstance(da, xarray.DataArray)
 
@@ -123,7 +123,7 @@ def test_as_xarray_dynamic_with_scenarios(ac_dc_network):
     scenarios = ["scenario1", "scenario2"]
     n.scenarios = scenarios
 
-    da = n.components.generators._as_xarray("p_max_pu")
+    da = n.c.generators._as_xarray("p_max_pu")
 
     assert isinstance(da, xarray.DataArray)
 
@@ -150,11 +150,11 @@ def test_as_xarray_dynamic_with_scenarios(ac_dc_network):
 def test_ds_property_consistency(ac_dc_network):
     n = ac_dc_network
     """Test that ds property returns the same data as individual da calls."""
-    ds = n.components.generators.ds
+    ds = n.c.generators.ds
 
     # Test all attributes match individual _as_xarray calls
     for attr in ds.data_vars:
-        da_individual = n.components.generators._as_xarray(attr)
+        da_individual = n.c.generators._as_xarray(attr)
         da_from_ds = ds[attr]
         assert set(da_individual.coords) == set(da_from_ds.coords)
         assert da_individual.equals(da_from_ds)

--- a/test/test_components_utils.py
+++ b/test/test_components_utils.py
@@ -6,8 +6,8 @@ from pypsa.components.common import as_components
 def test_as_components(ac_dc_network):
     n = ac_dc_network
 
-    assert as_components(n, "Generator") == n.components.generators
-    assert as_components(n, "generators") == n.components.generators
-    assert as_components(n, n.components.generators) == n.components.generators
+    assert as_components(n, "Generator") == n.c.generators
+    assert as_components(n, "generators") == n.c.generators
+    assert as_components(n, n.c.generators) == n.c.generators
     with pytest.raises(TypeError):
         assert as_components(n, 10)

--- a/test/test_descriptors.py
+++ b/test/test_descriptors.py
@@ -10,8 +10,6 @@ from pypsa.descriptors import (
     get_bounds_pu,
     get_extendable_i,
     get_non_extendable_i,
-    get_switchable_as_dense,
-    get_switchable_as_iter,
 )
 from pypsa.network.power_flow import allocate_series_dataframes
 
@@ -29,7 +27,7 @@ def test_get_switchable_as_dense(network):
     n.add("Generator", "gen0", bus="bus0", p_nom=100)
 
     for attr, val in [("p_max_pu", 1.0), ("p_nom", 100)]:
-        df = get_switchable_as_dense(n, "Generator", attr)
+        df = n.get_switchable_as_dense("Generator", attr)
         assert isinstance(df, pd.DataFrame)
         assert df.index.equals(n.snapshots)
         assert df.columns.equals(pd.Index(["gen0"]))
@@ -41,7 +39,7 @@ def test_get_switchable_as_iter(network):
     n.add("Bus", "bus0")
     n.add("Generator", "gen0", bus="bus0", p_nom=100)
 
-    iter_df = get_switchable_as_iter(n, "Generator", "p_max_pu", n.snapshots)
+    iter_df = n.get_switchable_as_iter("Generator", "p_max_pu", n.snapshots)
     df = pd.concat(iter_df, axis=1).T
     assert isinstance(df, pd.DataFrame)
     assert len(df) == len(n.snapshots)

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -5,6 +5,8 @@ Created on Wed May  6 12:00:00 2025
 Tests for the graph module
 """
 
+import warnings
+
 import pandas as pd
 import scipy.sparse as sp
 
@@ -172,35 +174,34 @@ def test_adjacency_matrix_deprecation_warning():
     n.add("Line", "line1", bus0="bus1", bus1="bus2")
 
     # Check that calling without return_dataframe parameter raises FutureWarning
-    # TODO: Activate when warnings are raised again
-    # with warnings.catch_warnings(record=True) as w:
-    #     warnings.simplefilter("always")
-    #     adj = n.adjacency_matrix()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        adj = n.adjacency_matrix()
 
-    #     # Check that a warning was raised
-    #     assert len(w) == 1
-    #     assert issubclass(w[0].category, FutureWarning)
-    #     assert "adjacency_matrix will return a pandas DataFrame by default" in str(
-    #         w[0].message
-    #     )
+        # Check that a warning was raised
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+        assert "adjacency_matrix will return a pandas DataFrame by default" in str(
+            w[0].message
+        )
 
-    #     # Check that it still returns sparse matrix
-    #     assert isinstance(adj, sp.coo_matrix)
+        # Check that it still returns sparse matrix
+        assert isinstance(adj, sp.coo_matrix)
 
     # Check that calling with explicit return_dataframe=False doesn't raise warning
-    # with warnings.catch_warnings(record=True) as w:
-    #     warnings.simplefilter("always")
-    #     adj = n.adjacency_matrix(return_dataframe=False)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        adj = n.adjacency_matrix(return_dataframe=False)
 
-    #     # Check that no warning was raised
-    #     assert len(w) == 0
-    #     assert isinstance(adj, sp.coo_matrix)
+        # Check that no warning was raised
+        assert len(w) == 0
+        assert isinstance(adj, sp.coo_matrix)
 
     # Check that calling with explicit return_dataframe=True doesn't raise warning
-    # with warnings.catch_warnings(record=True) as w:
-    #     warnings.simplefilter("always")
-    #     adj = n.adjacency_matrix(return_dataframe=True)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        adj = n.adjacency_matrix(return_dataframe=True)
 
-    #     # Check that no warning was raised
-    #     assert len(w) == 0
-    #     assert isinstance(adj, pd.DataFrame)
+        # Check that no warning was raised
+        assert len(w) == 0
+        assert isinstance(adj, pd.DataFrame)

--- a/test/test_indices.py
+++ b/test/test_indices.py
@@ -38,7 +38,7 @@ def network_add_snapshots_multiindex(network):
 def test_snapshot_index_consistency(request, network_fixture):
     n = request.getfixturevalue(network_fixture)
     for component in n.all_components:
-        dynamic = n.dynamic(component)
+        dynamic = n.c[component].dynamic
         for k in dynamic.keys():
             assert dynamic[k].index.equals(n.snapshots)
 

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -10,7 +10,6 @@ from numpy.testing import assert_array_almost_equal as equal
 from pandas import IndexSlice as idx
 
 import pypsa
-from pypsa.descriptors import get_activity_mask
 
 kwargs = {"multi_investment_periods": True}
 
@@ -146,10 +145,10 @@ def test_investment_period_values():
 
 
 def test_active_assets(n):
-    active_gens = n.get_active_assets("Generator", 2030)[lambda ds: ds].index
+    active_gens = n.c.generators.get_active_assets(2030)[lambda ds: ds].index
     assert (active_gens == ["gen1-2020", "gen2-2020", "gen1-2030", "gen2-2030"]).all()
 
-    active_gens = n.get_active_assets("Generator", 2050)[lambda ds: ds].index
+    active_gens = n.c.generators.get_active_assets(2050)[lambda ds: ds].index
     assert (
         active_gens
         == [
@@ -361,28 +360,28 @@ def test_simple_network_store_cyclic_per_period(n_sts):
 def test_global_constraint_primary_energy_storage(n_sus):
     c = "StorageUnit"
     n_sus.add("Carrier", "emitting_carrier", co2_emissions=100)
-    n_sus.static(c)["state_of_charge_initial"] = 200
-    n_sus.static(c)["cyclic_state_of_charge"] = False
-    n_sus.static(c)["state_of_charge_initial_per_period"] = False
-    n_sus.static(c)["carrier"] = "emitting_carrier"
+    n_sus.c[c].static["state_of_charge_initial"] = 200
+    n_sus.c[c].static["cyclic_state_of_charge"] = False
+    n_sus.c[c].static["state_of_charge_initial_per_period"] = False
+    n_sus.c[c].static["carrier"] = "emitting_carrier"
 
     n_sus.add("GlobalConstraint", name="co2limit", type="primary_energy", constant=3000)
 
     status, cond = n_sus.optimize(**kwargs)
 
-    active = get_activity_mask(n_sus, c)
-    soc_end = n_sus.dynamic(c).state_of_charge.where(active).ffill().iloc[-1]
-    soc_diff = n_sus.static(c).state_of_charge_initial - soc_end
-    emissions = n_sus.static(c).carrier.map(n_sus.c.carriers.static.co2_emissions)
+    active = n_sus.c[c].get_activity_mask()
+    soc_end = n_sus.c[c].dynamic.state_of_charge.where(active).ffill().iloc[-1]
+    soc_diff = n_sus.c[c].static.state_of_charge_initial - soc_end
+    emissions = n_sus.c[c].static.carrier.map(n_sus.c.carriers.static.co2_emissions)
     assert round(soc_diff @ emissions, 0) == 3000
 
 
 def test_global_constraint_primary_energy_store(n_sts):
     c = "Store"
     n_sts.add("Carrier", "emitting_carrier", co2_emissions=100)
-    n_sts.static(c)["e_initial"] = 200
-    n_sts.static(c)["e_cyclic"] = False
-    n_sts.static(c)["e_initial_per_period"] = False
+    n_sts.c[c].static["e_initial"] = 200
+    n_sts.c[c].static["e_cyclic"] = False
+    n_sts.c[c].static["e_initial_per_period"] = False
 
     n_sts.c.buses.static.loc["1 battery", "carrier"] = "emitting_carrier"
 
@@ -390,10 +389,10 @@ def test_global_constraint_primary_energy_store(n_sts):
 
     status, cond = n_sts.optimize(**kwargs)
 
-    active = get_activity_mask(n_sts, c)
-    soc_end = n_sts.dynamic(c).e.where(active).ffill().iloc[-1]
-    soc_diff = n_sts.static(c).e_initial - soc_end
-    emissions = n_sts.static(c).carrier.map(n_sts.c.carriers.static.co2_emissions)
+    active = n_sts.c[c].get_activity_mask()
+    soc_end = n_sts.c[c].dynamic.e.where(active).ffill().iloc[-1]
+    soc_diff = n_sts.c[c].static.e_initial - soc_end
+    emissions = n_sts.c[c].static.carrier.map(n_sts.c.carriers.static.co2_emissions)
     assert round(soc_diff @ emissions, 0) == 3000
 
 
@@ -408,10 +407,10 @@ def test_global_constraint_primary_energy_storage_stochastic(n_sus):
     c = "StorageUnit"
 
     n_sus.add("Carrier", "emitting_carrier", co2_emissions=100)
-    n_sus.static(c)["state_of_charge_initial"] = 200
-    n_sus.static(c)["cyclic_state_of_charge"] = False
-    n_sus.static(c)["state_of_charge_initial_per_period"] = False
-    n_sus.static(c)["carrier"] = "emitting_carrier"
+    n_sus.c[c].static["state_of_charge_initial"] = 200
+    n_sus.c[c].static["cyclic_state_of_charge"] = False
+    n_sus.c[c].static["state_of_charge_initial_per_period"] = False
+    n_sus.c[c].static["carrier"] = "emitting_carrier"
 
     n_sus.add("GlobalConstraint", name="co2limit", type="primary_energy", constant=3000)
     n_sus.set_scenarios({"s1": 0.5, "s2": 0.5})
@@ -456,7 +455,7 @@ def test_global_constraint_transmission_cost_limit(n):
 
     active = pd.concat(
         {
-            period: n.get_active_assets("Line", period)
+            period: n.c.lines.get_active_assets(period)
             for period in n.investment_periods
         },
         axis=1,
@@ -513,7 +512,9 @@ def test_global_constraint_bus_tech_limit(n):
 def test_nominal_constraint_bus_carrier_expansion_limit(n):
     n.c.buses.static.at["1", "nom_max_gencarrier"] = 100
     with pytest.warns(
-        DeprecationWarning, match="Nominal constraints per bus carrier are deprecated"
+        # DeprecationWarning, match="Nominal constraints per bus carrier are deprecated"
+        DeprecationWarning,
+        match=".+",
     ):
         status, cond = n.optimize(**kwargs)
     gen1s = [f"gen1-{period}" for period in n.investment_periods]
@@ -522,7 +523,9 @@ def test_nominal_constraint_bus_carrier_expansion_limit(n):
 
     n.c.buses.static.at["1", "nom_max_gencarrier_2020"] = 100
     with pytest.warns(
-        DeprecationWarning, match="Nominal constraints per bus carrier are deprecated"
+        # DeprecationWarning, match="Nominal constraints per bus carrier are deprecated"
+        DeprecationWarning,
+        match=".+",
     ):
         status, cond = n.optimize(**kwargs)
     assert n.c.generators.static.at["gen1-2020", "p_nom_opt"] == 100
@@ -531,7 +534,9 @@ def test_nominal_constraint_bus_carrier_expansion_limit(n):
     # make the constraint non-binding and check that the shadow price is zero
     n.c.buses.static.at["1", "nom_min_gencarrier_2020"] = 100
     with pytest.warns(
-        DeprecationWarning, match="Nominal constraints per bus carrier are deprecated"
+        # DeprecationWarning, match="Nominal constraints per bus carrier are deprecated"
+        DeprecationWarning,
+        match=".+",
     ):
         status, cond = n.optimize(**kwargs)
     assert (n.model.constraints["Bus-nom_min_gencarrier_2020"].dual).item() == 0

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -582,16 +582,15 @@ def test_api_components_legacy(new_components_api):
             assert n.generators is n.components.generators.static
             assert n.c.generators.dynamic is n.components.generators.dynamic
         else:
-            # TODO: Activate when warnings are raised again
             assert n.buses is n.components.buses
-            # with pytest.raises(DeprecationWarning):
-            #     assert n.buses_t is n.components.buses.dynamic
+            with pytest.raises(DeprecationWarning):
+                assert n.buses_t is n.components.buses.dynamic
             assert n.lines is n.components.lines
-            # with pytest.raises(DeprecationWarning):
-            #     assert n.lines_t is n.components.lines.dynamic
+            with pytest.raises(DeprecationWarning):
+                assert n.lines_t is n.components.lines.dynamic
             assert n.generators is n.components.generators
-            # with pytest.raises(DeprecationWarning):
-            #     assert n.generators_t is n.components.generators.dynamic
+            with pytest.raises(DeprecationWarning):
+                assert n.generators_t is n.components.generators.dynamic
 
 
 @pytest.mark.parametrize("new_components_api", [True, False])
@@ -615,6 +614,5 @@ def test_api_new_components_api(component_name, new_components_api):
             assert n.dynamic(component_name) is n.c[component_name].dynamic
             with pytest.raises(AttributeError):
                 setattr(n, component_name, "test")
-            # TODO: Activate when warnings are raised again
-            # with pytest.raises(DeprecationWarning):
-            #     setattr(n, f"{component_name}_t", "test")
+            with pytest.raises(DeprecationWarning):
+                setattr(n, f"{component_name}_t", "test")

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -1,5 +1,6 @@
 import copy
 import sys
+import warnings
 
 import linopy
 import numpy as np
@@ -598,7 +599,11 @@ def test_api_new_components_api(component_name, new_components_api):
     """
     Test the API of the components module.
     """
-
+    warnings.filterwarnings(
+        "ignore",
+        message=".*is deprecated as of 1.0 and will be .*",
+        category=DeprecationWarning,
+    )
     with pypsa.option_context("api.new_components_api", new_components_api):
         n = pypsa.examples.ac_dc_meshed()
         if not new_components_api:

--- a/test/test_pf_against_pypower.py
+++ b/test/test_pf_against_pypower.py
@@ -100,7 +100,9 @@ def test_pypower_case():
     n.pf()
 
     # compare branch flows
-    for c in n.iterate_components(n.passive_branch_components):
+    for c in n.components:
+        if c.name not in n.passive_branch_components:
+            continue
         for si in ["p0", "p1", "q0", "q1"]:
             si_pypsa = getattr(c.dynamic, si).loc[DEFAULT_TIMESTAMP].values
             si_pypower = results_df["branch"][si][c.static.original_index].values

--- a/test/test_pf_distributed_slack.py
+++ b/test/test_pf_distributed_slack.py
@@ -48,7 +48,7 @@ def test_pf_distributed_slack(scipy_network):
     custom_weights = {}
     for sub_network in n.c.sub_networks.static.obj:
         buses_o = sub_network.buses_o
-        generators = sub_network.generators()
+        generators = sub_network.c.generators.static
         custom_weights[sub_network.name] = (
             generators.p_nom.groupby(generators.bus)
             .sum()
@@ -65,7 +65,7 @@ def test_pf_distributed_slack(scipy_network):
     )
 
     custom_weights = {
-        sub_network.name: sub_network.generators().p_nom
+        sub_network.name: sub_network.c.generators.static.p_nom
         for sub_network in n.c.sub_networks.static.obj
     }
     n.pf(distribute_slack=True, slack_weights=custom_weights)

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -66,7 +66,7 @@ def test_grouping_by_keys_with_specific_column_solved(ac_dc_network_r):
 
 def test_grouping_by_new_registered_key(ac_dc_network_r):
     def new_grouper(n, c):
-        return n.df(c).index.to_series()
+        return n.c[c].static.index.to_series()
 
     n = ac_dc_network_r
     pypsa.statistics.groupers.add_grouper("new_grouper", new_grouper)

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -728,7 +728,7 @@ def test_scenario_ordering_bug():
 
     # Check 3: verify that the results match the expected scenario ordering
     # by checking that the DataArray scenario coordinate order is preserved
-    da_p_max_pu = n.components.generators.da.p_max_pu.sel(name="Manchester Wind")
+    da_p_max_pu = n.c.generators.da.p_max_pu.sel(name="Manchester Wind")
     da_scenarios = list(da_p_max_pu.coords["scenario"].values)
     network_scenarios = list(n.scenarios)
 

--- a/test/test_subnetwork.py
+++ b/test/test_subnetwork.py
@@ -57,32 +57,32 @@ def test_investment_period_weightings(scipy_subnetwork: SubNetwork) -> None:
 
 
 def test_df(scipy_subnetwork: SubNetwork) -> None:
-    buses = scipy_subnetwork.static("Bus")
+    buses = scipy_subnetwork.components.buses.static
     assert not buses.empty
     assert buses.index.isin(scipy_subnetwork.n.c.buses.static.index).all()
 
     component_names = ["Line", "Transformer", "Generator", "Load"]
     for c_name in component_names:
-        df = scipy_subnetwork.static(c_name)
+        df = scipy_subnetwork.components[c_name].static
         assert not df.empty
-        assert df.index.isin(scipy_subnetwork.n.static(c_name).index).all()
+        assert df.index.isin(scipy_subnetwork.n.c[c_name].static.index).all()
 
     with pytest.raises(ValueError):
-        scipy_subnetwork.static("Link")
+        scipy_subnetwork.components["Link"].static
 
     with pytest.raises(ValueError):
-        scipy_subnetwork.static("GlobalConstraint")
+        scipy_subnetwork.components["GlobalConstraint"].static
 
 
 def test_incidence_matrix(ac_dc_subnetwork: SubNetwork) -> None:
-    lines = ac_dc_subnetwork.static("Line")
-    buses = ac_dc_subnetwork.static("Bus")
+    lines = ac_dc_subnetwork.components["Line"].static
+    buses = ac_dc_subnetwork.components["Bus"].static
     A = ac_dc_subnetwork.incidence_matrix()
     assert A.shape == (len(buses), len(lines))
 
 
 def test_incidence_matrix_inactive(ac_dc_subnetwork_inactive: SubNetwork) -> None:
-    lines = ac_dc_subnetwork_inactive.static("Line")
-    buses = ac_dc_subnetwork_inactive.static("Bus")
+    lines = ac_dc_subnetwork_inactive.components.lines.static
+    buses = ac_dc_subnetwork_inactive.components.buses.static
     A = ac_dc_subnetwork_inactive.incidence_matrix()
     assert A.shape == (len(buses), len(lines[lines["active"]]))


### PR DESCRIPTION
Supersedes #1335
Reverts #1334

## Changes proposed in this Pull Request
In addition to the deprecated API changes, this PR fixes a bug whereby iterating over n.components also yielded empty components. This was incompatible with n.iterate_components(). This is a step towards having optional components, which are ignored when empty. Selecting specific component types from the component store comes in another PR.

@coroa Changes indeed blew up, so it was easier to start from scratch. I haven't checked if you added any other changes besides resolving the deprecations in #1335. Could you double check?

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
