### PR TITLE
fix: ramp limit constraint leaking p_nom of other generators on non-alphabetical index

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Bug Fixes
 
+- Fix ramp limit constraints leaking another generator's `p_nom` variable into the constraint when a component held both fixed and extendable generators and their names were not in alphabetical order. See [#1675](https://github.com/PyPSA/PyPSA/issues/1675).
+
 - Fix `n.statistics.transmission()` returning zero flows when `bus_carrier` is set. (<!-- md:pr 1662 -->)
 
 - Fix `n.add(..., overwrite=True)` leaving stale time-varying (dynamic) attributes from the previously existing component, which silently shadowed the new static values at solve time. `overwrite=True` now behaves consistently with `n.remove(...)` followed by `n.add(...)`. See [#1628](https://github.com/PyPSA/PyPSA/issues/1628).

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -851,7 +851,7 @@ def define_ramp_limit_constraints(
         if is_com_fix.any():
             ds_ext = filter_first_sn * (1 - s_init_ext)
             rhs = rhs + limit_start.sel(name=ext_main_names) * p_nom_ext_var * ds_ext
-        # Restore original name order; addition above re-sorts it (see #1675).
+        # Adding a partial name expression sorts the name dim. This should be guarded more heavily in a future linopy release
         rhs = rhs.sel(name=idx)
     mask_up = mask & ~no_up_limit & non_com_ext
     m.add_constraints(lhs <= rhs, name=f"{c.name}-{attr}-ramp_limit_up", mask=mask_up)
@@ -867,7 +867,7 @@ def define_ramp_limit_constraints(
         if is_com_fix.any():
             ds_ext = filter_first_sn * (1 - s_init_ext)
             rhs = rhs + limit_shut.sel(name=ext_main_names) * p_nom_ext_var * ds_ext
-        # Restore original name order; addition above re-sorts it (see #1675).
+        # Adding a partial name expression sorts the name dim. This should be guarded more heavily in a future linopy release
         rhs = rhs.sel(name=idx)
     mask_down = mask & ~no_down_limit & non_com_ext
     m.add_constraints(

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -851,6 +851,8 @@ def define_ramp_limit_constraints(
         if is_com_fix.any():
             ds_ext = filter_first_sn * (1 - s_init_ext)
             rhs = rhs + limit_start.sel(name=ext_main_names) * p_nom_ext_var * ds_ext
+        # Restore original name order; addition above re-sorts it (see #1675).
+        rhs = rhs.sel(name=idx)
     mask_up = mask & ~no_up_limit & non_com_ext
     m.add_constraints(lhs <= rhs, name=f"{c.name}-{attr}-ramp_limit_up", mask=mask_up)
 
@@ -865,6 +867,8 @@ def define_ramp_limit_constraints(
         if is_com_fix.any():
             ds_ext = filter_first_sn * (1 - s_init_ext)
             rhs = rhs + limit_shut.sel(name=ext_main_names) * p_nom_ext_var * ds_ext
+        # Restore original name order; addition above re-sorts it (see #1675).
+        rhs = rhs.sel(name=idx)
     mask_down = mask & ~no_down_limit & non_com_ext
     m.add_constraints(
         lhs >= rhs, name=f"{c.name}-{attr}-ramp_limit_down", mask=mask_down

--- a/test/test_lopf_unit_commitment.py
+++ b/test/test_lopf_unit_commitment.py
@@ -628,6 +628,53 @@ def test_dynamic_ramp_rates():
 
 
 @pytest.mark.parametrize("direction", ["up", "down"])
+def test_generator_ramp_constraints_unsorted_names(direction):
+    """
+    See https://github.com/PyPSA/PyPSA/issues/1675
+
+    With one fixed and one extendable generator on the same component,
+    a non-alphabetical insertion order used to leak the extendable's
+    p_nom variable into the fixed generator's ramp constraint.
+    """
+    n = pypsa.Network()
+    n.set_snapshots(pd.date_range("2025-01-01", periods=3, freq="h"))
+
+    n.add("Bus", "bus")
+    n.add("Load", "load", bus="bus", p_set=100)
+
+    # Fixed generator's name sorts AFTER the extendable's; this ordering
+    # is what triggered the bug.
+    n.add(
+        "Generator",
+        "fixed_lignite",
+        bus="bus",
+        p_nom=944,
+        marginal_cost=30,
+        **{f"ramp_limit_{direction}": 0.04},
+    )
+    n.add(
+        "Generator",
+        "ext_gas",
+        bus="bus",
+        p_nom_extendable=True,
+        marginal_cost=95,
+        capital_cost=52_000,
+    )
+
+    n.optimize.create_model()
+
+    con = n.model.constraints[f"Generator-p-ramp_limit_{direction}"]
+    p_nom_ext_label = int(
+        n.model.variables["Generator-p_nom"].labels.sel(name="ext_gas")
+    )
+    vars_for_fixed = con.vars.sel(name="fixed_lignite").values
+    assert (vars_for_fixed != p_nom_ext_label).all(), (
+        f"ramp_{direction} for 'fixed_lignite' references the extendable's "
+        f"p_nom variable (issue #1675)"
+    )
+
+
+@pytest.mark.parametrize("direction", ["up", "down"])
 def test_generator_ramp_constraints_mask_nan(direction):
     """
     See https://github.com/PyPSA/PyPSA/issues/1493


### PR DESCRIPTION
Closes #1675.

## Summary

`define_ramp_limit_constraints` (consolidated in #1553) builds the right-hand side of the ramp constraint in two passes: first a full-name term covering every generator's static capacity, then (for extendable generators) an additive term carrying the `p_nom` decision variable. The second add joins two `LinearExpression`s whose `name` axes carry different label sets (`[fixed, extendable]` vs `[extendable]`), and xarray's outer-join alignment quietly re-sorts the result's `name` axis alphabetically. The matching `lhs` was built earlier from a single full-set array and still carries the original insertion order. `linopy` then zips `lhs <= rhs` by position, so for any pair of generators whose names aren't alphabetically sorted, the rows swap, and the fixed generator's ramp constraint ends up carrying the extendable generator's `p_nom` variable instead of its physical ramp limit.

### Minimal reproducer (from #1675)

```python
import pandas as pd, pypsa

n = pypsa.Network()
n.set_snapshots(pd.date_range("2015-01-01", periods=3, freq="h"))
n.add("Bus", "bus")
n.add("Load", "load", bus="bus", p_set=100)
n.add("Generator", "c", bus="bus", p_nom=492, p_min_pu=0.9,
      marginal_cost=10, ramp_limit_up=0.1, ramp_limit_down=0.1)
n.add("Generator", "b", bus="bus", p_nom=0,
      p_nom_extendable=True, marginal_cost=100)
n.optimize.create_model()
print(n.model.constraints["Generator-p-ramp_limit_up"].sel(name="c"))
# before this PR (idx = ['c','b'] is not sorted, bug triggers):
#   p[t,c] - p[t-1,c] - p_nom[b]  <=  0     (extendable's variable leaked)
# after this PR:
#   p[t,c] - p[t-1,c]             <=  49.2  (correct, 0.1 * 492)
```

## Why this matters

The bug is silent: no exception, no warning, the solver reports `Optimal` and a clean objective value. It only triggers when (a) a component holds at least one fixed and one extendable generator with `ramp_limit_*` set on the fixed one, and (b) the names aren't already in alphabetical order. Test fixtures using `gen0`, `gen1`, ... happen to be alphabetical, which is why the consolidation in #1553 passed CI.

Consider a realistic capacity-expansion setup: a 944 MW lignite plant with `ramp_limit_up = 0.04` and a candidate gas peaker (`p_nom_extendable=True`, no ramp limit) on the same bus, with a single demand swing of 200 → 900 → 200 → 900 MW. The buggy constraint becomes `|Δp_lignite| ≤ p_nom_gas`. The solver, free to ramp lignite at whatever rate it wants by underbuilding the peaker, returns a "solution" where the lignite plant ramps **350 MW/h** (≈9.3× its physical limit of 37.8 MW/h), builds a **350 MW** gas peaker instead of the **662 MW** physically required, and reports an annual system cost **47% below** the constraint-respecting answer. Capacity-planning workflows that import generators ordered by plant ID rather than alphabetically, which is most database-backed pipelines, silently consume this wrong number.

## Fix

After the partial-name addition in both the up-ramp and down-ramp branches of `define_ramp_limit_constraints` (`pypsa/optimization/constraints.py`), reindex `rhs` back to `idx` (the component's static index) so it matches the order `lhs` was built on:

```python
        # Restore original name order; addition above re-sorts it (see #1675).
        rhs = rhs.sel(name=idx)
```

The reindex is a no-op when there are no extendable generators (the conditional block is skipped) or when `idx` is already alphabetical. It does not change the variable contents, only the row order, so the resulting constraint is identical for every previously-working configuration.

`_define_ramp_limit_big_m` (the committable+extendable code path) was reviewed for the same pattern; it builds each branch on its own subset via `.sel(name=com_ext_i)` and doesn't mix partial-name and full-name expressions, so it's unaffected.

## Test plan

- [x] New regression test `test_generator_ramp_constraints_unsorted_names` in `test/test_lopf_unit_commitment.py`, parametrised over `up` / `down`. Names the fixed generator `fixed_lignite` and the extendable one `ext_gas` so the index is `["fixed_lignite", "ext_gas"]` (not alphabetical), and asserts that the extendable's `p_nom` variable label does not appear in the fixed generator's constraint row. Fails on `master`, passes with this PR.
- [x] All 16 ramp-related tests in `test_lopf_unit_commitment.py` pass.
- [x] Wider related test files all green (`test_committable_extendable`, `test_compatibility_ext_and_com`, `test_lopf_modularity`, `test_lopf_rolling_horizon`, `test_lopf_basic_constraints`, `test_lopf_unit_commitment`): 91/91.
- [x] `pre-commit run --files <changed>` clean.

## A note on the underlying linopy behaviour

The trigger here isn't specific to the ramp constraint. It's a more general property of `linopy.LinearExpression` comparisons: when `lhs` and `rhs` carry the same dimension labels but in different orders, the comparison combines them positionally rather than reindexing by label first. xarray's own arithmetic (`a + b`) aligns by label, so the mismatch is easy to walk into.

This is already tracked upstream as [PyPSA/linopy#670](https://github.com/PyPSA/linopy/issues/670) (with related variants in PyPSA/linopy#586, PyPSA/linopy#550, PyPSA/linopy#257), and an in-flight refactor in [PyPSA/linopy#591](https://github.com/PyPSA/linopy/pull/591) introduces a strict label-matching convention behind an opt-in `linopy.options["arithmetic_convention"] = "v1"` setting. The default mode in linopy stays `"legacy"` for backward compatibility, so PyPSA users on every released version of linopy remain exposed to this class of silent bug until v1 becomes the default. That's why a local fix on the PyPSA side is worth shipping now rather than waiting on upstream.

@FabianHofmann @fneum, would value a review of the fix. I have a self-contained linopy-only reproducer (a `Model`, two variables, two `LinearExpression`s with different name orderings, a row-swapped constraint) ready if it would help as an additional data point on PyPSA/linopy#670.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
