### PR TITLE
rolling horizon: track e_sum_max constraints

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,8 @@ SPDX-License-Identifier: CC-BY-4.0
     next update! If you would like to use these features in the meantime, you will need
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
 
+- [`optimize_with_rolling_horizon`][pypsa.optimization.OptimizationAccessor.optimize_with_rolling_horizon] now tracks Generator `e_sum_max` budgets across iterations by reducing the remaining budget in each window by the energy already committed in previous windows (excluding overlap that is re-optimised).
+
 - Fix operational constraints for non-extendable components producing `NaN` bounds when `p_nom` is infinite and `p_min_pu`/`p_max_pu` is zero. The bound now falls back to zero in this case. Relevant for linopy versions `>=0.7` where `NaN` bounds are not dropped explicitly.
 
 - Lift `xarray<2026.4` upper bound and bump `linopy>=0.7.0` floor. The xarray API change (rejecting `Dataset` as `data_vars` to the `Dataset()` constructor) was fixed in [linopy PR #647](https://github.com/PyPSA/linopy/pull/647), released in linopy 0.7.0. With the new floor, the xarray cap is no longer needed.

--- a/pypsa/optimization/abstract.py
+++ b/pypsa/optimization/abstract.py
@@ -498,6 +498,10 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
     ) -> Network:
         """Optimizes the network in a rolling horizon fashion.
 
+        Generator `e_sum_max` budgets are tracked across iterations: the remaining
+        budget in each window is reduced by the weighted energy already produced
+        in previously committed snapshots (excluding overlap that is re-optimised).
+
         Parameters
         ----------
         snapshots : list-like
@@ -519,6 +523,10 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
             raise ValueError(msg)
 
         starting_points = range(0, len(snapshots), horizon - overlap)
+        track_e_sum_max = (n.c.generators.static.e_sum_max < np.inf).any()
+        if track_e_sum_max:
+            e_sum_max_orig = n.c.generators.static.e_sum_max.copy()
+
         for i, start in enumerate(starting_points):
             end = min(len(snapshots), start + horizon)
             sns = snapshots[start:end]
@@ -541,6 +549,15 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
                             snapshots[start - 1]
                         ].values
                     )
+                if track_e_sum_max:
+                    committed = snapshots[:start]
+                    weights = n.snapshot_weightings.generators.loc[committed]
+                    generated = (
+                        n.c.generators.dynamic.p.loc[committed]
+                        .multiply(weights, axis=0)
+                        .sum()
+                    )
+                    n.c.generators.static["e_sum_max"] = e_sum_max_orig - generated
 
             status, condition = n.optimize(sns, **kwargs)
             if status != "ok":
@@ -549,6 +566,9 @@ class OptimizationAbstractMixin(OptimizationAbstractMGAMixin):
                     status,
                     condition,
                 )
+
+        if track_e_sum_max:
+            n.c.generators.static["e_sum_max"] = e_sum_max_orig
         return n
 
     def optimize_and_run_non_linear_powerflow(

--- a/test/test_lopf_rolling_horizon.py
+++ b/test/test_lopf_rolling_horizon.py
@@ -222,6 +222,46 @@ def test_rolling_horizon_committable_overlap_matches_full_run():
     assert (ramping >= -static.eval("ramp_limit_down * p_nom_opt")).all().all()
 
 
+def test_rolling_horizon_e_sum_max():
+    n = get_network(committable=False)
+
+    # Total unconstrained dispatch for coal in a single-shot run as reference
+    n_ref = n.copy()
+    n_ref.optimize()
+    full_coal = n_ref.c.generators.dynamic.p["coal"].sum()
+
+    # Cap coal generation below the unconstrained level
+    budget = 0.5 * full_coal
+    n.c.generators.static.loc["coal", "e_sum_max"] = budget
+
+    n.optimize.optimize_with_rolling_horizon(horizon=3)
+
+    weights = n.snapshot_weightings.generators
+    coal_total = (n.c.generators.dynamic.p["coal"] * weights).sum()
+    assert coal_total <= budget + 1e-6
+
+    # Static attribute is restored after the run
+    assert n.c.generators.static.loc["coal", "e_sum_max"] == budget
+
+
+def test_rolling_horizon_e_sum_max_with_overlap():
+    n = get_network(committable=False)
+
+    n_ref = n.copy()
+    n_ref.optimize()
+    full_coal = n_ref.c.generators.dynamic.p["coal"].sum()
+
+    budget = 0.5 * full_coal
+    n.c.generators.static.loc["coal", "e_sum_max"] = budget
+
+    n.optimize.optimize_with_rolling_horizon(horizon=3, overlap=1)
+
+    weights = n.snapshot_weightings.generators
+    coal_total = (n.c.generators.dynamic.p["coal"] * weights).sum()
+    assert coal_total <= budget + 1e-6
+    assert n.c.generators.static.loc["coal", "e_sum_max"] == budget
+
+
 def test_rolling_horizon_linearized_uc_with_ramp_limits():
     """
     Test rolling horizon with linearized UC and ramp limits on committables.


### PR DESCRIPTION
Rolling horizon optimisation now tracks Generator `e_sum_max` budgets across iterations by reducing the remaining budget in each window by the energy already committed in previous windows (excluding overlap that is re-optimised).
