### PR TITLE
Add apply_outage_schedule helper for exogenous outage replay

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,10 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix operational constraints for non-extendable components producing `NaN` bounds when `p_nom` is infinite and `p_min_pu`/`p_max_pu` is zero. The bound now falls back to zero in this case. Relevant for linopy versions `>=0.7` where `NaN` bounds are not dropped explicitly.
 
+### Features
+
+- Add `pypsa.apply_outage_schedule` to write user-supplied outage windows onto a built network. Sets time-varying `p_max_pu` for [Generator](./user-guide/components/generators.md) components and both `p_max_pu` and `p_min_pu` for [Link](./user-guide/components/links.md) components (asymmetric reverse direction is clamped to the static `p_min_pu`). Overlapping rows on the same asset collapse by `min(p_max_pu)` per snapshot. Complements endogenous maintenance scheduling: use this helper when the schedule is already known (validation runs, what-if studies, REMIT replay) and the solver does not need to choose timing.
+
 
 ## [**v1.2.1**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.1) <small>19th May 2026</small> { id="v1.2.1" }
 

--- a/pypsa/__init__.py
+++ b/pypsa/__init__.py
@@ -34,6 +34,10 @@ from pypsa._options import (
     option_context,
     options,
 )
+from pypsa._outage_schedule import (
+    apply_outage_schedule,
+    build_factor_series_per_asset,
+)
 from pypsa.collection import NetworkCollection
 from pypsa.components.components import Components
 from pypsa.networks import Network, SubNetwork
@@ -77,6 +81,8 @@ __all__ = [
     "NetworkCollection",
     "SubNetwork",
     "Components",
+    "apply_outage_schedule",
+    "build_factor_series_per_asset",
 ]
 
 

