### PR TITLE
Optimize _sort_attrs for already ordered axes

### DIFF
--- a/doc/references/release-notes.rst
+++ b/doc/references/release-notes.rst
@@ -56,6 +56,8 @@ Features
   ``__version_short__`` → ``__version_major_minor__``. Removed tuple versions.
   Old names raise ``DeprecationWarning``.
 
+* Improve performance of loading networks by avoiding re-ordering dataframe columns and indices where unnecessary; especially impactful for networks with large numbers of components.
+
 
 Bug Fixes
 ---------

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1046,13 +1046,25 @@ def _sort_attrs(df: pd.DataFrame, attrs_list: list[str], axis: int) -> pd.DataFr
         Sorted DataFrame
 
     """
-    df_cols_set = set(df.columns if axis == 1 else df.index)
+    axis_labels = df.columns if axis == 1 else df.index
+    if len(axis_labels) == 0 or len(attrs_list) == 0:
+        return df
 
-    existing_cols = [col for col in attrs_list if col in df_cols_set]
-    remaining_cols = [
-        col for col in (df.columns if axis == 1 else df.index) if col not in attrs_list
-    ]
-    return df.reindex(existing_cols + remaining_cols, axis=axis)
+    labels_set = set(axis_labels)
+    existing_cols = [col for col in attrs_list if col in labels_set]
+    if not existing_cols:
+        return df
+
+    axis_list = list(axis_labels)
+    remaining_cols = [col for col in axis_list if col not in attrs_list]
+    target = existing_cols + remaining_cols
+
+    if axis_list == target:
+        return df
+
+    if axis == 1:
+        return df.loc[:, target]
+    return df.loc[target]
 
 
 class NetworkIOMixin(_NetworkABC):

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1025,46 +1025,43 @@ class _ExporterNetCDF(_Exporter):
                 self.ds.to_netcdf(_path)
 
 
-def _sort_attrs(df: pd.DataFrame, attrs_list: list[str], axis: int) -> pd.DataFrame:
-    """Sort axis of DataFrame according to the order of attrs_list.
-
-    Attributes not in attrs_list are appended at the end. Attributes in the list but
-    not in the DataFrame are ignored.
+def _sort_attrs(
+    axis_labels: pd.Index, attrs_list: Sequence[str] | pd.Index
+) -> pd.Index:
+    """Order axis labels to match a desired attribute sequence.
 
     Parameters
     ----------
-    df : pandas.DataFrame
-        DataFrame to sort
-    attrs_list : list
-        List of attributes to sort by
-    axis : int
-        Axis to sort (0 for index, 1 for columns)
+    axis_labels : pandas.Index
+        Original axis labels that should be reordered.
+    attrs_list : Sequence[str] | pandas.Index
+        Desired ordering given as an ordered collection of attribute names.
 
     Returns
     -------
-    pd.DataFrame
-        Sorted DataFrame
+    pandas.Index
+        ``axis_labels`` with the attributes appearing in ``attrs_list`` first and
+        in the same order. Attributes missing from ``attrs_list`` follow in their
+        original order while names not present in ``axis_labels`` are ignored.
 
     """
-    axis_labels = df.columns if axis == 1 else df.index
-    if len(axis_labels) == 0 or len(attrs_list) == 0:
-        return df
+    if axis_labels.empty or len(attrs_list) == 0:
+        return axis_labels
 
-    labels_set = set(axis_labels)
-    existing_cols = [col for col in attrs_list if col in labels_set]
-    if not existing_cols:
-        return df
+    attrs_index = (
+        attrs_list if isinstance(attrs_list, pd.Index) else pd.Index(attrs_list)
+    )
+    existing = attrs_index.intersection(axis_labels, sort=False)
+    if existing.empty:
+        return axis_labels
 
-    axis_list = list(axis_labels)
-    remaining_cols = [col for col in axis_list if col not in attrs_list]
-    target = existing_cols + remaining_cols
+    remaining = axis_labels.difference(attrs_index, sort=False)
+    target = existing.append(remaining)
 
-    if axis_list == target:
-        return df
+    if axis_labels.equals(target):
+        return axis_labels
 
-    if axis == 1:
-        return df.loc[:, target]
-    return df.loc[target]
+    return target
 
 
 class NetworkIOMixin(_NetworkABC):
@@ -1819,7 +1816,16 @@ class NetworkIOMixin(_NetworkABC):
             new_static = gpd.GeoDataFrame(new_static, crs=self.crs)
 
         # Align index (component names) and columns (attributes)
-        new_static = _sort_attrs(new_static, attrs.index, axis=1)
+        ordered_columns = _sort_attrs(new_static.columns, attrs.index)
+        if not new_static.columns.equals(ordered_columns):
+            if isinstance(new_static.columns, pd.MultiIndex):
+                new_static = new_static.loc[:, ordered_columns]
+            else:
+                indexer = new_static.columns.get_indexer(ordered_columns)
+                if (indexer >= 0).all():
+                    new_static = new_static.iloc[:, indexer]
+                else:
+                    new_static = new_static.loc[:, ordered_columns]
 
         new_static.index.names = (
             ["name"]
@@ -1919,10 +1925,9 @@ class NetworkIOMixin(_NetworkABC):
         if not attrs.loc[attr].static:
             # Preserve static component order for consistency
             ordered_columns = _sort_attrs(
-                pd.DataFrame(columns=df.columns.union(static.index)),
-                static.index.tolist(),
-                axis=1,
-            ).columns
+                df.columns.union(static.index),
+                static.index,
+            )
             dynamic[attr] = dynamic[attr].reindex(
                 columns=ordered_columns,
                 fill_value=attrs.loc[attr].default,
@@ -1930,10 +1935,9 @@ class NetworkIOMixin(_NetworkABC):
         else:
             # Preserve existing dynamic order for static attrs
             ordered_columns = _sort_attrs(
-                pd.DataFrame(columns=df.columns.union(dynamic[attr].columns)),
-                dynamic[attr].columns.tolist(),
-                axis=1,
-            ).columns
+                df.columns.union(dynamic[attr].columns),
+                dynamic[attr].columns,
+            )
             dynamic[attr] = dynamic[attr].reindex(columns=ordered_columns)
 
         dynamic[attr].loc[self.snapshots, df.columns] = df.loc[


### PR DESCRIPTION
## Changes proposed in this Pull Request

This is a fairly simple change, adding a few fast-paths when reading networks from an .nc file.

In a slightly strange model I was working with, loading the model was taking minutes because `_sort_attrs` always ran a full reindex, even when the DataFrame’s axis already matched the target order. I will say that this was in a large network with lots and lots of components but not really any time series data; a fair atypical use-case but still.

In pypsa/network/io.py, `_sort_attrs` now:

- Returns immediately for empty data, missing attr lists, or when no columns/index overlap with attrs_list.
- Compares the current axis order with the desired order and skips the reindex if they’re already aligned.
- Falls back to a single df.loc[...] realignment only when the order actually differs.

The behaviour should be the same (and on my side all the tests passed), but in the example of my slightly weird model it cut the network loading time down from over 3 minutes to below 10 seconds (we're talking a 50MB .nc file size so IO was not a dominating factor).

Let me know if this is good as is or if you want more documentation / testing / release note :)

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
