### PR TITLE
fix: normalize Arrow-string indexes before optimize (#1585, #1656)

### DIFF
--- a/pypsa/consistency.py
+++ b/pypsa/consistency.py
@@ -49,6 +49,28 @@ def _log_or_raise(strict: bool, message: str, *args: Any) -> None:
     logger.warning(message, *args)
 
 
+def _normalize_static_string_dtypes(n: NetworkType) -> None:
+    """Cast every component's `static` string-typed index and columns to object.
+
+    Under pandas >= 2.1 with `future.infer_string=True` (the default since
+    pandas 3.0), CSV/parquet-loaded component data becomes
+    ArrowStringArray-backed. xarray rejects Arrow-backed pandas arrays as
+    `.sel()` indexers, breaking dozens of call sites in the optimization
+    module (e.g. `cbuses.sel(name=c.active_assets)` in
+    `define_nodal_balance_constraints`, where `cbuses` is built from
+    bus-column values). See GH #1585 / #1656.
+
+    Called from `Network.sanitize()` and from `Network.optimize` before model
+    construction, so the invariant holds for both manual and implicit flows.
+    """
+    for c in n.components:
+        if c.static.index.dtype != object:
+            c.static.index = c.static.index.astype(object)
+        for col in c.static.columns:
+            if str(c.static[col].dtype) in ("str", "string"):
+                c.static[col] = c.static[col].astype(object)
+
+
 def check_for_unknown_buses(
     n: NetworkType, component: Components, strict: bool = False
 ) -> None:
@@ -1045,6 +1067,8 @@ class NetworkConsistencyMixin(_NetworkABC):
 
         self.c.carriers.add_missing_carriers()
         self.c.carriers.assign_colors()
+
+        _normalize_static_string_dtypes(self)
 
         logger.info("Network sanitization complete.")
 

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -21,7 +21,11 @@ from pypsa._options import options
 from pypsa.common import UnexpectedError, as_index
 from pypsa.components.array import _from_xarray
 from pypsa.components.common import as_components
-from pypsa.consistency import check_big_m_exceeded, check_no_modular_committables
+from pypsa.consistency import (
+    _normalize_static_string_dtypes,
+    check_big_m_exceeded,
+    check_no_modular_committables,
+)
 from pypsa.descriptors import nominal_attrs
 from pypsa.guards import _assert_data_integrity
 from pypsa.optimization.abstract import OptimizationAbstractMixin
@@ -663,6 +667,10 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         n._linearized_uc = int(linearized_unit_commitment)
         n._multi_invest = int(multi_investment_periods)
         n._committable_big_m = committable_big_m
+
+        # Cast Arrow-backed string indexes/columns to object so xarray can
+        # accept them as `.sel(name=...)` indexers. See GH #1585 / #1656.
+        _normalize_static_string_dtypes(n)
 
         if linearized_unit_commitment:
             check_no_modular_committables(n)

--- a/test/test_lopf_rolling_horizon.py
+++ b/test/test_lopf_rolling_horizon.py
@@ -253,3 +253,38 @@ def test_rolling_horizon_linearized_uc_with_ramp_limits():
     static = n.c.generators.static.loc[committable_gens]
     ramp_limits = static.eval("ramp_limit_up * p_nom_opt")
     assert (ramping.values <= ramp_limits.values[None, :] + 1e-5).all()
+
+
+def test_rolling_horizon_ac_dc_meshed_arrow_string():
+    """Regression test for GH #1585 / #1656.
+
+    Under pandas >= 2.1 with `future.infer_string=True` (the default), CSV-loaded
+    component static indexes become ArrowStringArray-backed. xarray rejects these
+    as `.sel()` indexers, breaking `optimize()` and therefore
+    `optimize_with_rolling_horizon` on every example shipped with PyPSA.
+
+    Network.sanitize() now normalises component static indexes to object dtype.
+    """
+    import pandas as pd
+
+    prev = pd.get_option("future.infer_string")
+    pd.set_option("future.infer_string", True)
+    try:
+        n = pypsa.examples.ac_dc_meshed()
+        # Confirm precondition: Arrow-backed index would have broken .sel().
+        assert str(n.c.generators.static.index.dtype) in ("str", "string", "object")
+        n.sanitize()
+        # Post-sanitize invariant: object dtype on every component static
+        # index and on every string-typed column (sources of `.sel(name=...)`
+        # indexers downstream).
+        for c in n.components:
+            assert c.static.index.dtype == object, (
+                f"{c.name}.static.index dtype is {c.static.index.dtype}, expected object"
+            )
+            for col in c.static.columns:
+                assert str(c.static[col].dtype) not in ("str", "string"), (
+                    f"{c.name}.static[{col}] dtype is {c.static[col].dtype}, expected object"
+                )
+        n.optimize.optimize_with_rolling_horizon(horizon=4, overlap=1)
+    finally:
+        pd.set_option("future.infer_string", prev)


### PR DESCRIPTION
## What

Fixes the `TypeError: Invalid array type: <class 'pandas.arrays.ArrowStringArray'>` that breaks `Network.optimize()` and `optimize_with_rolling_horizon()` under pandas ≥ 2.1 with the default `future.infer_string=True`.

Closes / supersedes #1585.
Closes #1656 (rolling-horizon failure on `ac_dc_meshed`; the originally-reported `KeyError '0'` path is gone on current master, but the example still fails — at the Arrow-string boundary now, reported in #1585).

## Why

CSV-loaded component data becomes `ArrowStringArray`-backed under the new pandas default:

```python
n.c.generators.static.index.dtype           # 'str' (Arrow-backed)
type(n.c.generators.static.index.values)    # ArrowStringArray
```

xarray rejects Arrow-backed pandas arrays as `.sel()` indexers. Dozens of call sites in `pypsa/optimization/{constraints,variables,optimize,global_constraints}.py` pass `c.active_assets`, `get_extendable_i()`, `get_committable_i()`, etc. into `.sel(name=...)`. The first one to hit it is:

```
File ".../pypsa/optimization/constraints.py", line 1080, in define_nodal_balance_constraints
    cbuses = cbuses.sel(name=c.active_assets)
TypeError: Invalid array type: <class 'pandas.arrays.ArrowStringArray'>
```

Reproducer:

```python
import pandas as pd, pypsa
pd.set_option("future.infer_string", True)
n = pypsa.examples.ac_dc_meshed()
n.optimize.optimize_with_rolling_horizon(horizon=4, overlap=1)
```

## How

Single helper `_normalize_static_string_dtypes(n)` in `consistency.py` that casts string-typed indexes and columns to plain `object`. Wired into two entry points:

1. `Network.sanitize()` — manual sanitize path.
2. `Network.optimize.create_model()` — implicit fix when users call `optimize()` without `sanitize()`. `Network.optimize.__call__` already routes through `create_model`, so it inherits the fix.

This is the most upstream fix that doesn't require patching dozens of `.sel(name=...)` call sites or introducing per-helper dtype casts.

## Test

New regression test `test_rolling_horizon_ac_dc_meshed_arrow_string` in `test/test_lopf_rolling_horizon.py`:

- Forces `future.infer_string=True`.
- Loads `ac_dc_meshed`, runs `sanitize()`.
- Asserts post-sanitize invariant on every component static index and every string-typed column.
- Runs `optimize_with_rolling_horizon(horizon=4, overlap=1)` end-to-end.

Verified locally:

- `test/test_lopf_rolling_horizon.py` — 9/9 pass (previously 8/9 broken on master under current pandas).
- `test/test_lopf_unit_commitment.py`, `test/test_consistency_check.py`, `test/test_components.py` — green.
- Pre-existing 3 failures in `test/test_components_array.py` (`test_as_xarray_static_with_scenarios`, `test_as_xarray_scenario_dim_order`, `test_from_xarray[ac_dc_stochastic]`) reproduce on unmodified master — unrelated to this PR.

## Notes

- Helper is module-private (`_normalize_static_string_dtypes`) — happy to make it public if the maintainers prefer.
- The dtype check uses `str(dtype) in ("str", "string")` to catch both `pd.StringDtype()` and pandas 3.0's Arrow-backed string dtype. Pure-numpy `object` columns are left untouched.
- Tested against the project use case (PyPSA-based Dutch grid model with weekly-chunk rolling solves) and against the included examples.