--- a/pypsa/_outage_schedule.py
+++ b/pypsa/_outage_schedule.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Exogenous outage-schedule helper.
+
+Writes user-supplied outage windows onto a built PyPSA network by setting
+time-varying `p_max_pu` (and `p_min_pu` for asymmetric Links). Use this
+when the outage schedule is already known (validation runs, historical
+backcasts, prescribed what-if studies); use the maintenance-scheduling
+feature in `Network.optimize` when the solver should *decide* timing.
+
+Schema for the outages DataFrame
+--------------------------------
+Required columns:
+
+    asset_id   : str   — index entry in `network.generators` or `network.links`
+    component  : str   — `'Generator'` or `'Link'`
+    start      : pd.Timestamp (tz-aware or tz-naive UTC)
+    end        : pd.Timestamp (same tz convention as `start`)
+    p_max_pu   : float in [0, 1]  fractional availability inside the window
+
+Overlapping rows on the same asset are collapsed by `min(p_max_pu)` per
+snapshot (worst outage wins). The factor composes multiplicatively with
+any existing `p_max_pu_t` profile, so a generator at CF 0.30 during a
+0.50 derate becomes 0.15.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    import pypsa
+
+logger = logging.getLogger(__name__)
+
+OnUnknown = Literal["raise", "warn", "ignore"]
+
+_REQUIRED_COLUMNS = ("asset_id", "component", "start", "end", "p_max_pu")
+
+
+def _build_factor_series(
+    rows: pd.DataFrame,
+    snapshots: pd.DatetimeIndex,
+) -> pd.Series:
+    """Collapse outage rows for one asset into a per-snapshot factor series.
+
+    Overlapping rows take the minimum factor (worst outage wins). Outage
+    bounds may be tz-aware or tz-naive; they are normalized to the
+    snapshots' tz-awareness before comparison so the mask never silently
+    evaluates all-False.
+
+    Parameters
+    ----------
+    rows : pd.DataFrame
+        Outage rows with columns `start`, `end`, `p_max_pu`.
+    snapshots : pd.DatetimeIndex
+        Network snapshots.
+
+    Returns
+    -------
+    pd.Series
+        Factor series indexed by `snapshots`, dtype `float`, initialized at 1.0.
+
+    """
+    factor = pd.Series(1.0, index=snapshots, dtype=float)
+    tz_naive_snapshots = snapshots.tz is None
+    for _, row in rows.iterrows():
+        start = row["start"]
+        end = row["end"]
+        start_tz = getattr(start, "tz", None)
+        if tz_naive_snapshots and start_tz is not None:
+            start = start.tz_convert("UTC").tz_localize(None)
+            end = end.tz_convert("UTC").tz_localize(None)
+        elif not tz_naive_snapshots and start_tz is None:
+            start = pd.Timestamp(start, tz="UTC")
+            end = pd.Timestamp(end, tz="UTC")
+        mask = (snapshots >= start) & (snapshots <= end)
+        if not mask.any():
+            continue
+        factor.loc[mask] = np.minimum(factor.loc[mask].values, row["p_max_pu"])
+    return factor
+
+
+def build_factor_series_per_asset(
+    outages: pd.DataFrame,
+    snapshots: pd.DatetimeIndex,
+    component: str | None = None,
+) -> dict[str, pd.Series]:
+    """Return a per-asset factor series for every asset that has an outage.
+
+    Parameters
+    ----------
+    outages : pd.DataFrame
+        Outage rows; must contain `asset_id`, `start`, `end`, `p_max_pu`,
+        and (if `component` is None) `component`.
+    snapshots : pd.DatetimeIndex
+        Network snapshots used to build the per-snapshot factor series.
+    component : {'Generator', 'Link', None}
+        If given, filter `outages` to that component before collapsing.
+
+    Returns
+    -------
+    dict[str, pd.Series]
+        Only assets whose factor dips below 1.0 anywhere are returned.
+
+    """
+    if outages.empty:
+        return {}
+    df = outages
+    if component is not None and "component" in df.columns:
+        df = df[df["component"] == component]
+    if df.empty:
+        return {}
+    out: dict[str, pd.Series] = {}
+    for asset_id, rows in df.groupby("asset_id"):
+        factor = _build_factor_series(rows, snapshots)
+        if (factor < 1.0).any():
+            out[str(asset_id)] = factor
+    return out
+
+
+def _apply_link_factor(n: pypsa.Network, link_id: str, factor: pd.Series) -> None:
+    """Write an outage factor to a Link, respecting asymmetric capacity.
+
+    The same factor applies in both directions: forward goes into
+    `links_t.p_max_pu`; reverse is encoded as `links_t.p_min_pu` and
+    clamped so reverse availability is never more permissive than the
+    static `links.p_min_pu` (e.g. NorNed `p_min_pu = -0.957`).
+    """
+    static_p_min_pu = float(n.links.at[link_id, "p_min_pu"])
+
+    pmax = n.links_t.p_max_pu
+    if link_id in pmax.columns:
+        existing = pmax[link_id].reindex(factor.index).fillna(1.0)
+        pmax[link_id] = np.minimum(existing.values, factor.values)
+    else:
+        pmax[link_id] = factor.values
+
+    reverse_cap = -factor
+    reverse_series = reverse_cap.clip(lower=static_p_min_pu)
+
+    pmin = n.links_t.p_min_pu
+    if link_id in pmin.columns:
+        existing = pmin[link_id].reindex(factor.index).fillna(static_p_min_pu)
+        pmin[link_id] = np.maximum(existing.values, reverse_series.values)
+    else:
+        pmin[link_id] = reverse_series.values
+
+
+def _apply_generator_factor(n: pypsa.Network, gen_id: str, factor: pd.Series) -> None:
+    """Multiply outage factor into `generators_t.p_max_pu`.
+
+    Composes with any existing time-varying availability so a renewable
+    generator's capacity-factor profile is preserved underneath the derate.
+    """
+    pmax = n.generators_t.p_max_pu
+    if gen_id in pmax.columns:
+        existing = pmax[gen_id].reindex(factor.index).fillna(1.0)
+        pmax[gen_id] = (existing.values * factor.values).clip(0.0, 1.0)
+    else:
+        pmax[gen_id] = factor.values
+
+
+def apply_outage_schedule(
+    n: pypsa.Network,
+    outages: pd.DataFrame,
+    on_unknown: OnUnknown = "warn",
+) -> dict[str, int]:
+    """Write exogenous outage windows onto a built network.
+
+    Generators receive `n.generators_t.p_max_pu *= factor`; Links receive
+    `n.links_t.p_max_pu = min(existing, factor)` plus a clamped
+    `n.links_t.p_min_pu` for the reverse direction. Overlapping rows on
+    the same asset collapse by `min(p_max_pu)`.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Network with snapshots already set.
+    outages : pd.DataFrame
+        Outage rows; required columns: `asset_id`, `component`, `start`,
+        `end`, `p_max_pu`. `component` must be `'Generator'` or `'Link'`.
+    on_unknown : {'raise', 'warn', 'ignore'}
+        Behavior when an `asset_id` is not in the network's component index.
+
+    Returns
+    -------
+    dict[str, int]
+        `{'Generator': n_modified, 'Link': n_modified}`.
+
+    Raises
+    ------
+    ValueError
+        If `outages` is missing required columns or `component` is
+        not one of `'Generator'`, `'Link'`.
+    KeyError
+        If `on_unknown == 'raise'` and any `asset_id` is unknown.
+
+    """
+    counts: dict[str, int] = {"Generator": 0, "Link": 0}
+    if outages.empty:
+        return counts
+
+    missing = set(_REQUIRED_COLUMNS) - set(outages.columns)
+    if missing:
+        msg = f"outages is missing required columns: {sorted(missing)}"
+        raise ValueError(msg)
+
+    snapshots = n.snapshots
+    unknown: list[str] = []
+
+    for component, group in outages.groupby("component"):
+        if component == "Generator":
+            index = n.generators.index
+            apply_fn = _apply_generator_factor
+        elif component == "Link":
+            index = n.links.index
+            apply_fn = _apply_link_factor
+        else:
+            msg = (
+                f"unsupported component '{component}' in outages; "
+                f"expected 'Generator' or 'Link'"
+            )
+            raise ValueError(msg)
+        id_to_factor = build_factor_series_per_asset(group, snapshots)
+        for asset_id, factor in id_to_factor.items():
+            if asset_id not in index:
+                unknown.append(f"{component}:{asset_id}")
+                continue
+            apply_fn(n, asset_id, factor)
+            counts[component] += 1
+
+    if unknown:
+        msg = (
+            f"{len(unknown)} outage asset_id(s) not in network: "
+            f"{unknown[:5]}{'...' if len(unknown) > 5 else ''}"
+        )
+        if on_unknown == "raise":
+            raise KeyError(msg)
+        if on_unknown == "warn":
+            logger.warning(msg)
+    return counts

