### PR TITLE
docs: Fix a couple of typos

### DIFF
--- a/pypsa/data/component_attrs/line_types.csv
+++ b/pypsa/data/component_attrs/line_types.csv
@@ -2,7 +2,7 @@ attribute,type,unit,default,description,status
 name,string,n/a,n/a,Unique name,Input (required)
 f_nom,float,Hz,50.,Nominal frequency,Input (required)
 r_per_length,float,Ohm per km,0.,Series resistance per length,Input (required)
-x_per_length,float,Ohm per km,0.,Series resistance per length,Input (required)
+x_per_length,float,Ohm per km,0.,Series reactance per length,Input (required)
 c_per_length,float,nF per km,0.,Shunt capacitance per length,Input (optional)
 i_nom,float,kA,0.,Nominal current,Input (optional)
 mounting,string,n/a,ol,"Can be ""ol"" for overhead line or ""cs"" for cable",Input (optional)

--- a/pypsa/descriptors.py
+++ b/pypsa/descriptors.py
@@ -199,7 +199,7 @@ def get_bounds_pu(
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Retrieve per unit bounds of a given component.
 
-    Getter function to retrieve the per unit bounds of a given compoent for
+    Getter function to retrieve the per unit bounds of a given component for
     given snapshots and possible subset of elements (e.g. non-extendables).
     Depending on the attr you can further specify the bounds of the variable
     you are looking at, e.g. p_store for storage units.


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fix two typos in the documentation; one in LineType attributes, another in the docstring of the `get_bounds_pu()` function.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
