### PR TITLE
fix: suppress spurious warnings during network export

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -67,7 +67,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix compatibility with pandas 3 (<!-- md:pr 1617 -->)
 
-- Fix spurious `model`/`objective`/`objective_constant` warnings emitted during network export, and clarify the `n.model` warning to distinguish "not optimized yet" from "loaded from file". (<!-- md:issue 1658 -->)
+- Fix spurious `model`/`objective`/`objective_constant` warnings emitted during network export, and clarify the `n.model` warning to distinguish "not optimized yet" from "loaded from file". (<!-- md:pr 1659 -->)
 
 ### Documentation
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -67,6 +67,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix compatibility with pandas 3 (<!-- md:pr 1617 -->)
 
+- Fix spurious `model`/`objective`/`objective_constant` warnings emitted during network export, and clarify the `n.model` warning to distinguish "not optimized yet" from "loaded from file". (<!-- md:issue 1658 -->)
+
 ### Documentation
 
 - New example notebook modeling oligopolistic behavior in energy markets using Cournot-Nash equilibrium with the fictitious objective approach. See [:material-notebook-multiple: notebook](./examples/imperfect-competition.ipynb).

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1170,6 +1170,11 @@ class NetworkIOMixin(_NetworkABC):
                     message=r".*component_attrs is deprecated as of 1\.0 and will be removed in 2\.0\..*",
                     category=DeprecationWarning,
                 )
+                warnings.filterwarnings(
+                    "ignore",
+                    message=r".*the API for how to access components data has changed.*",
+                    category=DeprecationWarning,
+                )
                 value = getattr(self, attr)
             if isinstance(value, allowed_types):
                 _attrs[attr] = value

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1140,62 +1140,39 @@ class NetworkIOMixin(_NetworkABC):
         """
         # exportable component types
         allowed_types = (float, int, bool, str) + tuple(np.sctypeDict.values())
+        skip_attrs = {
+            "component_attrs",
+            "df",
+            "pnl",
+            "static",
+            "dynamic",
+            "iterate_components",
+            "_name",
+            "_pypsa_version",
+        }
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=r".*component_attrs is deprecated as of 1\.0 and will be removed in 2\.0\..*",
-                category=DeprecationWarning,
-            )
-
-            _attrs = {
-                attr: getattr(self, attr)
-                for attr in dir(self)
-                if (
-                    not attr.startswith("__")
-                    and attr
-                    not in {
-                        "component_attrs",
-                        "df",
-                        "pnl",
-                        "static",
-                        "dynamic",
-                        "iterate_components",
-                    }  # Skip deprecated methods
-                    and isinstance(getattr(self, attr), allowed_types)
-                )
-            }
         _attrs = {}
         for attr in dir(self):
-            if not attr.startswith("__") and attr not in {
-                "component_attrs",
-                "df",
-                "pnl",
-                "static",
-                "dynamic",
-                "iterate_components",
-            }:
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore",
-                        message=r".*component_attrs is deprecated as of 1\.0 and will be removed in 2\.0\..*",
-                        category=DeprecationWarning,
-                    )
-                    value = getattr(self, attr)
-                if isinstance(value, allowed_types):
-                    # TODO: This needs to be refactored with NetworkData class
-                    # Skip properties without setter, but not 'pypsa_version'
-                    prop = getattr(self.__class__, attr, None)
-                    if (
-                        isinstance(prop, property)
-                        and prop.fset is None
-                        and attr not in ["pypsa_version"]
-                    ):
-                        continue
-                    # Skip `_name` since it is writable
-                    if attr in ["_name", "_pypsa_version"]:
-                        continue
-                    _attrs[attr] = value
+            if attr.startswith("__") or attr in skip_attrs:
+                continue
+            # Skip read-only properties (except pypsa_version) without invoking
+            # their getters, which may emit warnings (e.g. model, objective).
+            prop = getattr(self.__class__, attr, None)
+            if (
+                isinstance(prop, property)
+                and prop.fset is None
+                and attr != "pypsa_version"
+            ):
+                continue
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=r".*component_attrs is deprecated as of 1\.0 and will be removed in 2\.0\..*",
+                    category=DeprecationWarning,
+                )
+                value = getattr(self, attr)
+            if isinstance(value, allowed_types):
+                _attrs[attr] = value
         exporter.save_attributes(_attrs)
 
         crs = {}

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -687,7 +687,9 @@ class Network(
         """
         if self._model is None:
             logger.warning(
-                "The network has not been optimized yet and no model is stored."
+                "No linopy model is stored on this network. "
+                "The network may not have been optimized yet, or it was loaded "
+                "from a file (models are not serialized on export)."
             )
         return self._model
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import logging
+import warnings
 from pathlib import Path
 
 import geopandas as gpd
