### PR TITLE
fix(optimization): include static phase_shift in cycle KVL

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,7 +14,11 @@ SPDX-License-Identifier: CC-BY-4.0
     next update! If you would like to use these features in the meantime, you will need
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
 
+### Bug Fixes
+
 - Fix operational constraints for non-extendable components producing `NaN` bounds when `p_nom` is infinite and `p_min_pu`/`p_max_pu` is zero. The bound now falls back to zero in this case. Relevant for linopy versions `>=0.7` where `NaN` bounds are not dropped explicitly.
+
+- Include static `phase_shift` on [Transformer](./user-guide/components/transformers.md) components in the cycle-based Kirchhoff Voltage Law constraint in [`n.optimize()`][pypsa.Network.optimize]. Previously the phase shift term was silently dropped in LOPF (only [`n.lpf()`][pypsa.Network.lpf] and [`n.pf()`][pypsa.Network.pf] respected it), so optimisation results diverged from a subsequent non-linear power-flow verification. Fixes issue #1220.
 
 
 ## [**v1.2.1**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.1) <small>19th May 2026</small> { id="v1.2.1" }

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import linopy
+import numpy as np
 import pandas as pd
 import xarray as xr
 from linopy import merge
@@ -1225,8 +1226,10 @@ def define_kirchhoff_voltage_constraints(n: Network, sns: pd.Index) -> None:
     m = n.model
     n.calculate_dependent_values()
 
+    deg_to_rad = np.pi / 180.0
     periods = sns.unique("period") if n._multi_invest else [None]
-    lhs = []
+    lhs_parts = []
+    rhs_parts = []
     for period in periods:
         snapshots = sns if period is None else sns[sns.get_loc(period)]
         C = n.cycle_matrix(investment_period=period, apply_weights=True)
@@ -1241,11 +1244,39 @@ def define_kirchhoff_voltage_constraints(n: Network, sns: pd.Index) -> None:
                 name=C_branch.indexes["name"].difference(n.c[c].inactive_assets),
             )
             exprs.append(flow @ C_branch * 1e5)
-        lhs.append(sum(exprs))
+        lhs_parts.append(sum(exprs))
 
-    if lhs:
-        lhs = merge(lhs, dim="snapshot")
-        con = lhs == 0
+        # Static phase_shift on Transformer components enters the cycle KVL as
+        # a constant on the RHS: around each cycle k,
+        #     sum_l C_lk * (x_l * flow_l + phase_shift_l_rad) = 0
+        # The unweighted cycle matrix carries the cycle-direction sign.
+        # Previously this term was dropped in LOPF, so static phase shifts
+        # were silently ignored (only n.lpf()/n.pf() honoured them). Fixes #1220.
+        if "Transformer" in C.index.unique("type"):
+            trafos = n.c.Transformer.static
+            C_unw = n.cycle_matrix(investment_period=period, apply_weights=False)
+            C_trafos = C_unw.loc["Transformer"]
+            active = trafos.index[trafos["active"] & trafos.index.isin(C_trafos.index)]
+            ps_deg = trafos.loc[active, "phase_shift"].astype(float)
+            nonzero = active[ps_deg.values != 0.0]
+            if len(nonzero):
+                C_ps = DataArray(C_trafos.loc[nonzero])
+                ps_rad = DataArray(
+                    (ps_deg.loc[nonzero] * deg_to_rad).values,
+                    coords={"name": nonzero},
+                    dims=["name"],
+                )
+                rhs_parts.append(-(ps_rad @ C_ps) * 1e5)
+
+    if lhs_parts:
+        lhs = merge(lhs_parts, dim="snapshot")
+        if rhs_parts:
+            rhs = (
+                merge(rhs_parts, dim="snapshot") if len(rhs_parts) > 1 else rhs_parts[0]
+            )
+            con = lhs == rhs
+        else:
+            con = lhs == 0
         mask = con.rhs.notnull()
         m.add_constraints(con, name="Kirchhoff-Voltage-Law", mask=mask)
 

