### PR TITLE
Fixed misaligned indices for pie charts.

### DIFF
--- a/pypsa/plot/maps/interactive.py
+++ b/pypsa/plot/maps/interactive.py
@@ -902,7 +902,7 @@ class PydeckPlotter:
         )
         bus_size = bus_size.unstack(level=1, fill_value=0)
         carrier_order = bus_size.columns.to_numpy()
-        
+
         valid_buses = bus_data.index.intersection(bus_size.index)
         bus_size = bus_size.loc[valid_buses]
 
@@ -931,7 +931,9 @@ class PydeckPlotter:
         bus_radius_neg = (bus_area_neg / np.pi) ** 0.5
 
         # Convert to NumPy arrays for speed-up
-        bus_coords = np.column_stack([self._x.loc[valid_buses], self._y.loc[valid_buses]]) # assumes that bus_data is aligned with self._x and self._y, done above
+        bus_coords = np.column_stack(
+            [self._x.loc[valid_buses], self._y.loc[valid_buses]]
+        )  # assumes that bus_data is aligned with self._x and self._y, done above
         bus_indices = valid_buses.to_numpy()
         bus_values = bus_size.to_numpy()
 

--- a/test/test_plot_maps_interactive.py
+++ b/test/test_plot_maps_interactive.py
@@ -1,6 +1,7 @@
+import sys
+
 import pydeck as pdk
 import pytest
-import sys
 
 import pypsa.plot.maps.interactive as interactive
 from pypsa.plot.maps.common import _is_cartopy_available
@@ -125,9 +126,8 @@ def test_pdk_tooltips(ac_dc_network):
     plotter.deck(tooltip=True)
     plotter.deck(tooltip=False)
 
-@pytest.mark.skipif(
-    sys.platform != "linux", reason="Cartopy issues on macos."
-)
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Cartopy issues on macos.")
 def test_geomap_warning(ac_dc_network, caplog):
     n = ac_dc_network
     with caplog.at_level("WARNING"):
@@ -178,9 +178,8 @@ def test_extra_columns(ac_dc_network, caplog):
     assert "bus0" in df.columns
     assert "doesnotexist" not in df.columns
 
-@pytest.mark.skipif(
-    sys.platform != "linux", reason="Cartopy issues on macos."
-)
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Cartopy issues on macos.")
 @pytest.mark.skipif(not cartopy_present, reason="Cartopy not installed")
 def test_geomap_params(ac_dc_network):
     n = ac_dc_network

--- a/test/test_plot_maps_interactive.py
+++ b/test/test_plot_maps_interactive.py
@@ -1,5 +1,6 @@
 import pydeck as pdk
 import pytest
+import sys
 
 import pypsa.plot.maps.interactive as interactive
 from pypsa.plot.maps.common import _is_cartopy_available
@@ -124,7 +125,9 @@ def test_pdk_tooltips(ac_dc_network):
     plotter.deck(tooltip=True)
     plotter.deck(tooltip=False)
 
-
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="Cartopy issues on macos."
+)
 def test_geomap_warning(ac_dc_network, caplog):
     n = ac_dc_network
     with caplog.at_level("WARNING"):
@@ -175,7 +178,9 @@ def test_extra_columns(ac_dc_network, caplog):
     assert "bus0" in df.columns
     assert "doesnotexist" not in df.columns
 
-
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="Cartopy issues on macos."
+)
 @pytest.mark.skipif(not cartopy_present, reason="Cartopy not installed")
 def test_geomap_params(ac_dc_network):
     n = ac_dc_network


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Fixed a bug in `n.explore()` that would misalign scaled pie charts to wrong locations
- https://github.com/PyPSA/PyPSA/pull/1312
- Fixed by reindexing before conversion to numpy array.

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [X] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X] I consent to the release of this PR's code under the MIT license.

<img width="466" height="591" alt="image" src="https://github.com/user-attachments/assets/6fa34dcd-41b4-4543-ae5d-e0b427f00916" />


vs.

<img width="450" height="389" alt="image" src="https://github.com/user-attachments/assets/5b3806dd-9836-467c-a9a4-8be513bfff77" />

