### PR TITLE
fix(optimization): mask ramp limits at investment-period boundaries (#1669)

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,7 @@ SPDX-License-Identifier: CC-BY-4.0
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
 
 - Fix operational constraints for non-extendable components producing `NaN` bounds when `p_nom` is infinite and `p_min_pu`/`p_max_pu` is zero. The bound now falls back to zero in this case. Relevant for linopy versions `>=0.7` where `NaN` bounds are not dropped explicitly.
+- Fix ramp limit constraints in multi-investment-period models. Previously the constraint at the first snapshot of each investment period (after the horizon start) linked dispatch to the last snapshot of the prior period, which collapsed to `p <= ramp_limit_up * p_nom` for newly built assets and could make pathway-planning models infeasible when `p_min_pu * p_nom > ramp_limit_up * p_nom` (e.g. nuclear with high `p_min_pu` and tight ramps). Ramp constraints are now dropped at period boundaries where the asset was inactive in the previous period; cross-period ramps for continuously active assets are preserved.
 
 
 ## [**v1.2.1**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.1) <small>19th May 2026</small> { id="v1.2.1" }

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -14,7 +14,7 @@ import linopy
 import pandas as pd
 import xarray as xr
 from linopy import merge
-from numpy import inf, isfinite, isinf, maximum, sqrt, tile
+from numpy import concatenate, inf, isfinite, isinf, maximum, sqrt, tile
 from xarray import DataArray, concat, where
 
 from pypsa.common import as_index, expand_series
@@ -648,6 +648,24 @@ def define_nominal_constraints_for_extendables(
         )
 
 
+def _period_boundary_mask(sns: pd.Index | pd.MultiIndex) -> DataArray:
+    """Flag first snapshot of each investment period beyond the horizon start.
+
+    For a flat snapshot index returns an all-False array. For a
+    ``(period, timestep)`` MultiIndex returns ``True`` at the first timestep of
+    every investment period except the very first one (which is already
+    handled by rolling-horizon ``p_init`` substitution). Used to drop ramp
+    constraints that would otherwise spuriously link dispatch across
+    investment periods (issue #1669).
+    """
+    if isinstance(sns, pd.MultiIndex) and "period" in sns.names:
+        periods = sns.get_level_values("period").to_numpy()
+        is_period_first = concatenate([[False], periods[1:] != periods[:-1]])
+    else:
+        is_period_first = [False] * len(sns)
+    return DataArray(is_period_first, coords=[sns])
+
+
 def _define_ramp_limit_big_m(
     n: Network,
     sns: pd.Index | pd.MultiIndex,
@@ -694,8 +712,14 @@ def _define_ramp_limit_big_m(
 
     lhs_delta = p - p_prev_ce
     mask = mask.sel(name=idx)
-    mask_up = mask & ~no_up_limit.sel(name=idx)
-    mask_down = mask & ~no_down_limit.sel(name=idx)
+    # Drop ramp constraints at investment-period boundaries where the asset was
+    # inactive in the previous period (issue #1669). For continuously active
+    # assets the cross-period link is preserved.
+    is_period_boundary = _period_boundary_mask(sns)
+    prev_active = mask.shift(snapshot=1).fillna(False).astype(bool)
+    keep = ~is_period_boundary | prev_active
+    mask_up = mask & ~no_up_limit.sel(name=idx) & keep
+    mask_down = mask & ~no_down_limit.sel(name=idx) & keep
 
     lu = limit_up.sel(name=idx)
     ld = limit_down.sel(name=idx)
@@ -857,7 +881,13 @@ def define_ramp_limit_constraints(
             rhs = rhs + limit_start.sel(name=ext_main_names) * p_nom_ext_var * ds_ext
         # Adding a partial name expression sorts the name dim. This should be guarded more heavily in a future linopy release
         rhs = rhs.sel(name=idx)
-    mask_up = mask & ~no_up_limit & non_com_ext
+    # Drop ramp at investment-period boundaries where the asset was inactive
+    # in the previous period (issue #1669); cross-period links for
+    # continuously active assets are preserved.
+    is_period_boundary = _period_boundary_mask(sns)
+    prev_active = mask.shift(snapshot=1).fillna(False).astype(bool)
+    keep_period = ~is_period_boundary | prev_active
+    mask_up = mask & ~no_up_limit & non_com_ext & keep_period
     m.add_constraints(lhs <= rhs, name=f"{c.name}-{attr}-ramp_limit_up", mask=mask_up)
 
     lhs = p - p_prev
@@ -873,7 +903,7 @@ def define_ramp_limit_constraints(
             rhs = rhs + limit_shut.sel(name=ext_main_names) * p_nom_ext_var * ds_ext
         # Adding a partial name expression sorts the name dim. This should be guarded more heavily in a future linopy release
         rhs = rhs.sel(name=idx)
-    mask_down = mask & ~no_down_limit & non_com_ext
+    mask_down = mask & ~no_down_limit & non_com_ext & keep_period
     m.add_constraints(
         lhs >= rhs, name=f"{c.name}-{attr}-ramp_limit_down", mask=mask_down
     )

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -1132,3 +1132,85 @@ def test_operational_limit_with_investment_period_storage():
     # Total operational value for 2030 should respect the limit
     total_2030 = soc_delta
     assert total_2030 <= 25 + 1e-6  # Allow small numerical tolerance
+
+
+def test_ramp_limit_masked_at_period_boundaries():
+    """Ramp constraints must not link dispatch across investment periods.
+
+    Regression test for issue #1669: PyPSA previously created a ramp
+    constraint at the first snapshot of every investment period beyond the
+    horizon start, including for generators that had not yet been built.
+    Because the previous-period dispatch of an inactive generator is zero,
+    the spurious constraint reduced to ``p[period_first] <= ramp_limit_up
+    * p_nom``, rendering models with ``p_min_pu * p_nom > ramp_limit_up *
+    p_nom`` (e.g. nuclear) infeasible.
+
+    The fix masks ramp constraints at investment-period boundaries where the
+    asset was inactive in the prior period; cross-period links for
+    continuously active assets are preserved.
+    """
+    n = pypsa.Network()
+
+    snapshots = pd.MultiIndex.from_product(
+        [
+            [2030, 2035, 2040],
+            pd.date_range("2018-01-01", periods=2, freq="h"),
+        ],
+        names=["period", "timestep"],
+    )
+
+    n.set_snapshots(snapshots)
+    n.investment_periods = pd.Index([2030, 2035, 2040])
+    n.investment_period_weightings.objective = 1.0
+    n.investment_period_weightings.years = 1.0
+
+    n.c.carriers.add(["AC", "nuclear"])
+    n.c.buses.add("elec", carrier="AC")
+    # Load above the nuclear minimum stable output so the model is feasible
+    # once the ramp bug is fixed (without the fix it is infeasible regardless).
+    n.c.loads.add("load", bus="elec", p_set=60.0)
+
+    for period in n.investment_periods:
+        n.c.generators.add(
+            f"nuclear/{period}",
+            bus="elec",
+            carrier="nuclear",
+            p_nom=100.0,
+            p_min_pu=0.5,  # exceeds ramp_limit_up, triggers the bug
+            marginal_cost=10.0,
+            ramp_limit_up=0.05,
+            ramp_limit_down=0.05,
+            build_year=period,
+            lifetime=5,  # each unit only active during its own investment period
+        )
+
+    m = n.optimize.create_model(
+        include_objective_constant=False,
+        multi_investment_periods=True,
+    )
+
+    cons_up = m.constraints["Generator-p-ramp_limit_up"]
+
+    # `mask` convention: True = constraint enforced, False = dropped.
+    # Each generator is active only during its own investment period
+    # (lifetime=5). Ramp constraint at the first snapshot of each period must
+    # be dropped because the unit was inactive in the previous period (this
+    # is the issue #1669 bug).
+    active_2030 = cons_up.sel(name="nuclear/2030").mask.values.astype(bool)
+    assert list(active_2030) == [False, True, False, False, False, False]
+
+    active_2035 = cons_up.sel(name="nuclear/2035").mask.values.astype(bool)
+    # Index 2 = (2035, t0): period-first, previously buggy, now dropped.
+    assert list(active_2035) == [False, False, False, True, False, False]
+
+    active_2040 = cons_up.sel(name="nuclear/2040").mask.values.astype(bool)
+    # Index 4 = (2040, t0): period-first, previously buggy, now dropped.
+    assert list(active_2040) == [False, False, False, False, False, True]
+
+    # Solve must be feasible now; previously infeasible due to the bug.
+    status, condition = n.optimize(
+        solver_name="highs",
+        multi_investment_periods=True,
+    )
+    assert status == "ok"
+    assert condition == "optimal"


### PR DESCRIPTION
Closes #1669.

## Changes proposed in this Pull Request

In multi-investment-period models the existing ramp-limit code calls `Generator-p.shift(snapshot=1)` on a flat-snapshot axis, so the first snapshot of every investment period gets coupled to the last snapshot of the prior period. Combined with `active`-mask zeroing for not-yet-built assets, the constraint at `(period_first, gen)` collapses to

```
p[period_first, gen]  -  0  <=  ramp_limit_up * p_nom
```

which makes pathway models infeasible whenever `p_min_pu * p_nom > ramp_limit_up * p_nom` (typical for nuclear with `p_min_pu = 0.5`, `ramp_limit_up = 0.05/h`).

The fix introduces `_period_boundary_mask(sns)` which flags the first snapshot of each investment period beyond the horizon start. Ramp constraints are then dropped at those snapshots whenever the asset was inactive in the previous snapshot (`mask.shift(snapshot=1).fillna(False) == False`). Cross-period ramps for continuously active assets are preserved, matching the expected behaviour in the issue.

The same logic is applied in both the standard LP path (`define_ramp_limit_constraints`) and the big-M committable-extendable path (`_define_ramp_limit_big_m`). The fix is a no-op for flat snapshot indices, so single-period models are unaffected.

A regression test (`test_ramp_limit_masked_at_period_boundaries`) sets up the nuclear case from the issue, asserts the per-generator mask shape matches the expected behaviour, and confirms the model solves to optimality.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.