@@ -13,6 +15,27 @@ from shapely.geometry import Polygon
 
 import pypsa
 from pypsa.constants import DEFAULT_EPSG
+
+
+@pytest.fixture
+def no_warnings():
+    """Fail if any Python warning or logging warning is emitted."""
+    allowed = {"does not exist, creating it"}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warnings.filterwarnings("default", category=ResourceWarning)
+        handler = logging.Handler()
+        handler.setLevel(logging.WARNING)
+        handler.emit = lambda record: (
+            None
+            if any(s in record.getMessage() for s in allowed)
+            else (_ for _ in ()).throw(
+                AssertionError(f"Unexpected log warning: {record.getMessage()}")
+            )
+        )
+        logging.root.addHandler(handler)
+        yield
+        logging.root.removeHandler(handler)
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -70,7 +70,7 @@ class TestCSVDir:
             {"test": {"test": "test", "test2": "test2"}},
         ],
     )
-    def test_csv_io(self, scipy_network, tmpdir, meta):
+    def test_csv_io(self, scipy_network, tmpdir, meta, no_warnings):
         fn = tmpdir / "csv_export"
         scipy_network.meta = meta
         scipy_network.export_to_csv_folder(fn)
@@ -172,7 +172,7 @@ class TestNetcdf:
             {"test": {"test": "test", "test2": "test2"}},
         ],
     )
-    def test_netcdf_io(self, scipy_network, tmpdir, meta):
+    def test_netcdf_io(self, scipy_network, tmpdir, meta, no_warnings):
         fn = tmpdir / "netcdf_export.nc"
         scipy_network.meta = meta
         scipy_network.export_to_netcdf(fn)
@@ -311,7 +311,7 @@ class TestHDF5:
             {"test": {"test": "test", "test2": "test2"}},
         ],
     )
-    def test_hdf5_io(self, scipy_network, tmpdir, meta):
+    def test_hdf5_io(self, scipy_network, tmpdir, meta, no_warnings):
         fn = tmpdir / "hdf5_export.h5"
         scipy_network.meta = meta
         scipy_network.export_to_hdf5(fn)
@@ -397,7 +397,7 @@ class TestExcelIO:
             {"test": {"test": "test", "test2": "test2"}},
         ],
     )
-    def test_excel_io(self, scipy_network, tmpdir, meta):
+    def test_excel_io(self, scipy_network, tmpdir, meta, no_warnings):
         fn = tmpdir / "excel_export.xlsx"
         scipy_network.meta = meta
         scipy_network.export_to_excel(fn)


### PR DESCRIPTION
Closes #1658.

## Changes proposed in this Pull Request

- Remove dead-code dict comprehension in `_export_to_exporter` (`pypsa/network/io.py`) that was immediately overwritten by `_attrs = {}` and only served to double-fire property warnings.
- Check `isinstance(prop, property) and prop.fset is None` **before** invoking `getattr`, so read-only property getters (`model`, `objective`, `objective_constant`) are never triggered during export.
- Reword the `n.model` warning in `pypsa/networks.py` to distinguish *"not optimized yet"* from *"loaded from file"* — loaded solved networks have `n.is_solved is True` but no model object.
- Add release-notes entry.

### Before / After

```python
import pypsa
n = pypsa.examples.ac_dc_meshed()
n.export_to_netcdf("test.nc")
```
Before: 6 warnings (3 messages × 2 fires each). After: silent.

```python
n = pypsa.examples.carbon_management()  # loaded, n.is_solved is True
n.export_to_netcdf("test.nc")
```
Before: 2 copies of *"The network has not been optimized yet and no model is stored"* (misleading — it **is** optimized). After: silent.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable). — N/A: behavior change is "no longer emits stray logger warnings during introspection"; existing I/O tests (`pytest test/test_io.py`, 34 passed) cover the export path.
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.