### PR TITLE
fix: pin xarray<2026.4, drop netcdf4 pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
     "numpy",
     "scipy",
     "pandas>=2.0",
-    "xarray",
-    "netcdf4!=1.7.4",  # See https://github.com/PyPSA/PyPSA/issues/1510
+    "xarray<2026.4",  # See https://github.com/PyPSA/linopy/pull/647
+    "netcdf4",
     "linopy>=0.6.1",
     "matplotlib",
     "plotly",


### PR DESCRIPTION
- pinning xarray, which is currently a problem until we have a new linopy release. See https://github.com/PyPSA/linopy/pull/647
- Unpins `netcdf4` again, since I think no more wheels are missing