### PR TITLE
ci: release workflow simplification and move example networks to bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,63 +9,12 @@ on:
     tags:
     - v*.*.*
 
-env:
-  PREPARATION_COMMIT: '[github-actions.ci] prepare release ${{ github.ref_name }}'
-
 jobs:
-  check-preparation:
-    name: Check if release is prepared
-    runs-on: ubuntu-latest
-    outputs:
-      prepared: ${{ steps.validate.outputs.prepared }}
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Validate commit message
-      id: validate
-      run: |
-        # Check if last commit is the expected commit message
-        COMMIT_MESSAGE=$(git log -1 --pretty=%B)
-        echo "Expected: '${{ env.PREPARATION_COMMIT }}'"
-        echo "Received: '$COMMIT_MESSAGE'"
-
-        prepared="false"
-        if [[ "$COMMIT_MESSAGE" == "${{ env.PREPARATION_COMMIT }}" ]]; then
-          prepared="true"
-        fi
-
-        echo "prepared=$prepared" >> $GITHUB_OUTPUT
-
-  prepare-release:
-    name: Prepare release
-    needs: [check-preparation]
-    if: ${{ needs.check-preparation.outputs.prepared == 'false' }}
+  publish-examples:
+    name: Publish example networks to bucket
     runs-on: ubuntu-latest
     steps:
-    - name: Generate token for PyPSA Bot
-      id: generate-token
-      uses: actions/create-github-app-token@v3
-      with:
-        app-id: ${{ vars.PYPSA_BOT_ID }}
-        private-key: ${{ secrets.PYPSA_BOT_PRIVATE_KEY }}
-
     - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-
