### PR TITLE
[TEST] Verify doctest failures on master

### DIFF
--- a/test/test_common.py
+++ b/test/test_common.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+# Testing CI doctest failures - this is a no-op change
+
 import copy
 import warnings
 from unittest.mock import patch


### PR DESCRIPTION
## Purpose

This is a test PR to verify that the doctest failures seen in #1425 are pre-existing on master and not related to the time-varying startup cost changes.

## Changes

- Added a single comment to `test/test_common.py` (no functional changes)

## Expected Result

If the CI "Check docs" job fails with the same errors as #1425, this confirms the doctest failures are on master.

**This PR should be closed after verification - it serves only as a test.**