### PR TITLE
Fix custom variable bug

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -59,6 +59,9 @@ Bug Fixes
   resulting in false update information being logged.
   (https://github.com/PyPSA/PyPSA/pull/1300)
 
+* Fix bug when using ``solver_model`` after adding custom variable to linopy model.
+  (https://github.com/PyPSA/PyPSA/issues/1351)
+
 `v0.35.2 <https://github.com/PyPSA/PyPSA/releases/tag/v0.35.2>`__ (15th August 2025)
 =======================================================================================
 Bug Fixes

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -615,8 +615,22 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             sol = variable.solution
             if name == "objective_constant":
                 continue
-
+            if "-" not in name:
+                # Custom variables might not contain a dash
+                logger.info(
+                    "The variable '%s' could not be mapped to the network component because it does not include the symbol '-'.",
+                    name,
+                )
+                continue
             _c_name, attr = name.split("-", 1)
+            if not hasattr(n.c, _c_name):
+                # Custom variables might correspond to a designated component
+                logger.info(
+                    "The variable '%s' could not be mapped to the network component because the component '%s' does not exist.",
+                    name,
+                    _c_name,
+                )
+                continue
             c = n.c[_c_name]
             df = _from_xarray(sol, c)
 

--- a/test/test_lopf_global_constraints.py
+++ b/test/test_lopf_global_constraints.py
@@ -103,3 +103,13 @@ def test_assign_duals_noname(ac_dc_network):
     dual_model_co2 = float(n.model.constraints["GlobalConstraint-co2_limit"].dual)
     dual_network_co2 = float(n.c.global_constraints.static.mu.loc["co2_limit"])
     assert dual_model_co2 == pytest.approx(dual_network_co2, rel=1e-8, abs=1e-10)
+
+
+def test_assign_custom_variable(ac_dc_network):
+    """Test that adding custom variables does not raise an error when optimizing."""
+    n = ac_dc_network
+    m = n.optimize.create_model()
+
+    m.add_variables(name="custom_var")
+
+    n.optimize.solve_model()


### PR DESCRIPTION
Closes #1351

## Changes proposed in this Pull Request
Solutions of custom variables in the linopy model that can not be mapped to a network component should be skipped.
Log message for user, to allow user to understand why it was skipped.


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.