### PR TITLE
fix: regression of n.statistics.transmission with bus_carrier

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,13 +6,17 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Release Notes
 
-<!--## Upcoming Release
+## Upcoming Release
 
 !!! info "Upcoming Release"
 
     The features listed below have not yet been released, but will be included in the
     next update! If you would like to use these features in the meantime, you will need
-    to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.-->
+    to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
+
+### Bug Fixes
+
+- Fix `n.statistics.transmission()` returning zero flows when `bus_carrier` is set. (<!-- md:pr 1662 -->)
 
 
 ## [**v1.2.0**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.0) <small>21st April 2026</small> { id="v1.2.0" }

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -2123,6 +2123,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         if components is None:
             components = n.branch_components
 
+        if at_port is None and bus_carrier is not None:
+            at_port = "bus0"
+
         transmission_branches = get_transmission_branches(n, bus_carrier)
 
         @pass_empty_series_if_keyerror

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -2044,7 +2044,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         groupby_method: Callable | str = "sum",
         aggregate_across_components: bool = False,
         groupby: str | Sequence[str] | Callable | Literal[False] = "carrier",
-        at_port: PortsLike | None = None,
+        at_port: PortsLike = "bus0",
         carrier: str | Sequence[str] | None = None,
         bus_carrier: str | Sequence[str] | None = None,
         nice_names: bool | None = None,
@@ -2074,9 +2074,8 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
             - `False`: No grouping, return all components individually
             - string or list of strings: Group by column names from [c.static][pypsa.Components]
             - callable: Function that takes network and component name as arguments
-        at_port : PortsLike | None, default=None
+        at_port : PortsLike, default="bus0"
             Which ports to consider:
-            - None: Automatically set to "all" if bus_carrier is specified, otherwise "bus0"
             - "all": All ports of components
             - "bus0": Consider only first port
             - str or list of str: Specific ports to include (e.g., "bus1", "bus2")
@@ -2122,9 +2121,6 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         if components is None:
             components = n.branch_components
-
-        if at_port is None and bus_carrier is not None:
-            at_port = "bus0"
 
         transmission_branches = get_transmission_branches(n, bus_carrier)
 


### PR DESCRIPTION
Fixes https://github.com/PyPSA/pypsa-eur/issues/2121 .

Related to https://github.com/PyPSA/PyPSA/pull/1592 .

## Changes proposed in this Pull Request

Fixes regression introduced by #1386 , which aligned to
```
if at_port is None:
    at_port = "bus0" if bus_carrier is None else "all"
```

In the case of transmission which always connects buses with the same carrier,
at_port = "all" leads to double counting each line once with + and once with - leading to 0 everywhere.

Here we fix this single case with at_port = "bus0" in transmission.



## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
