### PR TITLE
warn about infinite resistance

### DIFF
--- a/pypsa/network/power_flow.py
+++ b/pypsa/network/power_flow.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 import networkx as nx
 import numpy as np
 import pandas as pd
-from numpy import ones, r_
+from numpy import ones, r_, isinf
 from numpy.linalg import norm
 from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, issparse
 from scipy.sparse import hstack as shstack
@@ -761,6 +761,10 @@ class NetworkPowerFlowMixin(_NetworkABC):
         self.c.lines.static["r_pu"] = self.c.lines.static.r / (
             self.c.lines.static.v_nom**2
         )
+        if isinf(self.c.lines.static["r_pu"]).any():
+            logger.warning(
+                "Warning, some lines have infinite per unit resistance. This may cause issues with power flow convergence. Consider removing these lines."
+            )
         self.c.lines.static["b_pu"] = (
             self.c.lines.static.b * self.c.lines.static.v_nom**2
         )

--- a/pypsa/network/power_flow.py
+++ b/pypsa/network/power_flow.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 import networkx as nx
 import numpy as np
 import pandas as pd
-from numpy import ones, r_, isinf
+from numpy import isinf, ones, r_
 from numpy.linalg import norm
 from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, issparse
 from scipy.sparse import hstack as shstack

--- a/pypsa/network/power_flow.py
+++ b/pypsa/network/power_flow.py
@@ -758,12 +758,16 @@ class NetworkPowerFlowMixin(_NetworkABC):
         self.c.lines.static["x_pu"] = self.c.lines.static.x / (
             self.c.lines.static.v_nom**2
         )
+        if isinf(self.c.lines.static["x_pu"]).any():
+            logger.warning(
+                "Some lines have infinite per unit reactance `x_pu`. This may cause issues with power flow convergence. Consider removing these lines."
+            )
         self.c.lines.static["r_pu"] = self.c.lines.static.r / (
             self.c.lines.static.v_nom**2
         )
         if isinf(self.c.lines.static["r_pu"]).any():
             logger.warning(
-                "Warning, some lines have infinite per unit resistance. This may cause issues with power flow convergence. Consider removing these lines."
+                "Some lines have infinite per unit resistance `r_pu`. This may cause issues with power flow convergence. Consider removing these lines."
             )
         self.c.lines.static["b_pu"] = (
             self.c.lines.static.b * self.c.lines.static.v_nom**2
@@ -778,9 +782,17 @@ class NetworkPowerFlowMixin(_NetworkABC):
         self.c.transformers.static["x_pu"] = (
             self.c.transformers.static.x / self.c.transformers.static.s_nom
         )
+        if isinf(self.c.transformers.static["x_pu"]).any():
+            logger.warning(
+                "Some transformers have infinite per unit reactance `x_pu`. This may cause issues with power flow convergence. Consider removing these transformers."
+            )
         self.c.transformers.static["r_pu"] = (
             self.c.transformers.static.r / self.c.transformers.static.s_nom
         )
+        if isinf(self.c.transformers.static["r_pu"]).any():
+            logger.warning(
+                "Some transformers have infinite per unit resistance `r_pu`. This may cause issues with power flow convergence. Consider removing these transformers."
+            )
         self.c.transformers.static["b_pu"] = (
             self.c.transformers.static.b * self.c.transformers.static.s_nom
         )

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -14,7 +14,7 @@ import linopy
 import pandas as pd
 import xarray as xr
 from linopy import merge
-from numpy import inf, isfinite, maximum, sqrt, tile
+from numpy import inf, isinf, isfinite, maximum, sqrt, tile
 from xarray import DataArray, concat, where
 
 from pypsa.common import as_index, expand_series
@@ -2159,7 +2159,9 @@ def define_secant_loss_constraints(
         stepfactor_k = maximum(stepfactor_atol, stepfactor_rtol)
         breakpoint_factors_list.append(breakpoint_factors_list[-1] * stepfactor_k)
         if k >= max_segments:
-            msg = f"Secant loop hit max_segments; check atol/rtol or line parameters; current inputs would result in {2 * max_segments} additional constraints per line"
+            msg = f"Secant loop hit max_segments; check atol/rtol or line parameters; current inputs would result in {2 * max_segments} additional constraints per line."
+            if isinf(r_pu_eff).any():
+                msg += " Hint: Found Inf in r_pu_eff values, which may indicate a line with zero capacity, which should probably be removed from the network."
             raise RuntimeError(msg)
 
     # make a separate array of factors for every line

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -2161,7 +2161,7 @@ def define_secant_loss_constraints(
         if k >= max_segments:
             msg = f"Secant loop hit max_segments; check atol/rtol or line parameters; current inputs would result in {2 * max_segments} additional constraints per line."
             if isinf(r_pu_eff).any():
-                msg += " Hint: Found Inf in r_pu_eff values, which may indicate a line with zero capacity, which should probably be removed from the network."
+                msg += " Identified infinite `r_pu_eff` in lines likely caused by a line with `s_nom=0`. Consider removing this line."
             raise RuntimeError(msg)
 
     # make a separate array of factors for every line

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -14,7 +14,7 @@ import linopy
 import pandas as pd
 import xarray as xr
 from linopy import merge
-from numpy import inf, isinf, isfinite, maximum, sqrt, tile
+from numpy import inf, isfinite, isinf, maximum, sqrt, tile
 from xarray import DataArray, concat, where
 
 from pypsa.common import as_index, expand_series

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -2161,7 +2161,7 @@ def define_secant_loss_constraints(
         if k >= max_segments:
             msg = f"Secant loop hit max_segments; check atol/rtol or line parameters; current inputs would result in {2 * max_segments} additional constraints per line."
             if isinf(r_pu_eff).any():
-                msg += " Identified infinite `r_pu_eff` in lines likely caused by a line with `s_nom=0`. Consider removing this line."
+                msg += " Identified an infinite `r_pu_eff` in lines likely caused by a line with `s_nom=0`. Consider removing this line."
             raise RuntimeError(msg)
 
     # make a separate array of factors for every line


### PR DESCRIPTION
## Changes proposed in this Pull Request

I noticed that sometimes the secant loss approximation would not be able to construct enough linear segments. This happened because r_pu may contain INF when s_nom is set 0. Basically, this should not happen in a well specified network, so i added some warnings

@fneum 

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
