### PR TITLE
fix: pin `netcdf!=1.7.4`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "scipy",
     "pandas>=0.24",
     "xarray",
-    "netcdf4",
+    "netcdf4!=1.7.4",  # See https://github.com/PyPSA/PyPSA/issues/1510
     "linopy>=0.5.5",
     "matplotlib",
     "plotly",


### PR DESCRIPTION
Ignore netcdf4 1.7.4 which  misses some wheels (see [here](https://pypi.org/project/netCDF4/1.7.4/#files)).