### PR TITLE
docs: add partial elastic demand and log-log approximation

### DIFF
--- a/docs/examples/demand-elasticity.ipynb
+++ b/docs/examples/demand-elasticity.ipynb
@@ -465,7 +465,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n.optimize(solver_name=\"gurobi\")",
+    "n.optimize(solver_name=\"gurobi\")"
    ]
   },
   {
@@ -559,7 +559,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n.optimize(solver_name=\"gurobi\")",
+    "n.optimize(solver_name=\"gurobi\")"
    ]
   },
   {


### PR DESCRIPTION
Addition of partial demand elasticity and a piecewise-linear demand curve as approximation for a log-log demand curve as proposed in Brown, Neumann, Riepin (2025)

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