-    - name: Find the branch for commit/ tag
-      run: |
-        branch=$(git branch -r --points-at ${{ github.sha }} | grep -v 'HEAD' | head -n 1 | sed 's|origin/||' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-        echo "Branch found: $branch"
-        echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
-
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        ref: ${{ env.BRANCH_NAME }}
-        token: ${{ steps.generate-token.outputs.token }}
-
-    # Start of preparation script
 
     - uses: actions/setup-python@v6
       with:
@@ -74,71 +23,77 @@ jobs:
     - name: Install packages
       run: |
         python -m pip install uv
-        uv pip install --system toml
-        uv pip install --system setuptools_scm
+        uv pip install --system boto3
         uv pip install --system .
 
-    - name: Update CITATION.cff
+    - name: Publish example networks to S3
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
+        S3_ENDPOINT_URL: ${{ vars.S3_ENDPOINT_URL }}
+        S3_BUCKET: ${{ vars.S3_BUCKET }}
+        S3_EXAMPLES_PREFIX: ${{ vars.S3_EXAMPLES_PREFIX }}
+        RELEASE_TAG: ${{ github.ref_name }}
       run: |
-        import re
-        from setuptools_scm import get_version
+        import os
+        from pathlib import Path
 
-        version = get_version()
-
-        with open('CITATION.cff', 'r') as file:
-          cff_content = file.read()
-        cff_content = open('CITATION.cff', 'r').read()
-
-        updated_cff_content = re.sub(r"(?<=version: ).+(?= #)",version,cff_content,flags=re.MULTILINE)
-
-        with open('CITATION.cff', 'w') as file:
-          file.write(updated_cff_content)
-      shell: python
-
-    - name: Update example notebooks
-      run: |
+        import boto3
         import pypsa
-        # ac-dc-meshed
-        n = pypsa.Network("examples/networks/ac-dc-meshed/ac-dc-meshed")
-        n.export_to_csv_folder("examples/networks/ac-dc-meshed/ac-dc-meshed")
-        n.export_to_netcdf("examples/networks/ac-dc-meshed/ac-dc-meshed.nc")
-        # storage-hvdc
-        n = pypsa.Network("examples/networks/storage-hvdc/storage-hvdc")
-        n.export_to_csv_folder("examples/networks/storage-hvdc/storage-hvdc")
-        n.export_to_netcdf("examples/networks/storage-hvdc/storage-hvdc.nc")
-        # scigrid-de
-        n = pypsa.Network("examples/networks/scigrid-de/scigrid-de")
-        n.export_to_csv_folder("examples/networks/scigrid-de/scigrid-de")
-        n.export_to_netcdf("examples/networks/scigrid-de/scigrid-de.nc")
-        # model-energy
-        n = pypsa.Network("examples/networks/model-energy/model-energy")
-        n.export_to_csv_folder("examples/networks/model-energy/model-energy")
-        n.export_to_netcdf("examples/networks/model-energy/model-energy.nc")
-        # stochastic-network
-        n = pypsa.Network("examples/networks/stochastic-network/stochastic-network.nc")
-        n.export_to_netcdf("examples/networks/stochastic-network/stochastic-network.nc")
+
+        tag = os.environ["RELEASE_TAG"]
+        assert tag.startswith("v"), f"unexpected release tag: {tag!r}"
+        version_base = tag[1:]
+
+        endpoint_url = os.environ["S3_ENDPOINT_URL"]
+        bucket = os.environ["S3_BUCKET"]
+        base_prefix = os.environ["S3_EXAMPLES_PREFIX"]
+
+        client = boto3.client("s3", endpoint_url=endpoint_url)
+
+        examples = [
+            "ac_dc_meshed",
+            "storage_hvdc",
+            "scigrid_de",
+            "model_energy",
+            "stochastic_network",
+            "carbon_management",
+        ]
+
+        tmp = Path("/tmp/pypsa-examples")
+        tmp.mkdir(exist_ok=True)
+
+        # Upload examples to versioned prefix
+        for name in examples:
+            n = getattr(pypsa.examples, name)()
+            local = tmp / f"{name}.nc"
+            n.export_to_netcdf(str(local))
+            key = f"{base_prefix}/v{version_base}/{name}.nc"
+            client.upload_file(
+                str(local),
+                bucket,
+                key,
+                ExtraArgs={"ACL": "public-read", "ContentType": "application/x-netcdf"},
+            )
+            print(f"uploaded {key}")
+
+        # Repoint latest/ to new version
+        for name in examples:
+            src_key = f"{base_prefix}/v{version_base}/{name}.nc"
+            dst_key = f"{base_prefix}/latest/{name}.nc"
+            client.copy_object(
+                Bucket=bucket,
+                CopySource={"Bucket": bucket, "Key": src_key},
+                Key=dst_key,
+                ACL="public-read",
+                ContentType="application/x-netcdf",
+                MetadataDirective="REPLACE",
+            )
+            print(f"repointed {dst_key} -> {src_key}")
       shell: python
-
-    # End of preparation script
-
-    - name: Remove previous tag
-      run: |
-        git tag -d ${{ github.ref_name }}
-        git push origin --delete ${{ github.ref_name }}
-
-    - name: Commit changes
-      uses: stefanzweifel/git-auto-commit-action@v7
-      with:
-        branch: ${{ env.BRANCH_NAME }}
-        commit_message: '${{ env.PREPARATION_COMMIT }}'
-        tagging_message: '${{ github.ref_name }}' # add tag again
-        push_options: '${{ github.ref_name }}'
-        add_options: '-u' # Never add untracked files
 
   build:
     name: Build and verify package
-    needs: [check-preparation]
-    if: ${{ needs.check-preparation.outputs.prepared == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,6 @@ cff-version: 1.2.0
 message: "If you use this package, please cite the corresponding manuscript in Journal of Open Research Software."
 title: "PyPSA: Python for Power System Analysis"
 repository: https://github.com/pypsa/pypsa
-version: 1.1.2 # Don't touch, will be updated by the release script
 license: MIT
 journal: Journal of Open Research Software
 doi: 10.5334/jors.188

--- a/docs/examples/demand-elasticity.ipynb
+++ b/docs/examples/demand-elasticity.ipynb
@@ -46,15 +46,7 @@
     "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
-   "source": [
-    "## Preparations\n",
-    "\n",
-    "We start by loading the required packages, an example network and defining an utility function to compute the price-duration curve.\n",
-    "\n",
-    "The network used here (see ``examples/networks/model-energy/model-energy`` for details) is a minimal renewable-based system. It consists of wind and solar generators, a hydrogen conversion chain via electrolysis and a turbine, and storage (battery and hydrogen), which allows energy to be shifted over time.\n",
-    "\n",
-    "In the default configuration, the main components have extendable capacities, so the optimization jointly determines both capacity investments and dispatch subject to availability, conversion efficiencies, and storage dynamics."
-   ]
+   "source": "## Preparations\n\nWe start by loading the required packages, an example network and defining an utility function to compute the price-duration curve.\n\nThe network used here (see ``pypsa.examples.model_energy`` for details) is a minimal renewable-based system. It consists of wind and solar generators, a hydrogen conversion chain via electrolysis and a turbine, and storage (battery and hydrogen), which allows energy to be shifted over time.\n\nIn the default configuration, the main components have extendable capacities, so the optimization jointly determines both capacity investments and dispatch subject to availability, conversion efficiencies, and storage dynamics."
   },
   {
    "cell_type": "code",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "validators",
     "highspy",
     "levenshtein>=0.27.1",
+    "platformdirs",
 ]
 
 [project.urls]

--- a/pypsa/examples.py
+++ b/pypsa/examples.py
@@ -35,22 +35,14 @@ def _check_url_availability(url: str) -> bool:
         return False
 
 
-def _example_url(name: str) -> str:
-    """Resolve the bucket URL for an example network."""
-    versioned = f"{_EXAMPLES_BASE_URL}/v{__version_base__}/{name}.nc"
-    if _check_url_availability(versioned):
-        return versioned
-    return f"{_EXAMPLES_BASE_URL}/latest/{name}.nc"
-
-
 def _cache_root() -> Path:
     """Return the cache root for example networks."""
     return Path(user_cache_dir("pypsa")) / "examples"
 
 
 def _load_example(name: str) -> Network:
-    url = _example_url(name)
-    cache = _cache_root() / url.removeprefix(_EXAMPLES_BASE_URL + "/")
+    url = f"{_EXAMPLES_BASE_URL}/v{__version_base__}/{name}.nc"
+    cache = _cache_root() / f"v{__version_base__}" / f"{name}.nc"
 
     if not cache.exists():
         if not options.get_option("general.allow_network_requests"):

--- a/pypsa/examples.py
+++ b/pypsa/examples.py
@@ -7,27 +7,21 @@
 from __future__ import annotations
 
 import logging
+import shutil
 import warnings
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.request import urlopen
+from urllib.request import urlopen, urlretrieve
 
-from packaging.version import parse as parse_version
+from platformdirs import user_cache_dir
 
+from pypsa._options import options
 from pypsa.networks import Network
 from pypsa.version import __version_base__
 
 logger = logging.getLogger(__name__)
 
-
-def _repo_url(
-    master: bool = False, url: str = "https://github.com/PyPSA/PyPSA/raw/"
-) -> str:
-    if master or parse_version(__version_base__) < parse_version(
-        "0.35.0"
-    ):  # Feature was added in 0.35.0
-        return f"{url}master/"
-    return f"{url}v{__version_base__}/"
+_EXAMPLES_BASE_URL = "https://data.pypsa.org/networks/examples"
 
 
 def _check_url_availability(url: str) -> bool:
@@ -41,10 +35,34 @@ def _check_url_availability(url: str) -> bool:
         return False
 
 
-def _retrieve_if_not_local(path: str | Path) -> Network:
-    if not (Path.cwd() / path).exists():
-        path = _repo_url() + str(path)
-        Path.cwd()
+def _example_url(name: str) -> str:
+    """Resolve the bucket URL for an example network."""
+    versioned = f"{_EXAMPLES_BASE_URL}/v{__version_base__}/{name}.nc"
+    if _check_url_availability(versioned):
+        return versioned
+    return f"{_EXAMPLES_BASE_URL}/latest/{name}.nc"
+
+
+def _cache_root() -> Path:
+    """Return the cache root for example networks."""
+    return Path(user_cache_dir("pypsa")) / "examples"
+
+
+def _load_example(name: str) -> Network:
+    url = _example_url(name)
+    cache = _cache_root() / url.removeprefix(_EXAMPLES_BASE_URL + "/")
+
+    if not cache.exists():
+        if not options.get_option("general.allow_network_requests"):
+            msg = (
+                f"Network requests are disabled. Enable "
+                f"`pypsa.options.general.allow_network_requests` or manually "
+                f"place the example file at {cache}."
+            )
+            raise ValueError(msg)
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        logger.info("Downloading %s to %s", url, cache)
+        urlretrieve(url, cache)  # noqa: S310
 
     # Suppress warning which occurs due to numpy version mismatch
     with warnings.catch_warnings():
@@ -53,7 +71,14 @@ def _retrieve_if_not_local(path: str | Path) -> Network:
             message="numpy.ndarray size changed, may indicate binary incompatibility",
             category=RuntimeWarning,
         )
-        return Network(path)
+        return Network(str(cache))
+
+
+def clear_cache() -> None:
+    """Delete the local cache of example networks."""
+    cache = _cache_root()
+    if cache.exists():
+        shutil.rmtree(cache)
 
 
 def ac_dc_meshed() -> Network:
@@ -83,7 +108,7 @@ def ac_dc_meshed() -> Network:
     Snapshots: 10
 
     """
-    return _retrieve_if_not_local("examples/networks/ac-dc-meshed/ac-dc-meshed.nc")
+    return _load_example("ac_dc_meshed")
 
 
 def storage_hvdc() -> Network:
@@ -114,7 +139,7 @@ def storage_hvdc() -> Network:
     Snapshots: 12
 
     """
-    return _retrieve_if_not_local("examples/networks/storage-hvdc/storage-hvdc.nc")
+    return _load_example("storage_hvdc")
 
 
 def scigrid_de() -> Network:
@@ -144,7 +169,7 @@ def scigrid_de() -> Network:
     Snapshots: 24
 
     """
-    return _retrieve_if_not_local("examples/networks/scigrid-de/scigrid-de.nc")
+    return _load_example("scigrid_de")
 
 
 def model_energy() -> Network:
@@ -181,7 +206,7 @@ def model_energy() -> Network:
     [^1]: See https://model.energy/
 
     """
-    return _retrieve_if_not_local("examples/networks/model-energy/model-energy.nc")
+    return _load_example("model_energy")
 
 
 def stochastic_network() -> Network:
@@ -209,10 +234,7 @@ def stochastic_network() -> Network:
     Scenarios: 3
 
     """
-    n = _retrieve_if_not_local(
-        "examples/networks/stochastic-network/stochastic-network.nc"
-    )
-    return n
+    return _load_example("stochastic_network")
 
 
 def carbon_management() -> Network:
@@ -251,16 +273,4 @@ def carbon_management() -> Network:
     <BLANKLINE>
 
     """
-    primary_url = (
-        "https://tubcloud.tu-berlin.de/s/4nsj6XSAbnq8skc/download/carbon-management.nc"
-    )
-
-    if _check_url_availability(primary_url):
-        return Network(primary_url)
-    else:
-        msg = (
-            "The carbon management example is currently unavailable. Please check "
-            "your internet connection and make sure you are on the latest version of "
-            "PyPSA."
-        )
-        raise RuntimeError(msg)
+    return _load_example("carbon_management")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -359,7 +359,7 @@ def stochastic_benchmark_network():
     GAS_PRICE = 40  # Default scenario
     FREQ = "3h"
     LOAD_MW = 1
-    TS_URL = "https://tubcloud.tu-berlin.de/s/pKttFadrbTKSJKF/download/time-series-lecture-2.csv"
+    TS_URL = "https://data.pypsa.org/tests/pypsa/time-series-lecture-2.csv"
 
     # Technology specs
     TECH = {

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -313,8 +313,8 @@ def test_collection_repr(network1, network2, network3):
 
 def test_collection_init_with_paths(tmp_path):
     """Test initialization with string paths and Path objects."""
-    example_path1 = str(tmp_path / "ac_dc_meshed.nc")
-    example_path2 = str(tmp_path / "scigrid_de.nc")
+    example_path1 = tmp_path / "ac_dc_meshed.nc"
+    example_path2 = tmp_path / "scigrid_de.nc"
     pypsa.examples.ac_dc_meshed().export_to_netcdf(example_path1)
     pypsa.examples.scigrid_de().export_to_netcdf(example_path2)
 

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -311,11 +311,12 @@ def test_collection_repr(network1, network2, network3):
     assert "... and 5 more" in repr_str
 
 
-def test_collection_init_with_paths():
+def test_collection_init_with_paths(tmp_path):
     """Test initialization with string paths and Path objects."""
-    # Use example networks from the examples directory
-    example_path1 = "examples/networks/ac-dc-meshed/ac-dc-meshed.nc"
-    example_path2 = "examples/networks/scigrid-de/scigrid-de.nc"
+    example_path1 = str(tmp_path / "ac_dc_meshed.nc")
+    example_path2 = str(tmp_path / "scigrid_de.nc")
+    pypsa.examples.ac_dc_meshed().export_to_netcdf(example_path1)
+    pypsa.examples.scigrid_de().export_to_netcdf(example_path2)
 
     # Test with list of strings
     collection = pypsa.NetworkCollection([example_path1, example_path2])
@@ -346,10 +347,11 @@ def test_collection_init_with_paths():
     assert list(collection_dict.networks.index) == ["net1", "net2"]
 
 
-def test_collection_init_mixed_networks_and_strings(network1):
+def test_collection_init_mixed_networks_and_strings(network1, tmp_path):
     """Test initialization with mixed Network objects and strings."""
     network1.name = "manual_net"
-    example_path = "examples/networks/ac-dc-meshed/ac-dc-meshed.nc"
+    example_path = str(tmp_path / "ac_dc_meshed.nc")
+    pypsa.examples.ac_dc_meshed().export_to_netcdf(example_path)
 
     # Test with mixed list
     collection = pypsa.NetworkCollection([network1, example_path])

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -40,16 +40,51 @@ def test_carbon_management():
         pytest.skip("Test failed but converted to warning")
 
 
+@pytest.fixture
+def seeded_cache(monkeypatch, tmp_path):
+    """Seed a cache directory with a dummy network file."""
+    monkeypatch.setattr(pypsa.examples, "_cache_root", lambda: tmp_path)
+    url = f"{pypsa.examples._EXAMPLES_BASE_URL}/latest/ac_dc_meshed.nc"
+    monkeypatch.setattr(pypsa.examples, "_example_url", lambda name: url)
+    cache = tmp_path / "latest" / "ac_dc_meshed.nc"
+    cache.parent.mkdir(parents=True)
+    pypsa.Network().export_to_netcdf(str(cache))
+    return tmp_path
+
+
+def test_caching(seeded_cache):
+    """Test that cached example is loaded from disk without network."""
+    n = pypsa.examples.ac_dc_meshed()
+    assert isinstance(n, pypsa.Network)
+
+
+def test_clear_cache(seeded_cache):
+
+    pypsa.examples.clear_cache()
+    assert not seeded_cache.exists()
+
+
+def test_cache_miss_network_disabled(monkeypatch, tmp_path):
+    """Test that cache miss with network requests disabled raises ValueError."""
+    monkeypatch.setattr(pypsa.examples, "_cache_root", lambda: tmp_path)
+    monkeypatch.setattr(pypsa.examples, "_check_url_availability", lambda url: False)
+
+    pypsa.options.general.allow_network_requests = False
+    try:
+        with pytest.raises(ValueError, match="Network requests are disabled"):
+            pypsa.examples.ac_dc_meshed()
+    finally:
+        pypsa.options.general.allow_network_requests = True
+
+
 def test_check_url_availability():
     """Test _check_url_availability function."""
     from pypsa.examples import _check_url_availability
 
-    # Test invalid URL formats
     assert not _check_url_availability("invalid-url")
     assert not _check_url_availability("ftp://example.com")
     assert not _check_url_availability("")
-    assert not _check_url_availability("https://google.com/invalid-url")
-
-    # Test valid URL format (should return True for valid URLs)
-    assert _check_url_availability("https://google.com")
-    assert _check_url_availability("https://google.com/search?q=pypsa")
+    assert not _check_url_availability("https://data.pypsa.org/nonexistent")
+    assert _check_url_availability(
+        "https://data.pypsa.org/networks/examples/latest/ac_dc_meshed.nc"
+    )

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -44,9 +44,8 @@ def test_carbon_management():
 def seeded_cache(monkeypatch, tmp_path):
     """Seed a cache directory with a dummy network file."""
     monkeypatch.setattr(pypsa.examples, "_cache_root", lambda: tmp_path)
-    url = f"{pypsa.examples._EXAMPLES_BASE_URL}/latest/ac_dc_meshed.nc"
-    monkeypatch.setattr(pypsa.examples, "_example_url", lambda name: url)
-    cache = tmp_path / "latest" / "ac_dc_meshed.nc"
+    version = pypsa.version.__version_base__
+    cache = tmp_path / f"v{version}" / "ac_dc_meshed.nc"
     cache.parent.mkdir(parents=True)
     pypsa.Network().export_to_netcdf(str(cache))
     return tmp_path
@@ -67,7 +66,6 @@ def test_clear_cache(seeded_cache):
 def test_cache_miss_network_disabled(monkeypatch, tmp_path):
     """Test that cache miss with network requests disabled raises ValueError."""
     monkeypatch.setattr(pypsa.examples, "_cache_root", lambda: tmp_path)
-    monkeypatch.setattr(pypsa.examples, "_check_url_availability", lambda url: False)
 
     pypsa.options.general.allow_network_requests = False
     try:
@@ -77,6 +75,10 @@ def test_cache_miss_network_disabled(monkeypatch, tmp_path):
         pypsa.options.general.allow_network_requests = True
 
 
+@pytest.mark.skipif(
+    not pypsa.examples._check_url_availability("https://data.pypsa.org"),
+    reason="No internet connection",
+)
 def test_check_url_availability():
     """Test _check_url_availability function."""
     from pypsa.examples import _check_url_availability

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -7,6 +7,7 @@ import logging
 import pytest
 
 import pypsa
+from pypsa.version import __version_base__
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +45,7 @@ def test_carbon_management():
 def seeded_cache(monkeypatch, tmp_path):
     """Seed a cache directory with a dummy network file."""
     monkeypatch.setattr(pypsa.examples, "_cache_root", lambda: tmp_path)
-    version = pypsa.version.__version_base__
-    cache = tmp_path / f"v{version}" / "ac_dc_meshed.nc"
+    cache = tmp_path / f"v{__version_base__}" / "ac_dc_meshed.nc"
     cache.parent.mkdir(parents=True)
     pypsa.Network().export_to_netcdf(str(cache))
     return tmp_path

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -232,7 +232,7 @@ class TestNetcdf:
         )
 
     def test_netcdf_from_url(self):
-        url = "https://github.com/PyPSA/PyPSA/raw/master/examples/networks/scigrid-de/scigrid-de.nc"
+        url = "https://data.pypsa.org/networks/examples/latest/scigrid_de.nc"
         pypsa.Network(url)
 
     def test_netcdf_io_no_compression(self, scipy_network, tmpdir):
@@ -569,41 +569,18 @@ def test_io_equality(networks_including_solved, tmp_path):
         assert custom_equals(n, n5, ignore_attrs=ignore)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 13) or sys.platform not in ["linux", "darwin"],
