### PR TITLE
docs: add user-guide for risk-averse optimization

### DIFF
--- a/pypsa/network/transform.py
+++ b/pypsa/network/transform.py
@@ -214,7 +214,7 @@ class NetworkTransformMixin(_NetworkABC):
             raise ValueError(msg)
 
         # Check custom attributes
-        standard_attrs = set(c.attrs.index)
+        standard_attrs = set(c.defaults.index)
         custom_attrs = set(kwargs.keys()) - standard_attrs
         if custom_attrs:
             # Raise warning if user adds a custom attribute which is a standard attribute


### PR DESCRIPTION
This PR extends documentation for stochastic optimization with a description of the risk-averse optimization functionality introduced recently in #1345. 

- [x] I consent to the release of this PR's code under the MIT license.
