### PR TITLE
include -1 * sign for loads in define_nodal_balance_constraint

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix [`n.add(..., overwrite=True)`][pypsa.Network.add] leaving stale dynamic attributes from the previously existing component, which silently shadowed the new static values at solve time. `overwrite=True` now behaves consistently with [`n.remove(...)`][pypsa.Network.remove] followed by `n.add(...)`. (<!-- md:pr 1666 -->)
 
+- Fix the sign of loads not being taken into account in the nodal balance constraint when calling `n.optimize()´. 
+
 
 ## [**v1.2.0**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.0) <small>21st April 2026</small> { id="v1.2.0" }
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,7 +28,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix [`n.add(..., overwrite=True)`][pypsa.Network.add] leaving stale dynamic attributes from the previously existing component, which silently shadowed the new static values at solve time. `overwrite=True` now behaves consistently with [`n.remove(...)`][pypsa.Network.remove] followed by `n.add(...)`. (<!-- md:pr 1666 -->)
 
-- Fix the sign of loads not being taken into account in the nodal balance constraint when calling `n.optimize()´. 
+- Fix the sign of loads not being taken into account in the nodal balance constraint when calling `n.optimize()´.
 
 
 ## [**v1.2.0**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.0) <small>21st April 2026</small> { id="v1.2.0" }

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1144,11 +1144,13 @@ def define_nodal_balance_constraints(
             dims=["snapshot", "name"],
         )
     else:
-        loads_values = (-1 *loads.da.p_set.where(
-            loads.da.active.sel(name=loads.active_assets, snapshot=sns)
+        loads_values = (
+            -1
+            * loads.da.p_set.where(
+                loads.da.active.sel(name=loads.active_assets, snapshot=sns)
             )
-        * loads.da.sign.where(
-            loads.da.active.sel(name=loads.active_assets, snapshot=sns)
+            * loads.da.sign.where(
+                loads.da.active.sel(name=loads.active_assets, snapshot=sns)
             )
         )
         loads_values = loads_values.reindex(name=loads.static.index.unique("name"))

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1144,8 +1144,12 @@ def define_nodal_balance_constraints(
             dims=["snapshot", "name"],
         )
     else:
-        loads_values = loads.da.p_set.where(
+        loads_values = (-1 *loads.da.p_set.where(
             loads.da.active.sel(name=loads.active_assets, snapshot=sns)
+            )
+        * loads.da.sign.where(
+            loads.da.active.sel(name=loads.active_assets, snapshot=sns)
+            )
         )
         loads_values = loads_values.reindex(name=loads.static.index.unique("name"))
         load_buses = loads._as_xarray("bus").rename("Bus")

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1144,15 +1144,8 @@ def define_nodal_balance_constraints(
             dims=["snapshot", "name"],
         )
     else:
-        loads_values = (
-            -1
-            * loads.da.p_set.where(
-                loads.da.active.sel(name=loads.active_assets, snapshot=sns)
-            )
-            * loads.da.sign.where(
-                loads.da.active.sel(name=loads.active_assets, snapshot=sns)
-            )
-        )
+        active_mask = loads.da.active.sel(name=loads.active_assets, snapshot=sns)
+        loads_values = (-loads.da.p_set * loads.da.sign).where(active_mask)
         loads_values = loads_values.reindex(name=loads.static.index.unique("name"))
         load_buses = loads._as_xarray("bus").rename("Bus")
         if n.has_scenarios:

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -406,7 +406,6 @@ def test_define_fixed_operational_constraints_extendable():
     assert n.c.generators.dynamic.p["gen2"].eq(0).all()
 
 
-
 def test_nodal_balance_respects_load_sign():
     """
     The sign attribute of Load components must be considered in the
@@ -456,6 +455,7 @@ def test_nodal_balance_load_sign_rhs_values():
     # sign=+1: RHS contribution = -p_set * (+1) = -p_set
     assert rhs.sel(name="B2").item() == -30.0
 
+
 def test_define_fixed_operational_constraints_infinite_p_nom():
     """Non-extendable generator with p_nom=inf and p_min_pu=0 must not produce NaN bounds.
 
@@ -480,4 +480,3 @@ def test_define_fixed_operational_constraints_infinite_p_nom():
 
     n.optimize.solve_model()
     assert n.c.generators.dynamic.p["gen_inf"].eq(10).all()
-

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -404,3 +404,53 @@ def test_define_fixed_operational_constraints_extendable():
     assert n.c.generators.dynamic.p["gen0"].eq(5).all()
     assert n.c.generators.dynamic.p["gen1"].eq(5).all()
     assert n.c.generators.dynamic.p["gen2"].eq(0).all()
+
+
+def test_nodal_balance_respects_load_sign():
+    """
+    The sign attribute of Load components must be considered in the
+    nodal balance constraint. With sign=-1 (default), a load consumes
+    power; with sign=+1, it represents a fixed supply injection.
+
+    Verifies both:
+      1. The nodal balance constraint RHS equals -p_set * sign.
+      2. The solved generator dispatch matches the resulting net demand.
+    """
+    n = pypsa.Network()
+    n.add("Bus", "B1")
+    n.add("Generator", "gen", bus="B1", p_nom=200, marginal_cost=10)
+    n.add("Load", "L_consume", bus="B1", p_set=100, sign=-1)
+    n.add("Load", "L_supply", bus="B1", p_set=100, sign=1)
+
+    n.optimize(solver_name="highs")
+
+    # Constraint RHS check: -p_set * sign per load, summed per bus
+    # Expected for bus B1: -(100 * -1) + -(100 * 1) = 100 - 100 = 0
+    rhs = n.model.constraints["Bus-nodal_balance"].rhs.sel(name="B1")
+    assert (rhs == 0).all().item()
+
+    # Generator stays idle
+    assert n.c.generators.dynamic.p["gen"].abs().max() < TOLERANCE
+    assert n.objective < TOLERANCE
+
+
+def test_nodal_balance_load_sign_rhs_values():
+    """
+    Verify the per-load contribution to the nodal balance RHS for both
+    sign conventions, independently of solver behavior.
+    """
+    n = pypsa.Network()
+    n.add("Bus", "B1")
+    n.add("Bus", "B2")
+    n.add("Generator", "gen1", bus="B1", p_nom=500, marginal_cost=1)
+    n.add("Generator", "gen2", bus="B2", p_nom=500, marginal_cost=1)
+    n.add("Load", "L_default", bus="B1", p_set=80)  # default sign = -1
+    n.add("Load", "L_supply", bus="B2", p_set=30, sign=1)
+
+    n.optimize.create_model()
+
+    rhs = n.model.constraints["Bus-nodal_balance"].rhs
+    # Default sign=-1: RHS contribution = -p_set * (-1) = +p_set
+    assert rhs.sel(name="B1").item() == 80.0
+    # sign=+1: RHS contribution = -p_set * (+1) = -p_set
+    assert rhs.sel(name="B2").item() == -30.0


### PR DESCRIPTION
Closes #1684 .

## Changes proposed in this Pull Request
Bugfix: Consider the sign of loads in optimization, not only lpf.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
