### PR TITLE
fix: use `latest` fallback to prevent race in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,13 @@ on:
     - v*.*.*
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+
   publish-examples:
     name: Publish example networks to bucket
+    needs: [test]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -94,6 +99,7 @@ jobs:
 
   build:
     name: Build and verify package
+    needs: [publish-examples]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
     branches: ["*"]
   schedule:
   - cron: "0 5 * * *"
+  workflow_call:
 
 # Cancel any in-progress runs when a new run is triggered
 concurrency:

--- a/pypsa/examples.py
+++ b/pypsa/examples.py
@@ -42,6 +42,7 @@ def _cache_root() -> Path:
 
 def _load_example(name: str) -> Network:
     url = f"{_EXAMPLES_BASE_URL}/v{__version_base__}/{name}.nc"
+    fallback_url = f"{_EXAMPLES_BASE_URL}/latest/{name}.nc"
     cache = _cache_root() / f"v{__version_base__}" / f"{name}.nc"
 
     if not cache.exists():
@@ -54,7 +55,13 @@ def _load_example(name: str) -> Network:
             raise ValueError(msg)
         cache.parent.mkdir(parents=True, exist_ok=True)
         logger.info("Downloading %s to %s", url, cache)
-        urlretrieve(url, cache)  # noqa: S310
+        try:
+            urlretrieve(url, cache)  # noqa: S310
+        except HTTPError as err:
+            if err.code != 404:
+                raise
+            logger.warning("404 at %s; using %s", url, fallback_url)
+            urlretrieve(fallback_url, cache)  # noqa: S310
 
     # Suppress warning which occurs due to numpy version mismatch
     with warnings.catch_warnings():

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -75,6 +75,30 @@ def test_cache_miss_network_disabled(monkeypatch, tmp_path):
         pypsa.options.general.allow_network_requests = True
 
 
+def test_cache_miss_404_falls_back_to_latest(monkeypatch, tmp_path, caplog):
+    """404 on versioned URL falls back to latest/ with warning."""
+    from urllib.error import HTTPError
+
+    monkeypatch.setattr(pypsa.examples, "_cache_root", lambda: tmp_path)
+    calls = []
+
+    def fake_urlretrieve(url, cache):
+        calls.append(url)
+        if f"/v{__version_base__}/" in url:
+            raise HTTPError(url, 404, "Not Found", {}, None)
+        pypsa.Network().export_to_netcdf(str(cache))
+
+    monkeypatch.setattr(pypsa.examples, "urlretrieve", fake_urlretrieve)
+    with caplog.at_level(logging.WARNING, logger="pypsa.examples"):
+        pypsa.examples.ac_dc_meshed()
+
+    assert [f"/v{__version_base__}/" in calls[0], "/latest/" in calls[1]] == [
+        True,
+        True,
+    ]
+    assert any("404" in r.message for r in caplog.records)
+
+
 @pytest.mark.skipif(
     not pypsa.examples._check_url_availability("https://data.pypsa.org"),
     reason="No internet connection",


### PR DESCRIPTION
Some small follow up on #1652

- Brings back the latest fallback
- Chains release pipeline and also depends on tests passing now