### PR TITLE
docs: reduce peak memory in scigrid-redispatch example

### DIFF
--- a/docs/examples/scigrid-redispatch.ipynb
+++ b/docs/examples/scigrid-redispatch.ipynb
@@ -79,7 +79,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "m = o.copy()  # for market model"
+   "source": [
+    "m = o.copy()  # for market model"
+   ]
   },
   {
    "cell_type": "code",
@@ -141,7 +143,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "zones = (o.buses.y > 51).map(lambda x: \"North\" if x else \"South\")"
+   "source": [
+    "zones = (o.buses.y > 51).map(lambda x: \"North\" if x else \"South\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -220,15 +224,20 @@
   },
   {
    "cell_type": "markdown",
-   "source": "Before building the redispatch model, we extract the market results we need and free the market model. This avoids holding all three network copies (`o`, `m`, `n`) in memory simultaneously. On production-scale networks, this reduces peak memory by ~33%.",
-   "metadata": {}
+   "metadata": {},
+   "source": "Before building the redispatch model, we extract the market results we need and free the market model. This avoids holding all three network copies (`o`, `m`, `n`) in memory simultaneously. On production-scale networks, this reduces peak memory by ~33%."
   },
   {
    "cell_type": "code",
-   "source": "market_dispatch = m.generators_t.p.copy()\nmarket_p_max_pu = m.get_switchable_as_dense(\"Generator\", \"p_max_pu\").copy()\nmarket_p_nom = m.generators.p_nom.copy()\ndel m",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "market_dispatch = m.generators_t.p.copy()\n",
+    "market_p_max_pu = m.get_switchable_as_dense(\"Generator\", \"p_max_pu\").copy()\n",
+    "market_p_nom = m.generators.p_nom.copy()\n",
+    "del m"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -247,7 +256,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "n = o.copy()  # create redispatch model after freeing market model\n\np = market_dispatch / market_p_nom\nn.generators_t.p_min_pu = p\nn.generators_t.p_max_pu = p"
+   "source": [
+    "n = o.copy()  # create redispatch model after freeing market model\n",
+    "\n",
+    "p = market_dispatch / market_p_nom\n",
+    "n.generators_t.p_min_pu = p\n",
+    "n.generators_t.p_max_pu = p"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -267,7 +282,29 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "g_up = n.generators.copy()\ng_down = n.generators.copy()\n\ng_up.index = g_up.index.map(lambda x: x + \" ramp up\")\ng_down.index = g_down.index.map(lambda x: x + \" ramp down\")\n\nup = (\n    market_p_max_pu * market_p_nom\n    - market_dispatch\n).clip(0) / market_p_nom\ndown = -market_dispatch / market_p_nom\n\nup.columns = up.columns.map(lambda x: x + \" ramp up\")\ndown.columns = down.columns.map(lambda x: x + \" ramp down\")\n\nn.add(\"Generator\", g_up.index, p_max_pu=up, **g_up.drop(\"p_max_pu\", axis=1))\n\nn.add(\n    \"Generator\",\n    g_down.index,\n    p_min_pu=down,\n    p_max_pu=0,\n    **g_down.drop([\"p_max_pu\", \"p_min_pu\"], axis=1),\n);"
+   "source": [
+    "g_up = n.generators.copy()\n",
+    "g_down = n.generators.copy()\n",
+    "\n",
+    "g_up.index = g_up.index.map(lambda x: x + \" ramp up\")\n",
+    "g_down.index = g_down.index.map(lambda x: x + \" ramp down\")\n",
+    "\n",
+    "up = (market_p_max_pu * market_p_nom - market_dispatch).clip(0) / market_p_nom\n",
+    "down = -market_dispatch / market_p_nom\n",
+    "\n",
+    "up.columns = up.columns.map(lambda x: x + \" ramp up\")\n",
+    "down.columns = down.columns.map(lambda x: x + \" ramp down\")\n",
+    "\n",
+    "n.add(\"Generator\", g_up.index, p_max_pu=up, **g_up.drop(\"p_max_pu\", axis=1))\n",
+    "\n",
+    "n.add(\n",
+    "    \"Generator\",\n",
+    "    g_down.index,\n",
+    "    p_min_pu=down,\n",
+    "    p_max_pu=0,\n",
+    "    **g_down.drop([\"p_max_pu\", \"p_min_pu\"], axis=1),\n",
+    ");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -304,7 +341,43 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "fig, axs = plt.subplots(\n    1, 3, figsize=(20, 10), subplot_kw={\"projection\": ccrs.AlbersEqualArea()}\n)\n\nmarket = (\n    n.generators_t.p[o.generators.index]\n    .T.squeeze()\n    .groupby(n.generators.bus)\n    .sum()\n    .div(2e4)\n)\nn.plot(ax=axs[0], bus_size=market, title=\"2 bidding zones market simulation\")\n\nredispatch_up = (\n    n.generators_t.p.filter(like=\"ramp up\")\n    .T.squeeze()\n    .groupby(n.generators.bus)\n    .sum()\n    .div(2e4)\n)\nn.plot(ax=axs[1], bus_size=redispatch_up, bus_color=\"blue\", title=\"Redispatch: ramp up\")\n\nredispatch_down = (\n    n.generators_t.p.filter(like=\"ramp down\")\n    .T.squeeze()\n    .groupby(n.generators.bus)\n    .sum()\n    .div(-2e4)\n)\nn.plot(\n    ax=axs[2],\n    bus_size=redispatch_down,\n    bus_color=\"red\",\n    title=\"Redispatch: ramp down / curtail\",\n);"
+   "source": [
+    "fig, axs = plt.subplots(\n",
+    "    1, 3, figsize=(20, 10), subplot_kw={\"projection\": ccrs.AlbersEqualArea()}\n",
+    ")\n",
+    "\n",
+    "market = (\n",
+    "    n.generators_t.p[o.generators.index]\n",
+    "    .T.squeeze()\n",
+    "    .groupby(n.generators.bus)\n",
+    "    .sum()\n",
+    "    .div(2e4)\n",
+    ")\n",
+    "n.plot(ax=axs[0], bus_size=market, title=\"2 bidding zones market simulation\")\n",
+    "\n",
+    "redispatch_up = (\n",
+    "    n.generators_t.p.filter(like=\"ramp up\")\n",
+    "    .T.squeeze()\n",
+    "    .groupby(n.generators.bus)\n",
+    "    .sum()\n",
+    "    .div(2e4)\n",
+    ")\n",
+    "n.plot(ax=axs[1], bus_size=redispatch_up, bus_color=\"blue\", title=\"Redispatch: ramp up\")\n",
+    "\n",
+    "redispatch_down = (\n",
+    "    n.generators_t.p.filter(like=\"ramp down\")\n",
+    "    .T.squeeze()\n",
+    "    .groupby(n.generators.bus)\n",
+    "    .sum()\n",
+    "    .div(-2e4)\n",
+    ")\n",
+    "n.plot(\n",
+    "    ax=axs[2],\n",
+    "    bus_size=redispatch_down,\n",
+    "    bus_color=\"red\",\n",
+    "    title=\"Redispatch: ramp down / curtail\",\n",
+    ");"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

- Defer creation of the redispatch network copy `n` until after the zonal market model `m` is solved and freed
- Extract lightweight DataFrames (`market_dispatch`, `market_p_max_pu`, `market_p_nom`) from `m` before `del m`
- Ensures at most **2 network copies** coexist at any time instead of **3**

## Motivation

The current example creates all three network copies (`o`, `m`, `n`) upfront in cell 5, keeping them in memory simultaneously throughout the entire workflow. On production-scale networks (500+ buses, 8760 snapshots), this causes ~3x peak memory usage when only ~2x is necessary.

The fix follows the same pattern already used in real-world redispatch implementations: extract the few DataFrames needed from the zonal market result, free the full network, then build the redispatch model.

Closes #1586

## Changes

| Before | After |
|--------|-------|
| `n = o.copy()` created upfront (cell 5) | `n = o.copy()` created after `del m` |
| `m` held in memory until end | `m` freed after extracting results |
| 3 networks coexist during redispatch build | Max 2 networks coexist |
| References `m.generators_t.p`, `m.generators.p_nom` | References `market_dispatch`, `market_p_nom` DataFrames |

🤖 Generated with [Claude Code](https://claude.com/claude-code)