### PR TITLE
fix: Fix groupby() call for pandas 3.0

### DIFF
--- a/docs/examples/scigrid-redispatch.ipynb
+++ b/docs/examples/scigrid-redispatch.ipynb
@@ -383,7 +383,7 @@
    "source": [
     "grouper = n.generators.index.str.split(\" ramp\", expand=True).get_level_values(0)\n",
     "\n",
-    "n.generators_t.p.groupby(grouper, axis=1).sum().squeeze()"
+    "n.generators_t.p.T.groupby(grouper).sum().squeeze()"
    ]
   },
   {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,10 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Add weighted-time delays for Link outputs via new attributes `delay` and `cyclic_delay` (auto-expanded as `delay2`, `delay3`, ... and `cyclic_delay2`, `cyclic_delay3`, ... for additional ports). Delay is interpreted in units of `snapshot_weightings.generators`, with cyclic or non-cyclic boundary behavior. For the Process component the corresponding attributes have explicit numbering (`delay0`, `delay1`, `delay2`, ... and `cyclic_delay0`, `cyclic_delay1`). (<!-- md:pr 1569 -->)
 
+### Bug Fixes
+
+- Fix call to `DataFrame/Series.groupby()` in pandas 3.0, dropping the `axis` argument (<!-- md:pr 1596 -->)
+
 ### Documentation
 
 - New example notebook modeling oligopolistic behavior in energy markets using Cournot-Nash equilibrium with the fictitious objective approach. See [:material-notebook-multiple: notebook](./examples/imperfect-competition.ipynb).

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -269,10 +269,10 @@ def aggregateoneport(
     capacity = static.columns.intersection({"p_nom", "e_nom"})
     if len(capacity):
         capacity_weights = (
-            static[capacity[0]].groupby(grouper, axis=0).transform(normed_or_uniform)
+            static[capacity[0]].groupby(grouper).transform(normed_or_uniform)
         )
     if "weight" in static.columns:
-        weights = static.weight.groupby(grouper, axis=0).transform(normed_or_uniform)
+        weights = static.weight.groupby(grouper).transform(normed_or_uniform)
 
     for k, v in static_strategies.items():
         if v == "weighted_average":


### PR DESCRIPTION
## Changes proposed in this Pull Request

This fixes a call to the `pandas.Series.groupby()` method in spatial clustering code. The method dropped the `axis` argument in pandas 3.0 (deprecated since version 2.1.0) and the values PyPSA is using (`axis=0`) is the default, so it should work fine even without it.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
