### PR TITLE
fix: update pydeck min version to 0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "linopy>=0.5.5",
     "matplotlib",
     "plotly",
-    "pydeck",
+    "pydeck>=0.6",
     "seaborn",
     "geopandas>=0.9",
     "shapely",


### PR DESCRIPTION
## Changes proposed in this Pull Request

With pydeck < 0.6, `import pypsa` fails with:

```python
366 # Class-level constants
367 VALID_MAP_STYLES = {
368     "light": pdk.map_styles.LIGHT,
369     "dark": pdk.map_styles.DARK,
--> 370     "road": pdk.map_styles.ROAD,
371     "dark_no_labels": pdk.map_styles.DARK_NO_LABELS,
372     "light_no_labels": pdk.map_styles.LIGHT_NO_LABELS,
373     "none": "",
374 }
375 ARROW = np.array(
376     [
377         [1, 0],  # reference triangle as arrow head
(...)    380     ]
381 )
382 ARROW = ARROW - ARROW.mean(axis=0)  # center at geometric center

AttributeError: module 'pydeck.bindings.map_styles' has no attribute 'ROAD'
```

This is pulled into some environments through some strange version restriction interactions.

@lkstrp Please also remember to add this version constraint to the feedstock recipe, when you release the next version. Thanks

## Checklist

- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
