### PR TITLE
fix: preserve index name in expand_series

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Bug Fixes
 
+- Fix `expand_series` losing index name on the resulting DataFrame with pandas >= 3.0, which caused xarray alignment errors in multi-investment period optimization. (<!-- md:pr 1581 -->)
+
 ## [**v1.1.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.1.2) <small>23rd February 2026</small> { id="v1.1.2" }
 
 ### Bug Fixes

--- a/pypsa/common.py
+++ b/pypsa/common.py
@@ -840,7 +840,9 @@ def expand_series(ser: pd.Series, columns: Sequence[str]) -> pd.DataFrame:
     c   3.0   3.0
 
     """
-    return ser.to_frame(columns[0]).reindex(columns=columns).ffill(axis=1)
+    result = ser.to_frame(columns[0]).reindex(columns=columns).ffill(axis=1)
+    result.index.name = ser.index.name
+    return result
 
 
 def _scenarios_not_implemented(func: Callable) -> Callable:

--- a/test/test_descriptors.py
+++ b/test/test_descriptors.py
@@ -98,6 +98,15 @@ def test_expand_series():
     assert (df["a"] == df["b"]).all()
     assert (df["b"] == df["c"]).all()
 
+    # Test index name preservation with MultiIndex (regression for #1580)
+    mi = pd.MultiIndex.from_product(
+        [[2020, 2030], [1, 2]], names=["period", "timestep"]
+    )
+    mi.name = "snapshot"
+    s_named = pd.Series([1.0] * 4, index=mi)
+    df_named = expand_series(s_named, ["x", "y"])
+    assert df_named.index.name == "snapshot"
+
 
 def test_additional_linkports():
     n = pypsa.Network()


### PR DESCRIPTION
Closes #1580
Closes #1541

Another case where we loose the index names. This is only an issue for `pandas>3`