### PR TITLE
fix: align dimensions to not rely on transpose in linopy

### DIFF
--- a/pypsa/components/array.py
+++ b/pypsa/components/array.py
@@ -338,6 +338,9 @@ class ComponentsArrayMixin(_ComponentsABC):
                 .reindex(name=self.names)
                 .reindex(scenario=self.scenarios)
             )
+            # xr.unstack can leave .dims and .coords in different orders
+            # Make sure dimensions match
+            res = res.transpose(*[c for c in res.coords if c in res.dims])
 
         # Set attibute name as DataArray name
         res.name = attr

--- a/test/test_components_array.py
+++ b/test/test_components_array.py
@@ -151,6 +151,19 @@ def test_as_xarray_dynamic_with_scenarios(ac_dc_network):
     # TODO add test for non_dynamic_index
 
 
+def test_as_xarray_scenario_dim_order(ac_dc_network):
+    """Scenario dataarrays must have dims matching coords iteration order."""
+    n = ac_dc_network
+    n.scenarios = ["s1", "s2"]
+
+    for attr in ["active", "p_max_pu", "bus"]:
+        da = n.c.generators._as_xarray(attr)
+        coord_dim_order = tuple(c for c in da.coords if c in da.dims)
+        assert da.dims == coord_dim_order, (
+            f"Dim order mismatch for {attr}: dims={da.dims}, coords order={coord_dim_order}"
+        )
+
+
 def test_ds_property_consistency(ac_dc_network):
     n = ac_dc_network
     """Test that ds property returns the same data as individual da calls."""


### PR DESCRIPTION
Fix for `linopy==0.6.2`. See https://github.com/PyPSA/linopy/pull/575