### PR TITLE
feat: support paths in network collection init

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,7 @@ SPDX-License-Identifier: CC-BY-4.0
     - Improved multi-level index handling with automatic grouping/faceting
 
 - Add environment variable support for options via `PYPSA_*` prefix (e.g., `PYPSA_PARAMS__OPTIMIZE__SOLVER_NAME=gurobi`). (<!-- md:pr 1513 -->)
+- Add support for pathlike arguments in NetworkCollection initialization.
 
 ## [**v1.0.7**](https://github.com/PyPSA/PyPSA/releases/tag/v1.0.7) <small>13th January 2026</small> { id="v1.0.7" }
 

--- a/pypsa/collection.py
+++ b/pypsa/collection.py
@@ -11,6 +11,11 @@ from typing import Any
 
 import pandas as pd
 
+try:
+    from cloudpathlib import AnyPath as Path
+except ImportError:
+    from pathlib import Path
+
 from pypsa._options import options
 from pypsa.definitions.structures import Dict
 from pypsa.networks import Network
@@ -129,17 +134,17 @@ class NetworkCollection:
 
     def __init__(
         self,
-        networks: pd.Series | Sequence[Network | str],
+        networks: pd.Series | Sequence[Network | str | Path],
         index: pd.Index | pd.MultiIndex | Sequence | None = None,
     ) -> None:
         """Initialize the NetworkCollection with one or more networks.
 
         Parameters
         ----------
-        networks : pd.Series | Sequence[Network | str]
-            Sequence or pd.Series of Network objects or strings (file paths/ urls) to
-            include in the collection. If strings are provided, they will be passed to
-            pypsa.Network() to create Network objects.
+        networks : pd.Series | Sequence[Network | str | Path]
+            Sequence or pd.Series of Network objects, strings (file paths/ urls), or
+            Path objects to include in the collection. If strings or Paths are provided,
+            they will be passed to pypsa.Network() to create Network objects.
         index : pd.Index, pd.MultiIndex, Sequence, or None, optional
             The index to use for the collection. If `networks` is of type `pd.Series`,
             no index is allowed and it will be retrieved from the Series. If None, a
@@ -161,10 +166,10 @@ class NetworkCollection:
         def _convert_to_network(item: Any) -> Network:
             if isinstance(item, Network):
                 return item
-            elif isinstance(item, str):
+            elif isinstance(item, (str | Path)):
                 return Network(item)
             else:
-                msg = f"All values must be PyPSA Network objects or strings, got {type(item)}."
+                msg = f"All values must be PyPSA Network objects, strings, or Path objects, got {type(item)}."
                 raise TypeError(msg)
 
         if isinstance(networks, pd.Series):

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -354,6 +354,47 @@ def test_collection_init_empty_string():
     assert isinstance(collection.networks.iloc[0], pypsa.Network)
 
 
+def test_collection_init_with_pathlib_path():
+    """Test initialization with pathlib.Path objects."""
+    from pathlib import Path
+
+    # Use existing example networks
+    path1 = Path("examples/networks/ac-dc-meshed/ac-dc-meshed.nc")
+    path2 = Path("examples/networks/storage-hvdc/storage-hvdc.nc")
+
+    # Test with list of Path objects
+    collection = pypsa.NetworkCollection([path1, path2])
+    assert len(collection) == 2
+    assert all(isinstance(n, pypsa.Network) for n in collection.networks)
+
+    # Test with pandas Series containing Path objects
+    networks_series = pd.Series([path1, path2], index=["net1", "net2"])
+    collection_series = pypsa.NetworkCollection(networks_series)
+    assert len(collection_series) == 2
+    assert all(isinstance(n, pypsa.Network) for n in collection_series.networks)
+
+
+def test_collection_init_mixed_networks_strings_and_paths(network1):
+    """Test initialization with mixed Network objects, strings, and Path objects."""
+    from pathlib import Path
+
+    network1.name = "manual_net"
+
+    # Use existing example networks
+    path_net = Path("examples/networks/ac-dc-meshed/ac-dc-meshed.nc")
+    str_net = "examples/networks/storage-hvdc/storage-hvdc.nc"
+
+    # Test with mixed list of Network and Path
+    collection = pypsa.NetworkCollection([network1, path_net])
+    assert len(collection) == 2
+    assert all(isinstance(n, pypsa.Network) for n in collection.networks)
+    assert collection["manual_net"] == network1
+
+    # Test with mixed list using string path as well
+    collection_mixed = pypsa.NetworkCollection([network1, str_net])
+    assert len(collection_mixed) == 2
+
+
 class TestCollectionComponents:
     """Test the components property of NetworkCollection."""
 


### PR DESCRIPTION
Closes #1525 

## Changes proposed in this Pull Request

Allow pathlike args in NetworkCollection initialization. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
