### PR TITLE
Line losses with absolute approximation error

### DIFF
--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1692,13 +1692,11 @@ def define_loss_constraints(
         loss <= upper_limit, name=f"{c.name}-loss_upper", mask=active
     )
     # Add lower limit constraint
-    n.model.add_constraints(
-        loss >= 0, name=f"{c.name}-loss_lower", mask=active
-    )
+    n.model.add_constraints(loss >= 0, name=f"{c.name}-loss_lower", mask=active)
 
     eps = transmission_losses
 
-    delta_p = sqrt(eps / r_pu_eff) 
+    delta_p = sqrt(eps / r_pu_eff)
 
     n_tangents = (s_max_pu * s_nom_max) // (2 * delta_p)
     if n_tangents.max().item() > 10:
@@ -1706,14 +1704,16 @@ def define_loss_constraints(
             f"High number of tangents ({n_tangents.max().item()}) for line loss "
             f"approximation. Consider increasing 'eps' to reduce model size."
         )
-    for k in range(1, int(n_tangents.max().item()) + 1): # starting at 1 here is important, else we get nans for the lines with 0 tangents
+    for k in range(
+        1, int(n_tangents.max().item()) + 1
+    ):  # starting at 1 here is important, else we get nans for the lines with 0 tangents
         mask = n_tangents >= k
         # The commented lines are equivalent to the lines below, but numerically ill conditioned
-        # p_k = k * 2  * delta_p.where(mask, 0) 
+        # p_k = k * 2  * delta_p.where(mask, 0)
         # slope_k = 2 * r_pu_eff * p_k
         # offset_k = -r_pu_eff * p_k**2
         slope_k = 4 * k * sqrt(eps * r_pu_eff).where(mask, 0)
-        offset_k = - 4 * k**2 * eps * mask
+        offset_k = -4 * k**2 * eps * mask
 
         # Add constraints for both positive and negative flow
         for sign in [-1, 1]:


### PR DESCRIPTION
Closes #1320.
## Changes proposed in this Pull Request
If line losses are enabled, changing the capacity maximum for lines `s_nom_max`, affects the results of the optimization - even if the constraint is not binding (see #1320). The reason is that the tangents which approximate the quadratic loss depend on `s_nom_max`. More precisely: Currently the user specifies a number `N` of tangents they want to use for the approximation, and then the interval `[0, s_nom_max]` is divided into `N` segments, each corresponding to one tangent. If `s_nom_max` is changed, these intervals change, and so do the corresponding tangents. This PR  suggests to specify an absolute tolerance for the approximation error instead and to use that to partition `[0, s_nom_max]`. In this case, if `s_nom_max` is changed, the number of tangents in the approximation changes, but the tangents that still exist are the same.

Let $\epsilon$ be the absolute error tolerance, $r x^2$ be the loss parabola, and $2 r x_0 x   -  r  x_0^2$ be its tangent at the point $x_0$. Consider the points where the approximation error is exactly $\epsilon$, that is $r x^2 - 2 r x_0 x  + r x_0^2 = \epsilon$, the roots of this polynomial are $x_0 \pm \sqrt{\epsilon/r}$. We can conclude that the approximation error is smaller than $\epsilon$ in the interval $[x_0 - \sqrt{\epsilon/r}, x_0 + \sqrt{\epsilon/r}]$. Thus, if we pick the tangents at $x0 = \dots, -4\sqrt{\epsilon/r}, -2\sqrt{\epsilon/r}, 0, 2\sqrt{\epsilon/r}, 4\sqrt{\epsilon/r}, \dots$ we can be sure that the absolute error of the approximation is smaller than $\epsilon$ .

From this we can compute the number of tangents we need for a conservative loss approximation with error at most $\epsilon$ by partitioning the interval `[-s_nom_max, s_nom_max]` into segments of length $2\sqrt{\epsilon/r}$. If `s_nom_max` is very large or $\epsilon$ is too small the number of tangents may get large. To avoid performance hits from that, I added a warning.

This PR is orthogonal to https://github.com/PyPSA/PyPSA/pull/1409. It does not primarily improve the quality of the approximation, but fixes the side-effects of changing `s_nom_max`. 

## Checklist
This is a draft of the proposed change, if your feedback is positive I will polish it up.

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
