### PR TITLE
feat: more default params options for optimization module

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -45,6 +45,8 @@ Features
   ``__version_short__`` → ``__version_major_minor__``. Removed tuple versions.
   Old names raise ``DeprecationWarning``.
 
+* Added new options to set default optimization parameters, like `solver_name` and
+  `solver_options`. See https://go.pypsa.org/options-params for more information.
 
 Bug Fixes
 ---------

--- a/pypsa/_options.py
+++ b/pypsa/_options.py
@@ -457,6 +457,7 @@ options._add_option(
 )
 
 # Parameters category
+
 options._add_option(
     "params.statistics.nice_names",
     True,
@@ -472,10 +473,27 @@ options._add_option(
     5,
     "Default value for the 'round' parameter in statistics module.",
 )
+
 options._add_option(
     "params.add.return_names",
     False,
     "Default value for the 'return_names' parameter in Network.add method. "
     "If True, the add method returns the names of added components. "
     "If False, it returns None.",
+)
+
+options._add_option(
+    "params.optimize.model_kwargs",
+    {},
+    "Default value for the 'model_kwargs' parameter in optimization module.",
+)
+options._add_option(
+    "params.optimize.solver_name",
+    "highs",
+    "Default value for the 'solver_name' parameter in optimization module.",
+)
+options._add_option(
+    "params.optimize.solver_options",
+    {},
+    "Default value for the 'solver_options' parameter in optimization module.",
 )

--- a/pypsa/_options.py
+++ b/pypsa/_options.py
@@ -326,6 +326,15 @@ class OptionsNode:
         params.add.return_names:
             Default: False
             Description: Default value for the 'return_names' parameter in Network.add method. If True, the add method returns the names of added components. If False, it returns None.
+        params.optimize.model_kwargs:
+            Default: {}
+            Description: Default value for the 'model_kwargs' parameter in optimization module.
+        params.optimize.solver_name:
+            Default: highs
+            Description: Default value for the 'solver_name' parameter in optimization module.
+        params.optimize.solver_options:
+            Default: {}
+            Description: Default value for the 'solver_options' parameter in optimization module.
         params.statistics.drop_zero:
             Default: True
             Description: Default value for the 'drop_zero' parameter in statistics module.
@@ -370,6 +379,15 @@ class OptionsNode:
         params.add.return_names:
             Default: False
             Description: Default value for the 'return_names' parameter in Network.add method. If True, the add method returns the names of added components. If False, it returns None.
+        params.optimize.model_kwargs:
+            Default: {}
+            Description: Default value for the 'model_kwargs' parameter in optimization module.
+        params.optimize.solver_name:
+            Default: highs
+            Description: Default value for the 'solver_name' parameter in optimization module.
+        params.optimize.solver_options:
+            Default: {}
+            Description: Default value for the 'solver_options' parameter in optimization module.
         params.statistics.drop_zero:
             Default: True
             Description: Default value for the 'drop_zero' parameter in statistics module.
@@ -453,7 +471,7 @@ options._add_option(
 options._add_option(
     "warnings.components_store_iter",
     True,
-    "If False, suppresses the deprecatio warning when iterating over components. ",
+    "If False, suppresses the deprecation warning when iterating over components.",
 )
 
 # Parameters category

--- a/pypsa/components/transform.py
+++ b/pypsa/components/transform.py
@@ -74,7 +74,7 @@ class ComponentsTransformMixin:
             ignored.
         return_names : bool | None, default=None
             Whether to return the names of the new components. Defaults to module wide
-            option (default: False). See `pypsa.options.params.add.describe()` for more
+            option (default: False). See https://go.pypsa.org/options-params for more
             information.
         kwargs : Any
             Component attributes, e.g. x=[0.1, 0.2], can be list, pandas.Series

--- a/pypsa/network/transform.py
+++ b/pypsa/network/transform.py
@@ -79,7 +79,7 @@ class NetworkTransformMixin(_NetworkABC):
             ignored.
         return_names : bool | None, default=None
             Whether to return the names of the components added. Defaults to module wide
-            option (default: False). See `pypsa.options.params.add.describe()` for more
+            option (default: False). See https://go.pypsa.org/options-params for more
             information.
         kwargs : Any
             Component attributes, e.g. x=[0.1, 0.2], can be list, pandas.Series
@@ -134,7 +134,7 @@ class NetworkTransformMixin(_NetworkABC):
 
 
         """
-        # Use option default if return_names is None
+        # Handle default parameters from options
         if return_names is None:
             return_names = options.params.add.return_names
 

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from pypsa._options import options
 from pypsa.descriptors import nominal_attrs
 from pypsa.optimization.mga import OptimizationAbstractMGAMixin
 
@@ -391,15 +392,18 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
         multi_investment_periods : bool, default False
             Whether to optimise as a single investment period or to optimise in multiple
             investment periods. Then, snapshots should be a ``pd.MultiIndex``.
-        model_kwargs: dict
+        model_kwargs : dict, optional
             Keyword arguments used by `linopy.Model`, such as `solver_dir` or `chunk`.
+            Defaults to module wide option (default: {}). See
+            https://go.pypsa.org/options-params for more information.
         **kwargs:
             Keyword argument used by `linopy.Model.solve`, such as `solver_name`,
             `problem_fn` or solver options directly passed to the solver.
 
         """
+        # Handle default parameters from options
         if model_kwargs is None:
-            model_kwargs = {}
+            model_kwargs = options.params.optimize.model_kwargs.copy()
 
         n = self._n
 

--- a/pypsa/optimization/mga.py
+++ b/pypsa/optimization/mga.py
@@ -15,6 +15,7 @@ import pandas as pd
 from linopy import LinearExpression, QuadraticExpression, merge
 from scipy.stats.qmc import Halton
 
+from pypsa._options import options
 from pypsa.descriptors import nominal_attrs
 
 if TYPE_CHECKING:
@@ -302,9 +303,10 @@ class OptimizationAbstractMGAMixin:
             Can also be 'max'.
         slack : float
             Cost slack for budget constraint. Defaults to 0.05.
-        model_kwargs: dict
-            Keyword arguments used by `linopy.Model`, such as `solver_dir` or
-            `chunk`.
+        model_kwargs : dict, optional
+            Keyword arguments used by `linopy.Model`, such as `solver_dir` or `chunk`.
+            Defaults to module wide option (default: {}). See
+            https://go.pypsa.org/options-params for more information.
         **kwargs:
             Keyword argument used by `linopy.Model.solve`, such as `solver_name`,
 
@@ -319,8 +321,10 @@ class OptimizationAbstractMGAMixin:
             https://linopy.readthedocs.io/en/latest/generated/linopy.constants.TerminationCondition.html
 
         """
+        # Handle default parameters from options
         if model_kwargs is None:
-            model_kwargs = {}
+            model_kwargs = options.params.optimize.model_kwargs.copy()
+
         n = self._n
 
         if snapshots is None:
@@ -449,9 +453,10 @@ class OptimizationAbstractMGAMixin:
             ``pd.MultiIndex``.
         slack : float
             Cost slack for budget constraint. Defaults to 0.05.
-        model_kwargs: dict
-            Keyword arguments used by `linopy.Model`, such as `solver_dir` or
-            `chunk`.
+        model_kwargs : dict, optional
+            Keyword arguments used by `linopy.Model`, such as `solver_dir` or `chunk`.
+            Defaults to module wide option (default: {}). See
+            https://go.pypsa.org/options-params for more information.
         **kwargs:
             Keyword argument used by `linopy.Model.solve`, such as `solver_name`,
 
@@ -473,6 +478,10 @@ class OptimizationAbstractMGAMixin:
             this value is None.
 
         """
+        # Handle default parameters from options
+        if model_kwargs is None:
+            model_kwargs = options.params.optimize.model_kwargs.copy()
+
         # Check consistency of `direction` and `dimensions` arguments: keys have to be the same
         if set(direction.keys()) != set(dimensions.keys()):
             msg = (
@@ -483,9 +492,6 @@ class OptimizationAbstractMGAMixin:
 
         if snapshots is None:
             snapshots = self._n.snapshots
-
-        if model_kwargs is None:
-            model_kwargs = {}
 
         # check that network has been solved
         if not self._n.is_solved:
@@ -608,9 +614,10 @@ class OptimizationAbstractMGAMixin:
             multiple investment periods. Then, snapshots should be a ``pd.MultiIndex``.
         slack : float
             Cost slack for budget constraint. Defaults to 0.05.
-        model_kwargs: dict
-            Keyword arguments used by `linopy.Model`, such as `solver_dir` or
-            `chunk`.
+        model_kwargs : dict, optional
+            Keyword arguments used by `linopy.Model`, such as `solver_dir` or `chunk`.
+            Defaults to module wide option (default: {}). See
+            https://go.pypsa.org/options-params for more information.
         max_parallel : int
             Maximum number of parallel processes to use for solving multiple directions.
             Defaults to 4.
@@ -651,6 +658,10 @@ class OptimizationAbstractMGAMixin:
         ...
 
         """
+        # Handle default parameters from options
+        if model_kwargs is None:
+            model_kwargs = options.params.optimize.model_kwargs.copy()
+
         # Iterate over rows of `directions` if a DataFrame
         if isinstance(directions, pd.DataFrame):
             directions = list(directions.T.to_dict().values())

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -314,7 +314,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         model_kwargs: dict | None = None,
         extra_functionality: Callable | None = None,
         assign_all_duals: bool = False,
-        solver_name: str = "highs",
+        solver_name: str | None = None,
         solver_options: dict | None = None,
         compute_infeasibilities: bool = False,
         **kwargs: Any,
@@ -336,8 +336,10 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             Defaults to 0, which ignores losses.
         linearized_unit_commitment : bool, default False
             Whether to optimise using the linearised unit commitment formulation or not.
-        model_kwargs: dict
+        model_kwargs : dict, optional
             Keyword arguments used by `linopy.Model`, such as `solver_dir` or `chunk`.
+            Defaults to module wide option (default: {}). See
+            https://go.pypsa.org/options-params for more information.
         extra_functionality : callable
             This function must take two arguments
             `extra_functionality(n, snapshots)` and is called after
@@ -347,10 +349,14 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         assign_all_duals : bool, default False
             Whether to assign all dual values or only those that already
             have a designated place in the network.
-        solver_name : str
-            Name of the solver to use.
-        solver_options : dict
+        solver_name : str, optional
+            Name of the solver to use. Defaults to module wide option
+            (default: 'highs'). See https://go.pypsa.org/options-params for more
+            information.
+        solver_options : dict, optional
             Keyword arguments used by the solver. Can also be passed via `**kwargs`.
+            Defaults to module wide option (default: {}). See
+            https://go.pypsa.org/options-params for more information.
         compute_infeasibilities : bool, default False
             Whether to compute and print Irreducible Inconsistent Subsystem (IIS) in case
             of an infeasible solution. Requires Gurobi.
@@ -369,11 +375,13 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             https://linopy.readthedocs.io/en/latest/generated/linopy.constants.TerminationCondition.html
 
         """
+        # Handle default parameters from options
         if model_kwargs is None:
-            model_kwargs = {}
-
+            model_kwargs = options.params.optimize.model_kwargs.copy()
+        if solver_name is None:
+            solver_name = options.params.optimize.solver_name
         if solver_options is None:
-            solver_options = {}
+            solver_options = options.params.optimize.solver_options.copy()
 
         n = self._n
         sns = as_index(n, snapshots, "snapshots")
@@ -546,7 +554,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
     def solve_model(
         self,
         extra_functionality: Callable | None = None,
-        solver_name: str = "highs",
+        solver_name: str | None = None,
         solver_options: dict | None = None,
         assign_all_duals: bool = False,
         **kwargs: Any,
@@ -561,10 +569,14 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             the model building is complete, but before it is sent to the
             solver. It allows the user to
             add/change constraints and add/change the objective function.
-        solver_name : str
-            Name of the solver to use.
-        solver_options : dict
-            Keyword arguments used by the solver. Can also be passed via `**kwargs`.
+        solver_name : str | None, default=None
+            Name of the solver to use. Defaults to module wide option
+            (default: 'highs'). See https://go.pypsa.org/options-params for more
+            information.
+        solver_options : dict | None, default=None
+            Keyword arguments used by the solver. Defaults to module wide option
+            (default: {}). Can also be passed via `**kwargs`. See
+            https://go.pypsa.org/options-params for more information.
         assign_all_duals : bool, default False
             Whether to assign all dual values or only those that already
             have a designated place in the network.
@@ -584,8 +596,11 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             https://linopy.readthedocs.io/en/latest/generated/linopy.constants.TerminationCondition.html
 
         """
+        # Handle default parameters from options
         if solver_options is None:
-            solver_options = {}
+            solver_options = options.params.optimize.solver_options.copy()
+        if solver_name is None:
+            solver_name = options.params.optimize.solver_name
 
         n = self._n
         if extra_functionality:

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -506,15 +506,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Returns
         -------
@@ -616,15 +614,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -714,15 +710,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -817,15 +811,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -930,15 +922,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -1045,15 +1035,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -1159,15 +1147,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Returns
         -------
@@ -1262,15 +1248,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -1425,15 +1409,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -1540,15 +1522,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -1638,15 +1618,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -1736,15 +1714,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -1850,15 +1826,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -1983,15 +1957,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -2088,15 +2060,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -2196,15 +2166,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------
@@ -2325,15 +2293,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names : bool | None, default=None
             Whether to use carrier nice names defined in n.carriers.nice_name. Defaults
             to module wide option (default: True).
-            See `pypsa.options.params.statistics.describe()` for more information.
+            See https://go.pypsa.org/options-params for more information.
         drop_zero : bool | None, default=None
             Whether to drop zero values from the result. Defaults to module wide option
-            (default: True). See `pypsa.options.params.statistics.describe()` for more
-            information.
+            (default: True). See https://go.pypsa.org/options-params for more information.
         round : int | None, default=None
             Number of decimal places to round the result to. Defaults to module wide
-            option (default: 2). See `pypsa.options.params.statistics.describe()` for
-            more information.
+            option (default: 2). See https://go.pypsa.org/options-params for more information.
 
         Other Parameters
         ----------------

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -1,5 +1,7 @@
 import pytest
 
+import pypsa
+
 
 @pytest.fixture
 def mocked_pypsa():
@@ -238,3 +240,22 @@ def test_add_return_names_option():
         assert isinstance(result, pd.Index)
         assert result[0] == "bus5"
     assert n.add("Bus", "bus6") is None  # Back to False
+
+
+def test_params_optimize():
+    n = pypsa.examples.ac_dc_meshed()
+
+    n.optimize()
+    assert n.model.solver_name == "highs"
+
+    n.optimize.create_model()
+    n.optimize.solve_model()
+    assert n.model.solver_name == "highs"
+
+    with pypsa.option_context("params.optimize.solver_name", "gurobi"):
+        n.optimize()
+        assert n.model.solver_name == "gurobi"
+
+        n.optimize.create_model()
+        n.optimize.solve_model()
+        assert n.model.solver_name == "gurobi"


### PR DESCRIPTION
## Changes proposed in this Pull Request
Adds options to set defaults for optimization parameters: `model_kwargs`, `solver_name`, `solver_options`

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
