### PR TITLE
Change max_relative_growth unit to nan

### DIFF
--- a/pypsa/data/component_attrs/carriers.csv
+++ b/pypsa/data/component_attrs/carriers.csv
@@ -4,4 +4,4 @@ co2_emissions,float,tonnes/MWh,0,Emissions in tCO~2~ per MWh of primary energy (
 color,string,n/a,n/a,Color for plotting (e.g. `matplotlib` [named colors](https://matplotlib.org/stable/gallery/color/named_colors.html) or hexadecimal color codes like "#AB9812"),Input (optional)
 nice_name,string,n/a,n/a,Descriptive name for statistics and visualisations (e.g. "Natural Gas" for carrier `gas`),Input (optional)
 max_growth,float,MW,inf,Maximum new installed capacity per investment period,Input (optional)
-max_relative_growth,float,MW,0,Maximum capacity ratio for new installed capacity per investment period,Input (optional)
+max_relative_growth,float,nan,0,Maximum capacity ratio for new installed capacity per investment period,Input (optional)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: PyPSA Contributors

SPDX-License-Identifier: MIT
-->

Closes # (if applicable).

## Changes proposed in this Pull Request
Correct unit for `max_relativ_growth` 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
