### PR TITLE
feat: add apply_outage_schedule helper (refs #1696)

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,12 @@ SPDX-License-Identifier: CC-BY-4.0
     next update! If you would like to use these features in the meantime, you will need
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
 
+### Features
+
+- New helper [`pypsa.apply_outage_schedule`][pypsa.utils.apply_outage_schedule] writes exogenous outage windows (e.g. ENTSO-E unavailability reports, planned maintenance records, validation replays) onto a network by composing a derate factor into `generators_t.p_max_pu` and `links_t.p_max_pu`/`p_min_pu`. Overlapping windows on the same asset collapse by `min(p_max_pu)`. Orthogonal to the maintenance-optimization work in #1576 (deterministic schedule vs. MILP variables).
+
+### Bug Fixes
+
 - Fix operational constraints for non-extendable components producing `NaN` bounds when `p_nom` is infinite and `p_min_pu`/`p_max_pu` is zero. The bound now falls back to zero in this case. Relevant for linopy versions `>=0.7` where `NaN` bounds are not dropped explicitly.
 
 

--- a/pypsa/__init__.py
+++ b/pypsa/__init__.py
@@ -29,6 +29,7 @@ from pypsa import (
     optimization,
     plot,
     statistics,
+    utils,
 )
 from pypsa._options import (
     option_context,
@@ -37,6 +38,7 @@ from pypsa._options import (
 from pypsa.collection import NetworkCollection
 from pypsa.components.components import Components
 from pypsa.networks import Network, SubNetwork
+from pypsa.utils import apply_outage_schedule
 from pypsa.version import (
     __version__,
     __version_base__,
@@ -77,6 +79,8 @@ __all__ = [
     "NetworkCollection",
     "SubNetwork",
     "Components",
+    "utils",
+    "apply_outage_schedule",
 ]
 
 

--- a/pypsa/utils/__init__.py
+++ b/pypsa/utils/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""User-facing utility helpers that don't belong in core component logic."""
+
+from pypsa.utils.outage_schedule import apply_outage_schedule
+
+__all__ = [
+    "apply_outage_schedule",
+]

--- a/pypsa/utils/outage_schedule.py
+++ b/pypsa/utils/outage_schedule.py
@@ -288,10 +288,7 @@ def apply_outage_schedule(
     if unknown:
         preview = unknown[:5]
         ellipsis = "..." if len(unknown) > 5 else ""
-        msg = (
-            f"{len(unknown)} outage asset_id(s) not in network: "
-            f"{preview}{ellipsis}"
-        )
+        msg = f"{len(unknown)} outage asset_id(s) not in network: {preview}{ellipsis}"
         if on_unknown == "raise":
             raise KeyError(msg)
         if on_unknown == "warn":

--- a/pypsa/utils/outage_schedule.py
+++ b/pypsa/utils/outage_schedule.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Exogenous outage-schedule helper.
+
+Writes user-supplied outage windows onto a built PyPSA network by setting
+time-varying ``p_max_pu`` (and ``p_min_pu`` for asymmetric Links). The
+helper is policy-light: the caller decides which windows apply; PyPSA
+broadcasts them onto the snapshot index and composes multiplicatively with
+any existing dynamic availability.
+
+This is **deterministic** scheduling of known outage windows (planned
+maintenance records, ENTSO-E unavailability reports, post-mortem
+reconstruction for validation runs). It is intentionally orthogonal to
+PR #1576 ("Maintenance optimization"), which co-optimises maintenance
+windows as MILP variables.
+
+Schema for the ``outages`` DataFrame
+------------------------------------
+Required columns:
+
+- ``asset_id``: index entry in ``n.generators`` or ``n.links``
+- ``component``: ``'Generator'`` or ``'Link'``
+- ``start``: ``pd.Timestamp`` (tz-aware or tz-naive UTC)
+- ``end``: ``pd.Timestamp`` (same tz convention as ``start``)
+- ``p_max_pu``: float in ``[0, 1]``, fractional availability inside the
+  window
+
+Overlapping rows on the same asset collapse by ``min(p_max_pu)`` per
+snapshot (worst outage wins). The factor composes multiplicatively with
+any existing ``p_max_pu_t`` profile, so a generator at CF 0.30 during a
+0.50 derate becomes 0.15.
+
+See Also
+--------
+PyPSA GH #1576 for the maintenance-optimization PR (orthogonal).
+
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from pypsa.networks import Network
+
+logger = logging.getLogger(__name__)
+
+OnUnknown = Literal["raise", "warn", "ignore"]
+
+_REQUIRED_COLUMNS = ("asset_id", "component", "start", "end", "p_max_pu")
+_SUPPORTED_COMPONENTS = ("Generator", "Link")
+
+
+def _build_factor_series(
+    rows: pd.DataFrame,
+    snapshots: pd.DatetimeIndex,
+) -> pd.Series:
+    """Collapse outage rows for one asset into a per-snapshot factor series.
+
+    Overlapping rows take the minimum factor (worst outage wins). Outage
+    bounds may be tz-aware or tz-naive; they are normalized to the
+    snapshots' tz-awareness before comparison so the mask never silently
+    evaluates all-False.
+
+    Parameters
+    ----------
+    rows : pd.DataFrame
+        Outage rows with columns ``start``, ``end``, ``p_max_pu``.
+    snapshots : pd.DatetimeIndex
+        Network snapshots.
+
+    Returns
+    -------
+    pd.Series
+        Factor series indexed by ``snapshots``, dtype ``float``,
+        initialised at ``1.0``.
+
+    """
+    factor = pd.Series(1.0, index=snapshots, dtype=float)
+    tz_naive_snapshots = snapshots.tz is None
+    for _, row in rows.iterrows():
+        start = row["start"]
+        end = row["end"]
+        start_tz = getattr(start, "tz", None)
+        if tz_naive_snapshots and start_tz is not None:
+            start = start.tz_convert("UTC").tz_localize(None)
+            end = end.tz_convert("UTC").tz_localize(None)
+        elif not tz_naive_snapshots and start_tz is None:
+            start = pd.Timestamp(start, tz="UTC")
+            end = pd.Timestamp(end, tz="UTC")
+        mask = (snapshots >= start) & (snapshots <= end)
+        if not mask.any():
+            continue
+        p = float(row["p_max_pu"])
+        if not (0.0 <= p <= 1.0):
+            asset = row.get("asset_id", "?")
+            msg = f"p_max_pu must be in [0, 1]; got {p} for asset_id={asset}"
+            raise ValueError(msg)
+        factor.loc[mask] = np.minimum(factor.loc[mask].values, p)
+    return factor
+
+
+def build_factor_series_per_asset(
+    outages: pd.DataFrame,
+    snapshots: pd.DatetimeIndex,
+    component: str | None = None,
+) -> dict[str, pd.Series]:
+    """Return a per-asset factor series for every asset that has an outage.
+
+    Parameters
+    ----------
+    outages : pd.DataFrame
+        Outage rows; must contain ``asset_id``, ``start``, ``end``,
+        ``p_max_pu``, and (if ``component`` is ``None``) ``component``.
+    snapshots : pd.DatetimeIndex
+        Network snapshots.
+    component : {'Generator', 'Link', None}
+        If given, filter ``outages`` to that component before collapsing.
+
+    Returns
+    -------
+    dict[str, pd.Series]
+        Only assets whose factor dips below ``1.0`` anywhere are returned.
+
+    """
+    if outages.empty:
+        return {}
+    df = outages
+    if component is not None and "component" in df.columns:
+        df = df[df["component"] == component]
+    if df.empty:
+        return {}
+    out: dict[str, pd.Series] = {}
+    for asset_id, rows in df.groupby("asset_id"):
+        factor = _build_factor_series(rows, snapshots)
+        if (factor < 1.0).any():
+            out[str(asset_id)] = factor
+    return out
+
+
+def _apply_link_factor(n: Network, link_id: str, factor: pd.Series) -> None:
+    """Write an outage factor to a Link, respecting asymmetric capacity.
+
+    The same factor applies in both directions: forward goes into
+    ``links_t.p_max_pu``; reverse is encoded as ``links_t.p_min_pu`` and
+    clamped so reverse availability is never more permissive than the
+    static ``links.p_min_pu``.
+    """
+    static_p_min_pu = float(n.links.at[link_id, "p_min_pu"])
+
+    pmax = n.links_t.p_max_pu
+    if link_id in pmax.columns:
+        existing = pmax[link_id].reindex(factor.index).fillna(1.0)
+        pmax[link_id] = np.minimum(existing.values, factor.values)
+    else:
+        pmax[link_id] = factor.values
+
+    reverse_cap = -factor
+    reverse_series = reverse_cap.clip(lower=static_p_min_pu)
+
+    pmin = n.links_t.p_min_pu
+    if link_id in pmin.columns:
+        existing = pmin[link_id].reindex(factor.index).fillna(static_p_min_pu)
+        pmin[link_id] = np.maximum(existing.values, reverse_series.values)
+    else:
+        pmin[link_id] = reverse_series.values
+
+
+def _apply_generator_factor(n: Network, gen_id: str, factor: pd.Series) -> None:
+    """Multiply outage factor into ``generators_t.p_max_pu``.
+
+    Composes with any existing time-varying availability so a renewable
+    generator's capacity-factor profile is preserved underneath the
+    derate.
+    """
+    pmax = n.generators_t.p_max_pu
+    if gen_id in pmax.columns:
+        existing = pmax[gen_id].reindex(factor.index).fillna(1.0)
+        pmax[gen_id] = (existing.values * factor.values).clip(0.0, 1.0)
+    else:
+        pmax[gen_id] = factor.values
+
+
+def apply_outage_schedule(
+    n: Network,
+    outages: pd.DataFrame,
+    on_unknown: OnUnknown = "warn",
+) -> dict[str, int]:
+    """Write exogenous outage windows onto a built network.
+
+    Generators receive ``n.generators_t.p_max_pu *= factor``; Links
+    receive ``n.links_t.p_max_pu = min(existing, factor)`` plus a clamped
+    ``n.links_t.p_min_pu`` for the reverse direction. Overlapping rows on
+    the same asset collapse by ``min(p_max_pu)``.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Network with snapshots already set.
+    outages : pd.DataFrame
+        Outage rows; required columns: ``asset_id``, ``component``,
+        ``start``, ``end``, ``p_max_pu``. ``component`` must be
+        ``'Generator'`` or ``'Link'``.
+    on_unknown : {'raise', 'warn', 'ignore'}
+        Behaviour when an ``asset_id`` is not in the network's component
+        index. Default ``'warn'``.
+
+    Returns
+    -------
+    dict[str, int]
+        ``{'Generator': n_modified, 'Link': n_modified}``.
+
+    Raises
+    ------
+    ValueError
+        If ``outages`` is missing required columns, ``component`` is
+        unsupported, ``p_max_pu`` is outside ``[0, 1]``, or
+        ``n.snapshots`` is empty.
+    KeyError
+        If ``on_unknown == 'raise'`` and any ``asset_id`` is unknown.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import pypsa
+    >>> n = pypsa.Network()
+    >>> n.set_snapshots(pd.date_range("2025-01-01", periods=24, freq="h"))
+    >>> _ = n.add("Bus", "b")
+    >>> _ = n.add("Generator", "g", bus="b", p_nom=100)
+    >>> outages = pd.DataFrame({
+    ...     "asset_id": ["g"],
+    ...     "component": ["Generator"],
+    ...     "start": [pd.Timestamp("2025-01-01 06:00")],
+    ...     "end": [pd.Timestamp("2025-01-01 12:00")],
+    ...     "p_max_pu": [0.0],
+    ... })
+    >>> _ = pypsa.utils.apply_outage_schedule(n, outages)
+    >>> bool(n.generators_t.p_max_pu["g"].loc["2025-01-01 09:00"] == 0.0)
+    True
+
+    """
+    counts: dict[str, int] = {"Generator": 0, "Link": 0}
+    if not isinstance(n.snapshots, pd.DatetimeIndex):
+        msg = "n.snapshots must be a DatetimeIndex; call n.set_snapshots(...) first"
+        raise TypeError(msg)
+
+    if outages.empty:
+        return counts
+
+    missing = set(_REQUIRED_COLUMNS) - set(outages.columns)
+    if missing:
+        msg = f"outages is missing required columns: {sorted(missing)}"
+        raise ValueError(msg)
+
+    bad = ~outages["component"].isin(_SUPPORTED_COMPONENTS)
+    if bad.any():
+        unsupported = sorted(outages.loc[bad, "component"].unique().tolist())
+        msg = (
+            f"unsupported component(s) in outages: {unsupported}; "
+            f"expected one of {list(_SUPPORTED_COMPONENTS)}"
+        )
+        raise ValueError(msg)
+
+    snapshots = n.snapshots
+    unknown: list[str] = []
+
+    for component, group in outages.groupby("component"):
+        if component == "Generator":
+            index = n.generators.index
+            apply_fn = _apply_generator_factor
+        else:  # 'Link'
+            index = n.links.index
+            apply_fn = _apply_link_factor
+        id_to_factor = build_factor_series_per_asset(group, snapshots)
+        for asset_id, factor in id_to_factor.items():
+            if asset_id not in index:
+                unknown.append(f"{component}:{asset_id}")
+                continue
+            apply_fn(n, asset_id, factor)
+            counts[component] += 1
+
+    if unknown:
+        preview = unknown[:5]
+        ellipsis = "..." if len(unknown) > 5 else ""
+        msg = (
+            f"{len(unknown)} outage asset_id(s) not in network: "
+            f"{preview}{ellipsis}"
+        )
+        if on_unknown == "raise":
+            raise KeyError(msg)
+        if on_unknown == "warn":
+            logger.warning(msg)
+    return counts

--- a/test/test_outage_schedule.py
+++ b/test/test_outage_schedule.py
@@ -60,9 +60,11 @@ def test_re_exported_from_top_level() -> None:
 def test_generator_full_outage_zeros_window() -> None:
     """A `p_max_pu=0` outage zeroes only the masked snapshots."""
     n = _two_bus_network()
-    outages = pd.DataFrame([
-        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
+        ]
+    )
 
     counts = apply_outage_schedule(n, outages)
 
@@ -82,27 +84,43 @@ def test_generator_partial_derate_composes_multiplicatively() -> None:
     )
     n.generators_t.p_max_pu["g0"] = profile
 
-    outages = pd.DataFrame([
-        _outage_row("g0", "Generator", "2025-01-01 02:00", "2025-01-01 05:00", 0.5),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row("g0", "Generator", "2025-01-01 02:00", "2025-01-01 05:00", 0.5),
+        ]
+    )
     apply_outage_schedule(n, outages)
 
     series = n.generators_t.p_max_pu["g0"]
     # In-window: existing * 0.5
-    assert series.loc["2025-01-01 02:00"] == pytest.approx(profile.loc["2025-01-01 02:00"] * 0.5)
-    assert series.loc["2025-01-01 04:00"] == pytest.approx(profile.loc["2025-01-01 04:00"] * 0.5)
+    assert series.loc["2025-01-01 02:00"] == pytest.approx(
+        profile.loc["2025-01-01 02:00"] * 0.5
+    )
+    assert series.loc["2025-01-01 04:00"] == pytest.approx(
+        profile.loc["2025-01-01 04:00"] * 0.5
+    )
     # Out-of-window: untouched
-    assert series.loc["2025-01-01 06:00"] == pytest.approx(profile.loc["2025-01-01 06:00"])
-    assert series.loc["2025-01-01 01:00"] == pytest.approx(profile.loc["2025-01-01 01:00"])
+    assert series.loc["2025-01-01 06:00"] == pytest.approx(
+        profile.loc["2025-01-01 06:00"]
+    )
+    assert series.loc["2025-01-01 01:00"] == pytest.approx(
+        profile.loc["2025-01-01 01:00"]
+    )
 
 
 def test_overlapping_outages_collapse_to_minimum() -> None:
     """Two overlapping windows on the same asset take the worse derate."""
     n = _two_bus_network()
-    outages = pd.DataFrame([
-        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.50),
-        _outage_row("g0", "Generator", "2025-01-01 09:00", "2025-01-01 15:00", 0.20),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row(
+                "g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.50
+            ),
+            _outage_row(
+                "g0", "Generator", "2025-01-01 09:00", "2025-01-01 15:00", 0.20
+            ),
+        ]
+    )
     apply_outage_schedule(n, outages)
 
     series = n.generators_t.p_max_pu["g0"]
@@ -118,9 +136,11 @@ def test_link_outage_clamps_reverse_to_static_p_min_pu() -> None:
     """Link p_min_pu is clamped to the static lower bound (e.g. asymmetric HVDC)."""
     # Real-world example: NorNed has static p_min_pu = -0.957
     n = _two_bus_network(p_min_pu_link=-0.957)
-    outages = pd.DataFrame([
-        _outage_row("l0", "Link", "2025-01-01 00:00", "2025-01-01 23:00", 0.30),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row("l0", "Link", "2025-01-01 00:00", "2025-01-01 23:00", 0.30),
+        ]
+    )
     counts = apply_outage_schedule(n, outages)
 
     assert counts == {"Generator": 0, "Link": 1}
@@ -137,10 +157,12 @@ def test_link_outage_clamps_reverse_to_static_p_min_pu() -> None:
 def test_link_reverse_does_not_exceed_static_floor() -> None:
     """Reverse availability never gets *worse* than the static p_min_pu."""
     n = _two_bus_network(p_min_pu_link=-0.5)
-    outages = pd.DataFrame([
-        # Outage factor 0.9 -> reverse would be -0.9, clamped to -0.5
-        _outage_row("l0", "Link", "2025-01-01 00:00", "2025-01-01 12:00", 0.9),
-    ])
+    outages = pd.DataFrame(
+        [
+            # Outage factor 0.9 -> reverse would be -0.9, clamped to -0.5
+            _outage_row("l0", "Link", "2025-01-01 00:00", "2025-01-01 12:00", 0.9),
+        ]
+    )
     apply_outage_schedule(n, outages)
 
     pmin = n.links_t.p_min_pu["l0"].loc["2025-01-01 06:00"]
@@ -150,9 +172,13 @@ def test_link_reverse_does_not_exceed_static_floor() -> None:
 def test_unknown_asset_raises_when_requested() -> None:
     """`on_unknown='raise'` surfaces typos in `asset_id` immediately."""
     n = _two_bus_network()
-    outages = pd.DataFrame([
-        _outage_row("g_missing", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row(
+                "g_missing", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0
+            ),
+        ]
+    )
     with pytest.raises(KeyError, match="not in network"):
         apply_outage_schedule(n, outages, on_unknown="raise")
 
@@ -160,10 +186,14 @@ def test_unknown_asset_raises_when_requested() -> None:
 def test_unknown_asset_ignored_when_requested() -> None:
     """`on_unknown='ignore'` keeps the network untouched, no warning."""
     n = _two_bus_network()
-    outages = pd.DataFrame([
-        _outage_row("g_missing", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
-        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row(
+                "g_missing", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0
+            ),
+            _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
+        ]
+    )
     counts = apply_outage_schedule(n, outages, on_unknown="ignore")
     assert counts["Generator"] == 1
 
@@ -171,11 +201,13 @@ def test_unknown_asset_ignored_when_requested() -> None:
 def test_missing_required_columns_raises() -> None:
     """Schema validation rejects DataFrames missing any of the required columns."""
     n = _two_bus_network()
-    bad = pd.DataFrame({
-        "asset_id": ["g0"],
-        "component": ["Generator"],
-        # missing: start, end, p_max_pu
-    })
+    bad = pd.DataFrame(
+        {
+            "asset_id": ["g0"],
+            "component": ["Generator"],
+            # missing: start, end, p_max_pu
+        }
+    )
     with pytest.raises(ValueError, match="missing required columns"):
         apply_outage_schedule(n, bad)
 
@@ -183,9 +215,13 @@ def test_missing_required_columns_raises() -> None:
 def test_unsupported_component_raises() -> None:
     """Only Generator and Link are supported (e.g. Lines/Buses are out of scope)."""
     n = _two_bus_network()
-    outages = pd.DataFrame([
-        _outage_row("anything", "Store", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row(
+                "anything", "Store", "2025-01-01 06:00", "2025-01-01 12:00", 0.0
+            ),
+        ]
+    )
     with pytest.raises(ValueError, match="unsupported component"):
         apply_outage_schedule(n, outages)
 
@@ -193,9 +229,11 @@ def test_unsupported_component_raises() -> None:
 def test_p_max_pu_outside_unit_interval_raises() -> None:
     """`p_max_pu > 1` or `< 0` is rejected with a clear error."""
     n = _two_bus_network()
-    bad = pd.DataFrame([
-        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 1.5),
-    ])
+    bad = pd.DataFrame(
+        [
+            _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 1.5),
+        ]
+    )
     with pytest.raises(ValueError, match=r"p_max_pu must be in \[0, 1\]"):
         apply_outage_schedule(n, bad)
 
@@ -205,9 +243,11 @@ def test_non_datetime_snapshots_raises() -> None:
     n = pypsa.Network()
     n.add("Bus", "b0")
     n.add("Generator", "g0", bus="b0", p_nom=100)
-    outages = pd.DataFrame([
-        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
+        ]
+    )
     with pytest.raises(TypeError, match="DatetimeIndex"):
         apply_outage_schedule(n, outages)
 
@@ -215,8 +255,13 @@ def test_non_datetime_snapshots_raises() -> None:
 def test_empty_outages_is_noop() -> None:
     """Empty DataFrame returns zero counts and leaves the network untouched."""
     n = _two_bus_network()
-    counts = apply_outage_schedule(n, pd.DataFrame(columns=list(_build_factor_series.__defaults__ or [])
-                                                 + ["asset_id", "component", "start", "end", "p_max_pu"]))
+    counts = apply_outage_schedule(
+        n,
+        pd.DataFrame(
+            columns=list(_build_factor_series.__defaults__ or [])
+            + ["asset_id", "component", "start", "end", "p_max_pu"]
+        ),
+    )
     assert counts == {"Generator": 0, "Link": 0}
     # No dynamic columns added
     assert "g0" not in n.generators_t.p_max_pu.columns
@@ -226,15 +271,17 @@ def test_empty_outages_is_noop() -> None:
 def test_tz_aware_outage_on_tz_naive_snapshots_aligns_correctly() -> None:
     """A tz-aware outage window applies correctly to tz-naive snapshots (UTC convention)."""
     n = _two_bus_network()
-    outages = pd.DataFrame([
-        {
-            "asset_id": "g0",
-            "component": "Generator",
-            "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
-            "end": pd.Timestamp("2025-01-01 12:00", tz="UTC"),
-            "p_max_pu": 0.0,
-        },
-    ])
+    outages = pd.DataFrame(
+        [
+            {
+                "asset_id": "g0",
+                "component": "Generator",
+                "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+                "end": pd.Timestamp("2025-01-01 12:00", tz="UTC"),
+                "p_max_pu": 0.0,
+            },
+        ]
+    )
     apply_outage_schedule(n, outages)
     series = n.generators_t.p_max_pu["g0"]
     assert (series.loc["2025-01-01 06:00":"2025-01-01 12:00"] == 0.0).all()
@@ -243,11 +290,13 @@ def test_tz_aware_outage_on_tz_naive_snapshots_aligns_correctly() -> None:
 def test_build_factor_series_per_asset_skips_unaffected_assets() -> None:
     """Per-asset factor builder only returns assets whose factor dips below 1."""
     snapshots = pd.date_range("2025-01-01", periods=24, freq="h")
-    outages = pd.DataFrame([
-        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.5),
-        # Window entirely outside snapshots
-        _outage_row("g1", "Generator", "2024-12-30 00:00", "2024-12-30 06:00", 0.0),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.5),
+            # Window entirely outside snapshots
+            _outage_row("g1", "Generator", "2024-12-30 00:00", "2024-12-30 06:00", 0.0),
+        ]
+    )
     result = build_factor_series_per_asset(outages, snapshots, component="Generator")
     assert set(result.keys()) == {"g0"}
 
@@ -256,9 +305,11 @@ def test_partial_overlap_with_snapshots_only_writes_intersection() -> None:
     """Outage extending past snapshot range writes only the overlapping portion."""
     snapshots = pd.date_range("2025-01-01", periods=12, freq="h")
     n = _two_bus_network(snapshots=snapshots)
-    outages = pd.DataFrame([
-        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-02 18:00", 0.0),
-    ])
+    outages = pd.DataFrame(
+        [
+            _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-02 18:00", 0.0),
+        ]
+    )
     apply_outage_schedule(n, outages)
     series = n.generators_t.p_max_pu["g0"]
     assert (series.loc["2025-01-01 06:00":"2025-01-01 11:00"] == 0.0).all()

--- a/test/test_outage_schedule.py
+++ b/test/test_outage_schedule.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for ``pypsa.utils.apply_outage_schedule``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pypsa
+from pypsa.utils.outage_schedule import (
+    _build_factor_series,
+    apply_outage_schedule,
+    build_factor_series_per_asset,
+)
+
+
+def _two_bus_network(
+    snapshots: pd.DatetimeIndex | None = None,
+    *,
+    p_min_pu_link: float = -1.0,
+) -> pypsa.Network:
+    if snapshots is None:
+        snapshots = pd.date_range("2025-01-01", periods=48, freq="h")
+    n = pypsa.Network()
+    n.set_snapshots(snapshots)
+    n.add("Bus", "b0")
+    n.add("Bus", "b1")
+    n.add("Generator", "g0", bus="b0", p_nom=100.0)
+    n.add("Generator", "g1", bus="b1", p_nom=50.0)
+    n.add("Link", "l0", bus0="b0", bus1="b1", p_nom=200.0, p_min_pu=p_min_pu_link)
+    return n
+
+
+def _outage_row(
+    asset_id: str,
+    component: str,
+    start: str,
+    end: str,
+    p_max_pu: float,
+) -> dict[str, object]:
+    return {
+        "asset_id": asset_id,
+        "component": component,
+        "start": pd.Timestamp(start),
+        "end": pd.Timestamp(end),
+        "p_max_pu": p_max_pu,
+    }
+
+
+def test_re_exported_from_top_level() -> None:
+    """`pypsa.apply_outage_schedule` is the public entry point."""
+    assert pypsa.apply_outage_schedule is apply_outage_schedule
+    assert "apply_outage_schedule" in pypsa.utils.__all__
+
+
+def test_generator_full_outage_zeros_window() -> None:
+    """A `p_max_pu=0` outage zeroes only the masked snapshots."""
+    n = _two_bus_network()
+    outages = pd.DataFrame([
+        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
+    ])
+
+    counts = apply_outage_schedule(n, outages)
+
+    assert counts == {"Generator": 1, "Link": 0}
+    series = n.generators_t.p_max_pu["g0"]
+    assert (series.loc["2025-01-01 06:00":"2025-01-01 12:00"] == 0.0).all()
+    assert (series.loc["2025-01-01 13:00":] == 1.0).all()
+
+
+def test_generator_partial_derate_composes_multiplicatively() -> None:
+    """Outage factor multiplies existing dynamic `p_max_pu` (capacity factor)."""
+    n = _two_bus_network()
+    # Pre-existing CF profile: ramp 0.0 -> 0.5 -> 1.0 -> 0.5 -> ...
+    profile = pd.Series(
+        np.tile([0.0, 0.5, 1.0, 0.5], len(n.snapshots) // 4),
+        index=n.snapshots,
+    )
+    n.generators_t.p_max_pu["g0"] = profile
+
+    outages = pd.DataFrame([
+        _outage_row("g0", "Generator", "2025-01-01 02:00", "2025-01-01 05:00", 0.5),
+    ])
+    apply_outage_schedule(n, outages)
+
+    series = n.generators_t.p_max_pu["g0"]
+    # In-window: existing * 0.5
+    assert series.loc["2025-01-01 02:00"] == pytest.approx(profile.loc["2025-01-01 02:00"] * 0.5)
+    assert series.loc["2025-01-01 04:00"] == pytest.approx(profile.loc["2025-01-01 04:00"] * 0.5)
+    # Out-of-window: untouched
+    assert series.loc["2025-01-01 06:00"] == pytest.approx(profile.loc["2025-01-01 06:00"])
+    assert series.loc["2025-01-01 01:00"] == pytest.approx(profile.loc["2025-01-01 01:00"])
+
+
+def test_overlapping_outages_collapse_to_minimum() -> None:
+    """Two overlapping windows on the same asset take the worse derate."""
+    n = _two_bus_network()
+    outages = pd.DataFrame([
+        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.50),
+        _outage_row("g0", "Generator", "2025-01-01 09:00", "2025-01-01 15:00", 0.20),
+    ])
+    apply_outage_schedule(n, outages)
+
+    series = n.generators_t.p_max_pu["g0"]
+    # 06-08: only the 0.50 window
+    assert series.loc["2025-01-01 06:00":"2025-01-01 08:00"].eq(0.50).all()
+    # 09-12: overlap -> min(0.50, 0.20) = 0.20
+    assert series.loc["2025-01-01 09:00":"2025-01-01 12:00"].eq(0.20).all()
+    # 13-15: only the 0.20 window
+    assert series.loc["2025-01-01 13:00":"2025-01-01 15:00"].eq(0.20).all()
+
+
+def test_link_outage_clamps_reverse_to_static_p_min_pu() -> None:
+    """Link p_min_pu is clamped to the static lower bound (e.g. asymmetric HVDC)."""
+    # Real-world example: NorNed has static p_min_pu = -0.957
+    n = _two_bus_network(p_min_pu_link=-0.957)
+    outages = pd.DataFrame([
+        _outage_row("l0", "Link", "2025-01-01 00:00", "2025-01-01 23:00", 0.30),
+    ])
+    counts = apply_outage_schedule(n, outages)
+
+    assert counts == {"Generator": 0, "Link": 1}
+    # Forward: derated to 0.30
+    pmax = n.links_t.p_max_pu["l0"]
+    assert pmax.loc["2025-01-01 12:00"] == pytest.approx(0.30)
+    # Reverse: -0.30 would be more permissive than -0.957, so it's the binding cap
+    pmin = n.links_t.p_min_pu["l0"]
+    assert pmin.loc["2025-01-01 12:00"] == pytest.approx(-0.30)
+    # Out-of-window: untouched (pmin series only spans outage rows)
+    assert pmax.loc["2025-01-02 00:00"] == pytest.approx(1.0)
+
+
+def test_link_reverse_does_not_exceed_static_floor() -> None:
+    """Reverse availability never gets *worse* than the static p_min_pu."""
+    n = _two_bus_network(p_min_pu_link=-0.5)
+    outages = pd.DataFrame([
+        # Outage factor 0.9 -> reverse would be -0.9, clamped to -0.5
+        _outage_row("l0", "Link", "2025-01-01 00:00", "2025-01-01 12:00", 0.9),
+    ])
+    apply_outage_schedule(n, outages)
+
+    pmin = n.links_t.p_min_pu["l0"].loc["2025-01-01 06:00"]
+    assert pmin == pytest.approx(-0.5)
+
+
+def test_unknown_asset_raises_when_requested() -> None:
+    """`on_unknown='raise'` surfaces typos in `asset_id` immediately."""
+    n = _two_bus_network()
+    outages = pd.DataFrame([
+        _outage_row("g_missing", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
+    ])
+    with pytest.raises(KeyError, match="not in network"):
+        apply_outage_schedule(n, outages, on_unknown="raise")
+
+
+def test_unknown_asset_ignored_when_requested() -> None:
+    """`on_unknown='ignore'` keeps the network untouched, no warning."""
+    n = _two_bus_network()
+    outages = pd.DataFrame([
+        _outage_row("g_missing", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
+        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
+    ])
+    counts = apply_outage_schedule(n, outages, on_unknown="ignore")
+    assert counts["Generator"] == 1
+
+
+def test_missing_required_columns_raises() -> None:
+    """Schema validation rejects DataFrames missing any of the required columns."""
+    n = _two_bus_network()
+    bad = pd.DataFrame({
+        "asset_id": ["g0"],
+        "component": ["Generator"],
+        # missing: start, end, p_max_pu
+    })
+    with pytest.raises(ValueError, match="missing required columns"):
+        apply_outage_schedule(n, bad)
+
+
+def test_unsupported_component_raises() -> None:
+    """Only Generator and Link are supported (e.g. Lines/Buses are out of scope)."""
+    n = _two_bus_network()
+    outages = pd.DataFrame([
+        _outage_row("anything", "Store", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
+    ])
+    with pytest.raises(ValueError, match="unsupported component"):
+        apply_outage_schedule(n, outages)
+
+
+def test_p_max_pu_outside_unit_interval_raises() -> None:
+    """`p_max_pu > 1` or `< 0` is rejected with a clear error."""
+    n = _two_bus_network()
+    bad = pd.DataFrame([
+        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 1.5),
+    ])
+    with pytest.raises(ValueError, match=r"p_max_pu must be in \[0, 1\]"):
+        apply_outage_schedule(n, bad)
+
+
+def test_non_datetime_snapshots_raises() -> None:
+    """Snapshots must be a DatetimeIndex; the default `Index(['now'])` is rejected."""
+    n = pypsa.Network()
+    n.add("Bus", "b0")
+    n.add("Generator", "g0", bus="b0", p_nom=100)
+    outages = pd.DataFrame([
+        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.0),
+    ])
+    with pytest.raises(TypeError, match="DatetimeIndex"):
+        apply_outage_schedule(n, outages)
+
+
+def test_empty_outages_is_noop() -> None:
+    """Empty DataFrame returns zero counts and leaves the network untouched."""
+    n = _two_bus_network()
+    counts = apply_outage_schedule(n, pd.DataFrame(columns=list(_build_factor_series.__defaults__ or [])
+                                                 + ["asset_id", "component", "start", "end", "p_max_pu"]))
+    assert counts == {"Generator": 0, "Link": 0}
+    # No dynamic columns added
+    assert "g0" not in n.generators_t.p_max_pu.columns
+    assert "l0" not in n.links_t.p_max_pu.columns
+
+
+def test_tz_aware_outage_on_tz_naive_snapshots_aligns_correctly() -> None:
+    """A tz-aware outage window applies correctly to tz-naive snapshots (UTC convention)."""
+    n = _two_bus_network()
+    outages = pd.DataFrame([
+        {
+            "asset_id": "g0",
+            "component": "Generator",
+            "start": pd.Timestamp("2025-01-01 06:00", tz="UTC"),
+            "end": pd.Timestamp("2025-01-01 12:00", tz="UTC"),
+            "p_max_pu": 0.0,
+        },
+    ])
+    apply_outage_schedule(n, outages)
+    series = n.generators_t.p_max_pu["g0"]
+    assert (series.loc["2025-01-01 06:00":"2025-01-01 12:00"] == 0.0).all()
+
+
+def test_build_factor_series_per_asset_skips_unaffected_assets() -> None:
+    """Per-asset factor builder only returns assets whose factor dips below 1."""
+    snapshots = pd.date_range("2025-01-01", periods=24, freq="h")
+    outages = pd.DataFrame([
+        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-01 12:00", 0.5),
+        # Window entirely outside snapshots
+        _outage_row("g1", "Generator", "2024-12-30 00:00", "2024-12-30 06:00", 0.0),
+    ])
+    result = build_factor_series_per_asset(outages, snapshots, component="Generator")
+    assert set(result.keys()) == {"g0"}
+
+
+def test_partial_overlap_with_snapshots_only_writes_intersection() -> None:
+    """Outage extending past snapshot range writes only the overlapping portion."""
+    snapshots = pd.date_range("2025-01-01", periods=12, freq="h")
+    n = _two_bus_network(snapshots=snapshots)
+    outages = pd.DataFrame([
+        _outage_row("g0", "Generator", "2025-01-01 06:00", "2025-01-02 18:00", 0.0),
+    ])
+    apply_outage_schedule(n, outages)
+    series = n.generators_t.p_max_pu["g0"]
+    assert (series.loc["2025-01-01 06:00":"2025-01-01 11:00"] == 0.0).all()
+    assert series.shape[0] == 12


### PR DESCRIPTION
## Summary

Adds `pypsa.apply_outage_schedule`, a policy-light helper that writes
**user-supplied, deterministic outage windows** onto a built network by
composing a derate factor into `generators_t.p_max_pu` and
`links_t.p_max_pu` / `p_min_pu`. Refs #1696.

The mechanism:

- **Schema**: `asset_id`, `component ∈ {Generator, Link}`, `start`, `end`,
  `p_max_pu ∈ [0, 1]`. Snapshots must be a `DatetimeIndex`.
- **Overlapping rows** on the same asset collapse by `min(p_max_pu)`
  (worst outage wins).
- **Multiplicative composition** with existing `p_max_pu_t`: a renewable
  at CF 0.30 during a 0.50 derate becomes 0.15.
- **Asymmetric Links**: factor applies in both directions; reverse goes
  into `links_t.p_min_pu` and is clamped to the static `links.p_min_pu`
  so reverse availability is never *more* permissive than the static
  lower bound (NorNed `p_min_pu = -0.957` etc.).
- `on_unknown ∈ {raise, warn, ignore}` controls behaviour for typos in
  `asset_id`.

## Relationship to #1576

Orthogonal (see #1696 for the table). #1576 co-optimises maintenance
windows as MILP variables (`maintenance`, `maintenance_start`,
McCormick linearization). This PR is the **deterministic** counterpart:
windows are known a priori and written pre-solve, at zero solver cost.
No variables added, no constraints touched. Different sub-package
(`pypsa/utils/` vs `pypsa/optimization/`).

Opening as **draft** pending coordination on #1696. Happy to fold this
into a single helper module with #1576 if maintainers prefer.

## Files

- `pypsa/utils/__init__.py` (new): re-exports the helper.
- `pypsa/utils/outage_schedule.py` (new): the implementation.
- `pypsa/__init__.py`: re-exports `pypsa.apply_outage_schedule` and the
  `pypsa.utils` submodule (mirrors the pattern from #1694).
- `test/test_outage_schedule.py` (new): 16 unit tests.
- `docs/release-notes.md`: Features bullet under Upcoming Release.

## Test plan

- [x] `pytest test/test_outage_schedule.py` — 16 unit tests pass.
- [x] `pytest --doctest-modules pypsa/utils/outage_schedule.py` —
      executable docstring example passes.
- [x] `ruff check pypsa/utils/ test/test_outage_schedule.py` clean.
- [x] Re-export verified: `pypsa.apply_outage_schedule is pypsa.utils.apply_outage_schedule`.

Test coverage:

- Full outage (`p_max_pu=0`) zeros only the masked snapshots.
- Partial derate composes multiplicatively with existing `p_max_pu_t`.
- Overlapping windows collapse to the worst factor per snapshot.
- Link outage clamps reverse direction to the static `p_min_pu` floor
  (NorNed-style asymmetric HVDC).
- Reverse availability never exceeds the static lower bound.
- Unknown asset_id: `raise` / `warn` / `ignore` all behave as specified.
- Missing required columns raises `ValueError`.
- Unsupported component (e.g. `Store`) raises `ValueError`.
- `p_max_pu` outside `[0, 1]` raises `ValueError`.
- Non-`DatetimeIndex` snapshots raise `TypeError`.
- Empty `outages` DataFrame is a no-op.
- tz-aware outage windows align correctly to tz-naive snapshots.
- Per-asset factor builder skips assets whose window doesn't intersect
  snapshots.
- Partial overlap with snapshots writes only the intersection.

## Checklist

- [x] Code changes are sufficiently documented; new functions contain
      docstrings with an executable example.
- [x] Unit tests for new features were added.
- [x] A note for the release notes is included.
- [x] I consent to the release of this PR's code under the MIT license.
