### PR TITLE
fix: fix conftest problem

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -318,7 +318,7 @@ def stochastic_benchmark_network():
     FOM, DR, LIFE = 3.0, 0.03, 25
 
     for cfg in TECH.values():
-        cfg["fixed_cost"] = (pypsa.common.annuity(LIFE, DR) + FOM / 100) * cfg["inv"]
+        cfg["fixed_cost"] = (pypsa.common.annuity(DR, LIFE) + FOM / 100) * cfg["inv"]
 
     # Load time series data from URL - same as in the original script
     ts = pd.read_csv(TS_URL, index_col=0, parse_dates=True).resample(FREQ).asfreq()


### PR DESCRIPTION
This PR fixes a problem with failing tests in stochastic optimization test suite.

The problem was introduced in 15eeffc4359e9977b67909912bf45b1c033969c2 ("clustering user guide") where the commit removes the local annuity(lifetime, r) helper function and replaced it with pypsa.community.annuity() but does not swap the argument order. The local function signature was (lifetime, rate) but the pypsa.common.annuity has (rate, lifetime). 

this wasn't easy to find where this problem in v1-docs history I must admit 🧙‍♂️

- [x] I consent to the release of this PR's code under the MIT license.
