### PR TITLE
ci: free up disk space

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -118,6 +118,10 @@ jobs:
           results
         retention-days: 3
 
+    - name: Show remaining disk space
+      if: always()
+      run: df -h
+
 # Temporarily disabled until PyPSA-DE issues are resolved. This is not a problem of PyPSA.
   # test-pypsa-de:
   #   name: PyPSA-DE


### PR DESCRIPTION
## Changes proposed in this Pull Request
Hacky and I don't like it, but this resolves the disk space issues and gives us an extra ~20GB. The model runs within `PyPSA` are making problems again. Those in `PyPSA-Eur` not yet, but I guess it's just a matter of time.

This is just following 
https://carlosbecker.com/posts/github-actions-disk-space/
