### PR TITLE
fix: allow Path type in io methods

### DIFF
--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1462,7 +1462,7 @@ class NetworkIOMixin(_NetworkABC):
 
     def export_to_csv_folder(
         self,
-        path: str,
+        path: Path | str,
         encoding: str | None = None,
         quotechar: str = '"',
         export_standard_types: bool = False,
@@ -1484,7 +1484,7 @@ class NetworkIOMixin(_NetworkABC):
 
         Parameters
         ----------
-        path : string
+        path : Path | str
             Name of folder to which to export.
         encoding : str, default None
             Encoding to use for UTF when reading (ex. 'utf-8'). See [List of Python
@@ -1664,7 +1664,7 @@ class NetworkIOMixin(_NetworkABC):
 
         Parameters
         ----------
-        path : string|xr.Dataset
+        path : string | Path | xr.Dataset
             Path to netCDF dataset or instance of xarray Dataset.
             The string could be a URL.
         skip_time : bool, default False


### PR DESCRIPTION
## Changes proposed in this Pull Request

Allow passing a `Path` to `n.export_to_netcdf()`. It works already, but the argument type didn't allow for the option.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable) – not necessary, I believe?
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included – not necessary, I believe?
- [x] I consent to the release of this PR's code under the MIT license.