--- a/test/test_apply_outage_schedule.py
+++ b/test/test_apply_outage_schedule.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+"""Tests for the `apply_outage_schedule` helper."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pypsa
+from pypsa import apply_outage_schedule, build_factor_series_per_asset
+
+
+def _build_network(n_snaps: int = 24) -> pypsa.Network:
+    """Minimal network: one Generator and one asymmetric Link."""
+    n = pypsa.Network()
+    n.set_snapshots(pd.date_range("2025-01-01", periods=n_snaps, freq="h"))
+    n.add("Bus", "NL")
+    n.add("Bus", "NO")
+    n.add(
+        "Generator",
+        "Wind",
+        bus="NL",
+        p_nom=100.0,
+        carrier="wind",
+        marginal_cost=0.0,
+    )
+    n.add(
+        "Link",
+        "NorNed",
+        bus0="NL",
+        bus1="NO",
+        p_nom=700.0,
+        p_min_pu=-0.957,  # asymmetric: 700 MW NL→NO, 670 MW NO→NL
+        p_max_pu=1.0,
+        marginal_cost=0.0,
+    )
+    return n
+
+
+def _outages(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "asset_id",
+            "component",
+            "start",
+            "end",
+            "p_max_pu",
+        ],
+    )
+
+
+class TestApplyOutageSchedule:
+    def test_empty_outages_is_noop(self):
+        n = _build_network()
+        out = apply_outage_schedule(n, _outages([]))
+        assert out == {"Generator": 0, "Link": 0}
+        assert n.generators_t.p_max_pu.empty
+        assert n.links_t.p_max_pu.empty
+
+    def test_missing_columns_raises(self):
+        n = _build_network()
+        bad = pd.DataFrame({"asset_id": ["Wind"], "component": ["Generator"]})
+        with pytest.raises(ValueError, match="missing required columns"):
+            apply_outage_schedule(n, bad)
+
+    def test_unsupported_component_raises(self):
+        n = _build_network()
+        df = _outages(
+            [
+                {
+                    "asset_id": "Wind",
+                    "component": "StorageUnit",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 12:00", tz="UTC"),
+                    "p_max_pu": 0.0,
+                }
+            ]
+        )
+        with pytest.raises(ValueError, match="unsupported component"):
+            apply_outage_schedule(n, df)
+
+    def test_generator_full_outage_writes_zeros(self):
+        n = _build_network()
+        df = _outages(
+            [
+                {
+                    "asset_id": "Wind",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.0,
+                }
+            ]
+        )
+        counts = apply_outage_schedule(n, df)
+        assert counts == {"Generator": 1, "Link": 0}
+        s = n.generators_t.p_max_pu["Wind"]
+        assert (s.iloc[6:12] == 0.0).all()
+        assert (s.iloc[:6] == 1.0).all()
+        assert (s.iloc[12:] == 1.0).all()
+
+    def test_generator_outage_composes_with_existing_cf(self):
+        n = _build_network()
+        # Existing CF profile: 0.30 everywhere
+        n.generators_t.p_max_pu["Wind"] = pd.Series(0.30, index=n.snapshots)
+        df = _outages(
+            [
+                {
+                    "asset_id": "Wind",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.50,
+                }
+            ]
+        )
+        apply_outage_schedule(n, df)
+        s = n.generators_t.p_max_pu["Wind"]
+        assert np.allclose(s.iloc[6:12], 0.15)  # 0.30 * 0.50
+        assert np.allclose(s.iloc[:6], 0.30)
+        assert np.allclose(s.iloc[12:], 0.30)
+
+    def test_link_full_outage_zeroes_both_directions(self):
+        n = _build_network()
+        df = _outages(
+            [
+                {
+                    "asset_id": "NorNed",
+                    "component": "Link",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.0,
+                }
+            ]
+        )
+        apply_outage_schedule(n, df)
+        pmax = n.links_t.p_max_pu["NorNed"]
+        pmin = n.links_t.p_min_pu["NorNed"]
+        assert (pmax.iloc[6:12] == 0.0).all()
+        assert (pmin.iloc[6:12] == 0.0).all()  # reverse also zero
+        # Outside outage: reverse stays at static p_min_pu = -0.957
+        assert (pmin.iloc[:6] == -0.957).all()
+        assert (pmax.iloc[:6] == 1.0).all()
+
+    def test_link_partial_outage_clamps_reverse_to_factor(self):
+        """50% derate on NorNed: forward 0.5, reverse -0.5 (not -0.957)."""
+        n = _build_network()
+        df = _outages(
+            [
+                {
+                    "asset_id": "NorNed",
+                    "component": "Link",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.5,
+                }
+            ]
+        )
+        apply_outage_schedule(n, df)
+        pmax = n.links_t.p_max_pu["NorNed"]
+        pmin = n.links_t.p_min_pu["NorNed"]
+        assert (pmax.iloc[6:12] == 0.5).all()
+        assert np.allclose(pmin.iloc[6:12], -0.5)
+
+    def test_overlapping_rows_min_wins(self):
+        n = _build_network()
+        df = _outages(
+            [
+                {
+                    "asset_id": "Wind",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 18:00", tz="UTC"),
+                    "p_max_pu": 0.50,
+                },
+                {
+                    "asset_id": "Wind",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 10:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 14:00", tz="UTC"),
+                    "p_max_pu": 0.0,
+                },
+            ]
+        )
+        apply_outage_schedule(n, df)
+        s = n.generators_t.p_max_pu["Wind"]
+        assert (s.iloc[6:10] == 0.50).all()
+        assert (s.iloc[10:15] == 0.0).all()
+        assert (s.iloc[15:19] == 0.50).all()
+        assert (s.iloc[19:] == 1.0).all()
+
+    def test_unknown_asset_warns_by_default(self, caplog):
+        n = _build_network()
+        df = _outages(
+            [
+                {
+                    "asset_id": "DoesNotExist",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.0,
+                }
+            ]
+        )
+        counts = apply_outage_schedule(n, df)
+        assert counts == {"Generator": 0, "Link": 0}
+        assert any("not in network" in r.message for r in caplog.records)
+
+    def test_unknown_asset_raises_when_requested(self):
+        n = _build_network()
+        df = _outages(
+            [
+                {
+                    "asset_id": "DoesNotExist",
+                    "component": "Link",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.0,
+                }
+            ]
+        )
+        with pytest.raises(KeyError, match="not in network"):
+            apply_outage_schedule(n, df, on_unknown="raise")
+
+    def test_unknown_asset_silent_when_ignore(self, caplog):
+        n = _build_network()
+        df = _outages(
+            [
+                {
+                    "asset_id": "DoesNotExist",
+                    "component": "Link",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.0,
+                }
+            ]
+        )
+        with caplog.at_level("WARNING"):
+            apply_outage_schedule(n, df, on_unknown="ignore")
+        assert not any("not in network" in r.message for r in caplog.records)
+
+    def test_tz_aware_outage_on_tz_naive_snapshots(self):
+        """Snapshots tz-naive, outage tz-aware UTC — comparison must still hit."""
+        n = _build_network()
+        assert n.snapshots.tz is None
+        df = _outages(
+            [
+                {
+                    "asset_id": "Wind",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.25,
+                }
+            ]
+        )
+        apply_outage_schedule(n, df)
+        s = n.generators_t.p_max_pu["Wind"]
+        assert (s.iloc[6:12] == 0.25).all()
+
+    def test_returns_counts_per_component(self):
+        n = _build_network()
+        df = _outages(
+            [
+                {
+                    "asset_id": "Wind",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 00:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 02:00", tz="UTC"),
+                    "p_max_pu": 0.5,
+                },
+                {
+                    "asset_id": "NorNed",
+                    "component": "Link",
+                    "start": pd.Timestamp("2025-01-01 00:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 02:00", tz="UTC"),
+                    "p_max_pu": 0.5,
+                },
+            ]
+        )
+        counts = apply_outage_schedule(n, df)
+        assert counts == {"Generator": 1, "Link": 1}
+
+
+class TestBuildFactorSeriesPerAsset:
+    def test_empty(self):
+        snaps = pd.date_range("2025-01-01", periods=24, freq="h")
+        empty = pd.DataFrame(
+            columns=[
+                "asset_id",
+                "component",
+                "start",
+                "end",
+                "p_max_pu",
+            ]
+        )
+        assert build_factor_series_per_asset(empty, snaps) == {}
+
+    def test_filters_to_unity_only(self):
+        """Assets whose factor never dips below 1.0 are not returned."""
+        snaps = pd.date_range("2025-01-01", periods=24, freq="h")
+        df = pd.DataFrame(
+            [
+                {
+                    "asset_id": "A",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 1.0,
+                },  # no-op
+                {
+                    "asset_id": "B",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.5,
+                },
+            ]
+        )
+        out = build_factor_series_per_asset(df, snaps)
+        assert set(out) == {"B"}
+
+    def test_component_filter(self):
+        snaps = pd.date_range("2025-01-01", periods=24, freq="h")
+        df = pd.DataFrame(
+            [
+                {
+                    "asset_id": "G",
+                    "component": "Generator",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.5,
+                },
+                {
+                    "asset_id": "L",
+                    "component": "Link",
+                    "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                    "end": pd.Timestamp("2025-01-01 11:00", tz="UTC"),
+                    "p_max_pu": 0.5,
+                },
+            ]
+        )
+        gens = build_factor_series_per_asset(df, snaps, component="Generator")
+        links = build_factor_series_per_asset(df, snaps, component="Link")
+        assert set(gens) == {"G"}
+        assert set(links) == {"L"}


### PR DESCRIPTION
Closes #1688.

## Changes proposed in this Pull Request

Add `pypsa.apply_outage_schedule(n, outages, on_unknown='warn')`: a small helper that writes user-supplied outage windows onto a built network. Targets the validation/backcast use case where the user already knows which assets were down, when, and at what fractional availability, and wants those facts written into `n.generators_t.p_max_pu` and `n.links_t.p_max_pu` / `p_min_pu` before solving.

**Scope (intentionally small):**

- Generators receive `n.generators_t.p_max_pu *= factor`, composing with any existing CF profile.
- Links receive `n.links_t.p_max_pu = min(existing, factor)` plus a `p_min_pu_t` clamp that respects the static `p_min_pu` so asymmetric links (e.g. NorNed) cap their reverse direction symmetrically with the forward derate.
- Overlapping rows on the same asset collapse by `min(p_max_pu)` (worst outage wins).
- Outage timestamps may be tz-aware or tz-naive UTC; they are normalized to the snapshots' tz before comparison so the mask never silently evaluates all-False.
- `on_unknown ∈ {raise, warn, ignore}` controls behavior when an `asset_id` is missing from the network.

**Relation to #1576** (Maintenance optimization): orthogonal. #1576 lets the optimizer *decide* when to schedule maintenance; this helper *records* a schedule the user already has. No new optimization variables, no overlap, no shared code paths. Cross-reference added in docstring.

**Files touched:**

- `pypsa/_outage_schedule.py` (new) — implementation, ~240 LOC including docstrings.
- `pypsa/__init__.py` — re-export `apply_outage_schedule`.
- `test/test_apply_outage_schedule.py` (new) — 16 unit tests covering empty input, missing-column validation, generator full / partial outage, asymmetric link reverse-direction clamp, overlap min-wins, tz-aware-on-tz-naive snapshots, `on_unknown` behavior, CF composition, per-component counts.
- `docs/release-notes.md` — entry under Upcoming Release / Features.

**Out of scope** (happy to follow up if requested):

- `StorageUnit` outages (mechanical extension, no design questions).
- Network method `n.apply_outage_schedule(...)` (free function is easier to evolve; can promote later).
- Reading outages from a CSV format — left to the user/downstream, since column conventions vary by data source (REMIT, TSO).

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.

<details>
<summary>AI-assisted content (per AI-based-contributions policy)</summary>

Docstrings and the test suite were drafted with AI assistance and reviewed/trimmed by me before submission. The design, scope decisions, file layout, asymmetric-link semantics, and all judgment calls are mine. The implementation has been running in production in a downstream project (`psa_mee`) for validation backcasts before being lifted to this PR.

</details>
