### PR TITLE
Fix markdown syntax for pip install command

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -30,7 +30,7 @@ with new ideas, suggestions, submitting bug reports or contributing code changes
 1. Fork the repository on GitHub
 2. Clone your fork: `git clone https://github.com/<your-username>/PyPSA.git`
 3. Fetch the upstream tags `git fetch --tags https://github.com/PyPSA/PyPSA.git`
-4. Install with dependencies in editable mode: `pip install -e .[dev]`
+4. Install with dependencies in editable mode: `pip install -e '.[dev]'`
 5. Setup linter and formatter, e.g `pre-commit install` (see [Code Style](#style))
 6. Write your code (preferably on a new branch)
 7. Run tests: `pytest` (see [Testing](#testing))


### PR DESCRIPTION
Single quotes to avoid shell-glob issues

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