--- a/test/test_phase_shift_static_kvl.py
+++ b/test/test_phase_shift_static_kvl.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for static ``phase_shift`` in cycle-based KVL (issue #1220).
+
+Prior to the fix, ``n.optimize()`` silently dropped the static ``phase_shift``
+term from the cycle Kirchhoff Voltage Law constraint, so LOPF results diverged
+from a subsequent ``n.lpf()`` / ``n.pf()`` verification run.
+
+Physical setup
+--------------
+
+Two parallel branches between buses A and B (both at 380 kV):
+
+* Line L1 with ``x = 1444 ohm`` → per-unit ``x_pu = x / v_nom**2 = 0.01``.
+* Transformer T1 with ``x = 1.0``, ``s_nom = 100 MVA`` → ``x_pu = x / s_nom = 0.01``.
+
+PyPSA uses different bases for Line vs Transformer per-unit reactance (see
+``pypsa/network/power_flow.py``: ``x_pu_line = x / v_nom**2`` versus
+``x_pu_trafo = x / s_nom``). Matching the *numerical* ``x_pu`` is what makes
+the parallel branches split flow equally.
+
+Around the single cycle (L1 forward, T1 reversed):
+
+    x_pu * P_L - (x_pu * P_T + phi_rad) = 0
+
+so the flow imbalance is ``P_L - P_T = phi_rad / x_pu``. With 50 MW total
+flow A->B, the analytical split is::
+
+    P_L = 25 + 0.5 * phi_rad / x_pu
+    P_T = 25 - 0.5 * phi_rad / x_pu
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+import pypsa
+
+
+def _build(phase_shift_deg: float = 0.0) -> pypsa.Network:
+    """Two-bus parallel Line + Transformer, matching x_pu = 0.01."""
+    n = pypsa.Network()
+    n.set_snapshots(["t"])
+    n.add("Bus", "A", v_nom=380)
+    n.add("Bus", "B", v_nom=380)
+    n.add(
+        "Line",
+        "L1",
+        bus0="A",
+        bus1="B",
+        x=0.01 * 380**2,  # ohm  -> x_pu = 0.01
+        s_nom=200,
+    )
+    n.add(
+        "Transformer",
+        "T1",
+        bus0="A",
+        bus1="B",
+        x=1.0,  # per-unit on s_nom -> x_pu = 1.0 / 100 = 0.01
+        s_nom=100,
+        phase_shift=phase_shift_deg,
+    )
+    n.add("Generator", "G", bus="A", p_nom=100, marginal_cost=1.0)
+    n.add("Load", "D", bus="B", p_set=50)
+    return n
+
+
+def _flows(n: pypsa.Network) -> tuple[float, float]:
+    p_line = float(n.lines_t.p0["L1"].iloc[0])
+    p_trafo = float(n.transformers_t.p0["T1"].iloc[0])
+    return p_line, p_trafo
+
+
+def _solve(n: pypsa.Network) -> None:
+    status, _ = n.optimize(solver_name="highs")
+    assert status == "ok", f"solver returned {status!r}"
+
+
+@pytest.mark.parametrize("phi_deg", [0.0])
+def test_zero_phase_shift_splits_equally(phi_deg: float) -> None:
+    n = _build(phase_shift_deg=phi_deg)
+    _solve(n)
+    p_line, p_trafo = _flows(n)
+    assert p_line == pytest.approx(25.0, abs=1e-3)
+    assert p_trafo == pytest.approx(25.0, abs=1e-3)
+
+
+def test_positive_phase_shift_redistributes_flow() -> None:
+    phi_deg = 10.0
+    n = _build(phase_shift_deg=phi_deg)
+    _solve(n)
+    p_line, p_trafo = _flows(n)
+    delta = math.radians(phi_deg) / 0.01
+    assert p_line == pytest.approx(25.0 + 0.5 * delta, abs=1e-2)
+    assert p_trafo == pytest.approx(25.0 - 0.5 * delta, abs=1e-2)
+
+
+def test_negative_phase_shift_reverses_sign() -> None:
+    n_pos = _build(phase_shift_deg=+10.0)
+    n_neg = _build(phase_shift_deg=-10.0)
+    _solve(n_pos)
+    _solve(n_neg)
+    p_line_pos, p_trafo_pos = _flows(n_pos)
+    p_line_neg, p_trafo_neg = _flows(n_neg)
+    assert (p_line_pos - 25.0) == pytest.approx(-(p_line_neg - 25.0), abs=1e-2)
+    assert (p_trafo_pos - 25.0) == pytest.approx(-(p_trafo_neg - 25.0), abs=1e-2)
+
+
+def test_lopf_matches_nonlinear_pf() -> None:
+    """LOPF flow must match a subsequent n.pf() with the same phase shift."""
+    phi_deg = 5.0
+    n = _build(phase_shift_deg=phi_deg)
+    _solve(n)
+    p_line_lopf, p_trafo_lopf = _flows(n)
+
+    n.lpf()
+    p_line_lpf = float(n.lines_t.p0["L1"].iloc[0])
+    p_trafo_lpf = float(n.transformers_t.p0["T1"].iloc[0])
+
+    assert p_line_lopf == pytest.approx(p_line_lpf, abs=1e-2)
+    assert p_trafo_lopf == pytest.approx(p_trafo_lpf, abs=1e-2)


### PR DESCRIPTION
Closes #1220.

## Changes proposed in this Pull Request

Static `phase_shift` on `Transformer` components is now included in the cycle-based Kirchhoff Voltage Law constraint built by `n.optimize()`. Before this fix the term was silently dropped in LOPF, so an `n.optimize()` solution and a subsequent `n.lpf()` / `n.pf()` verification on the same network gave different flows whenever any transformer had a non-zero `phase_shift`. `n.lpf()` and `n.pf()` already handled the term correctly; this just brings LOPF into line with them.

The cycle KVL around each cycle `k` becomes

    sum_l C_{l,k} * (x_pu_l * P_l + phi_l_rad) = 0

where `phi_l` is zero for lines and for transformers without a phase shift. Static phase shifts contribute a constant on the RHS via the unweighted cycle matrix, so the existing weighted-cycle LHS code is untouched. No new attributes, no new variables.

## Tests

Four new cases in `test/test_phase_shift_static_kvl.py` on a 2-bus / parallel-path network with equal per-unit reactance:

- Zero phase shift → equal 50/50 split (regression guard for the unaffected path).
- +10° → flow split matches the analytical value `P_L - P_T = phi_rad / x_pu`.
- −10° → exact mirror of the +10° case (sign symmetry).
- LOPF flows match a subsequent `n.lpf()` on the same network (the bug this PR fixes).

## Checklist

- [x] Code changes are sufficiently documented; new code has docstring + inline comment explaining the cycle-direction sign.
- [x] Unit tests for new features were added.
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me.
- [x] I consent to the release of this PR's code under the MIT license.

## Note on PR #1661

The variable / extendable phase-shift feature from PR #1661 (issue #456) is being reworked separately into Option B (`phase_shift_{min,max,set}` writing back into `phase_shift`, no `_extendable` flag) per @fneum's review. This bugfix is split out so it can land on its own merits.
