### PR TITLE
fix: capacity bounds for infinite non-extendables

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,13 +6,16 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Release Notes
 
-<!--## Upcoming Release
+## Upcoming Release
 
 !!! info "Upcoming Release"
 
     The features listed below have not yet been released, but will be included in the
     next update! If you would like to use these features in the meantime, you will need
-    to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.-->
+    to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
+
+- Fix operational constraints for non-extendable components producing `NaN` bounds when `p_nom` is infinite and `p_min_pu`/`p_max_pu` is zero. The bound now falls back to zero in this case. Relevant for linopy versions `>=0.7` where `NaN` bounds are not dropped explicitly.
+
 
 ## [**v1.2.1**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.1) <small>19th May 2026</small> { id="v1.2.1" }
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -14,7 +14,7 @@ import linopy
 import pandas as pd
 import xarray as xr
 from linopy import merge
-from numpy import inf, isfinite, maximum, sqrt, tile
+from numpy import inf, isfinite, isinf, maximum, sqrt, tile
 from xarray import DataArray, concat, where
 
 from pypsa.common import as_index, expand_series
@@ -102,8 +102,12 @@ def define_operational_constraints_for_non_extendables(
         min_pu = min_pu.sel(snapshot=sns)
         max_pu = max_pu.sel(snapshot=sns)
 
-    lower = min_pu * nominal_fix
-    upper = max_pu * nominal_fix
+    is_inf = isinf(nominal_fix)
+    is_zero_min = min_pu == 0
+    is_zero_max = max_pu == 0
+
+    lower = (min_pu * nominal_fix).where(~(is_inf & is_zero_min), 0)
+    upper = (max_pu * nominal_fix).where(~(is_inf & is_zero_max), 0)
 
     active = c.da.active.sel(name=fix_i, snapshot=sns)
 

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -404,3 +404,29 @@ def test_define_fixed_operational_constraints_extendable():
     assert n.c.generators.dynamic.p["gen0"].eq(5).all()
     assert n.c.generators.dynamic.p["gen1"].eq(5).all()
     assert n.c.generators.dynamic.p["gen2"].eq(0).all()
+
+
+def test_define_fixed_operational_constraints_infinite_p_nom():
+    """Non-extendable generator with p_nom=inf and p_min_pu=0 must not produce NaN bounds.
+
+    Without the inf*0 fallback, the lower bound would be NaN and the solve would fail.
+    """
+    n = pypsa.Network()
+    n.add("Bus", "bus0")
+    n.add("Load", "load0", bus="bus0", p_set=10)
+    n.add(
+        "Generator",
+        "gen_inf",
+        bus="bus0",
+        p_nom=float("inf"),
+        p_min_pu=0,
+        p_max_pu=1,
+        marginal_cost=1,
+    )
+
+    n.optimize.create_model()
+    lower = n.model.constraints["Generator-fix-p-lower"].rhs
+    assert (lower == 0).all()
+
+    n.optimize.solve_model()
+    assert n.c.generators.dynamic.p["gen_inf"].eq(10).all()


### PR DESCRIPTION
## Summary
- When a non-extendable component has `p_nom=inf` and `p_min_pu`/`p_max_pu=0`, the operational constraint bound was `inf*0 = NaN`. With linopy `>=0.7`, NaN bounds are no longer silently dropped and the solve fails.
- Fall back to `0` for the bound in that case.

## Test plan
- [x] Added `test_define_fixed_operational_constraints_infinite_p_nom` asserting the lower-bound rhs is zero and the solve dispatches correctly.
- [x] Existing `fixed_operational` tests still pass.