-    reason="Only check once since it is an optional test when examples are updated.",
-)
 @pytest.mark.parametrize(
     "example_network",
     [
-        "ac-dc-meshed",
-        "storage-hvdc",
-        "scigrid-de",
-        "model-energy",
-    ],
-)
-def test_examples_against_master(tmp_path, example_network):
-    # Test examples are unchanged
-    n = pypsa.Network(f"examples/networks/{example_network}/{example_network}")
-    # Test examples vs master
-    example_network = pypsa.Network(
-        f"https://github.com/PyPSA/PyPSA/raw/master/examples/networks/{example_network}/{example_network}.nc"
-    )
-    assert n.equals(example_network, log_mode="strict")
-
-
-@pytest.mark.parametrize(
-    "example_network",
-    [
-        "ac-dc-meshed",
-        "storage-hvdc",
-        "scigrid-de",
-        "model-energy",
+        "ac_dc_meshed",
+        "storage_hvdc",
+        "scigrid_de",
+        "model_energy",
     ],
 )
 def test_examples_consistency(tmp_path, example_network):
-    # Test examples are unchanged
-    n = pypsa.Network(f"examples/networks/{example_network}/{example_network}")
+    # Round-trip example networks through CSV export/import to catch schema drift
+    n = getattr(pypsa.examples, example_network)()
     n.export_to_csv_folder(tmp_path / "network")
     n2 = pypsa.Network(tmp_path / "network")
     assert n.equals(n2, log_mode="strict")


### PR DESCRIPTION
Simplifies the complicated commit again on master release workflow, which lead to the yanked 1.1.1 release. Instead use our bucket for example networks and a user cache. 