### PR TITLE
fix: datetime-like support for CFTimeIndex snapshots

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,13 +6,17 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Release Notes
 
-<!--## Upcoming Release
+## Upcoming Release
 
 !!! info "Upcoming Release"
 
     The features listed below have not yet been released, but will be included in the
     next update! If you would like to use these features in the meantime, you will need
-    to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.-->
+    to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
+
+### Bug Fixes
+
+- `Network.set_snapshots` now preserves `xarray.CFTimeIndex` inputs (CF calendars such as `noleap` and `360_day`, standard for CMIP6 climate datasets) instead of collapsing them to a generic object index, and correctly computes `weightings_from_timedelta` for them. See [#1090](https://github.com/PyPSA/PyPSA/issues/1090).
 
 
 ## [**v1.2.0**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.0) <small>21st April 2026</small> { id="v1.2.0" }

--- a/pypsa/common.py
+++ b/pypsa/common.py
@@ -22,6 +22,7 @@ import pandas.testing as pd_testing
 from deprecation import deprecated
 from packaging import version
 from pandas.api.types import is_list_like
+from xarray import CFTimeIndex
 
 from pypsa._options import options
 from pypsa.definitions.structures import Dict
@@ -33,6 +34,16 @@ if TYPE_CHECKING:
     from pypsa.type_utils import NetworkType
 
 logger = logging.getLogger(__name__)
+
+
+def _is_datetime_like(idx: Any) -> bool:
+    """Return True if `idx` is a datetime-like index.
+
+    Covers `pd.DatetimeIndex` and `xarray.CFTimeIndex` (CF calendars such as
+    `noleap` or `360_day`). CFTimeIndex is a `pd.Index` subclass but not a
+    `pd.DatetimeIndex` subclass, so a plain `isinstance` check misses it.
+    """
+    return isinstance(idx, (pd.DatetimeIndex, CFTimeIndex))
 
 
 class UnexpectedError(AssertionError):

--- a/pypsa/network/index.py
+++ b/pypsa/network/index.py
@@ -21,6 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pypsa._options import options
+from pypsa.common import _is_datetime_like
 from pypsa.constants import HOURS_PER_YEAR
 from pypsa.guards import _assert_data_integrity
 from pypsa.network.abstract import _NetworkABC
@@ -101,6 +102,10 @@ class NetworkIndexMixin(_NetworkABC):
                 raise ValueError(msg)
             sns = snapshots.rename(["period", "timestep"])
             sns.name = "snapshot"
+        elif isinstance(snapshots, pd.Index):
+            # Preserve subclass (e.g. DatetimeIndex, CFTimeIndex) instead of
+            # collapsing to a generic object Index via pd.Index(...).
+            sns = snapshots.rename("snapshot")
         else:
             sns = pd.Index(snapshots, name="snapshot")
 
@@ -112,9 +117,9 @@ class NetworkIndexMixin(_NetworkABC):
             sns, fill_value=default_snapshot_weightings
         )
 
-        if isinstance(snapshots, pd.DatetimeIndex) and weightings_from_timedelta:
+        if _is_datetime_like(sns) and weightings_from_timedelta:
             hours_per_step = (
-                snapshots.to_series()
+                sns.to_series()
                 .diff(periods=1)
                 .shift(-1)
                 .ffill()  # fill last value by assuming same as the one before
@@ -123,9 +128,10 @@ class NetworkIndexMixin(_NetworkABC):
             self._snapshots_data = pd.DataFrame(
                 dict.fromkeys(self._snapshots_data.columns, hours_per_step), index=sns
             )
-        elif not isinstance(snapshots, pd.DatetimeIndex) and weightings_from_timedelta:
+        elif not _is_datetime_like(sns) and weightings_from_timedelta:
             logger.info(
-                "Skipping `weightings_from_timedelta` as `snapshots`is not of type `pd.DatetimeIndex`."
+                "Skipping `weightings_from_timedelta` as `snapshots` is not a "
+                "datetime-like index (pd.DatetimeIndex or xarray.CFTimeIndex)."
             )
 
         for component in self.all_components:

--- a/test/test_snapshot_weightings.py
+++ b/test/test_snapshot_weightings.py
@@ -47,3 +47,25 @@ def test_default_snapshot_weightings(time_index):
     df_actual = n.snapshot_weightings
 
     pd.testing.assert_frame_equal(df_true, df_actual)
+
+
+@pytest.mark.parametrize("calendar", ["noleap", "360_day"])
+def test_snapshot_weightings_with_timedelta_cftime(calendar):
+    """See GH#1090 — CFTimeIndex must be treated as datetime-like."""
+    xr = pytest.importorskip("xarray")
+    pytest.importorskip("cftime")
+
+    sns = xr.date_range(
+        "2015-01-01", periods=4, freq="2h", use_cftime=True, calendar=calendar
+    )
+    n = pypsa.Network()
+    n.set_snapshots(sns, weightings_from_timedelta=True)
+
+    # Calendar metadata must survive set_snapshots.
+    from xarray import CFTimeIndex
+
+    assert isinstance(n.snapshots, CFTimeIndex)
+    assert n.snapshots.calendar == calendar
+
+    # 2h freq → 2.0 hours per step.
+    assert (n.snapshot_weightings["objective"] == 2.0).all()


### PR DESCRIPTION
Closes #1090.

## Changes proposed in this Pull Request

`xarray.CFTimeIndex` (used for CF calendars like `noleap` and `360_day`, which underpin most CMIP6 climate datasets) is a `pd.Index` subclass but not a `pd.DatetimeIndex` subclass. PyPSA's `isinstance(..., pd.DatetimeIndex)` checks missed it, causing two silent failures:

1. `set_snapshots` rebuilt the index via `pd.Index(snapshots, name="snapshot")`, collapsing `CFTimeIndex` to a generic object `Index` and losing the calendar metadata.
2. `weightings_from_timedelta=True` was silently skipped — the snapshot spacing was ignored and default weights of `1.0` were used, even though `CFTimeIndex` supports the same `.to_series().diff()` arithmetic.

This PR:

- Adds `_is_datetime_like(idx)` in `pypsa/common.py`, covering `pd.DatetimeIndex` and `xarray.CFTimeIndex`.
- In `set_snapshots`, renames in place when the input is already a `pd.Index` subclass instead of rebuilding through `pd.Index(...)`, so `CFTimeIndex` (and any future pandas index subclass) survives the call.
- Replaces the `isinstance(..., pd.DatetimeIndex)` guards on the `weightings_from_timedelta` path with `_is_datetime_like(sns)`.
- Adds parametrized tests (`noleap`, `360_day`) asserting both type preservation and correct timedelta-derived weights.

Note: `n.cluster.temporal.resample()` still refuses `CFTimeIndex` because pandas' `.resample()` does not support it natively — routing through xarray's resampler is a larger design change and is left as a follow-up.

## Why this might be worth prioritising

The failure is silent: no exception, just a single `INFO` line, and `snapshot_weightings` quietly defaults to `1.0` regardless of the real snapshot spacing.

Because downstream quantities are computed as `Σ(weight × power)`, an N-hourly input (3h or 6h is typical for CMIP6) under-reports energy, variable costs and emissions by a factor of N, and the objective under-prices operations relative to new capacity — biasing capacity expansion toward less storage and more peaker dispatch. The total objective barely shifts (capital costs dominate), which makes it easy to miss by eyeballing headline numbers.

This shows up for anyone feeding CMIP6 / CORDEX output through xarray into PyPSA, so it seemed worth flagging here in case it raises the priority of the issue.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.