### PR TITLE
fix: optimize() now honours static `p_set` on Generator/StorageUnit/Store/Link/Process

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,15 +6,20 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Release Notes
 
-## [**v1.2.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.2) <small>25th May 2026</small> { id="v1.2.2" }
+## Upcoming Release
 
-<!--
 !!! info "Upcoming Release"
 
     The features listed below have not yet been released, but will be included in the
     next update! If you would like to use these features in the meantime, you will need
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
--->
+
+### Bug Fixes
+
+- Fix `n.optimize()` silently ignoring a static `p_set` on [Generator](./user-guide/components/generators.md), [StorageUnit](./user-guide/components/storage-units.md), [Store](./user-guide/components/stores.md), [Link](./user-guide/components/links.md), and [Process](./user-guide/components/processes.md) components. `lpf()` already honoured both static and dynamic `p_set`; the optimizer now matches the documented `static or series` semantics. See [#1701](https://github.com/PyPSA/PyPSA/issues/1701).
+
+
+## [**v1.2.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.2) <small>25th May 2026</small> { id="v1.2.2" }
 
 ### Bug Fixes
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,7 +16,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Bug Fixes
 
-- Fix `n.optimize()` silently ignoring a static `p_set` on [Generator](./user-guide/components/generators.md), [StorageUnit](./user-guide/components/storage-units.md), [Store](./user-guide/components/stores.md), [Link](./user-guide/components/links.md), and [Process](./user-guide/components/processes.md) components. `lpf()` already honoured both static and dynamic `p_set`; the optimizer now matches the documented `static or series` semantics. See [#1701](https://github.com/PyPSA/PyPSA/issues/1701).
+- Fix `n.optimize()` silently ignoring a static `p_set` attribute. (<!-- md:pr 1703 -->)
 
 
 ## [**v1.2.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.2) <small>25th May 2026</small> { id="v1.2.2" }

--- a/pypsa/clustering/spatial.py
+++ b/pypsa/clustering/spatial.py
@@ -29,11 +29,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _sum_keep_na(s: Series) -> float:
+    """Sum keeping all nan groups as nan instead of collapsing them to 0."""
+    return s.sum(min_count=1)
+
+
 DEFAULT_ONE_PORT_STRATEGIES = {
     "p": "sum",
     "q": "sum",
-    "p_set": "sum",
-    "q_set": "sum",
+    "p_set": _sum_keep_na,
+    "q_set": _sum_keep_na,
     "p_nom": pd.Series.sum,  # resolve infinities, see https://github.com/pandas-dev/pandas/issues/54161
     "p_nom_max": pd.Series.sum,  # resolve infinities, see https://github.com/pandas-dev/pandas/issues/54161
     "p_nom_min": "sum",

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1574,7 +1574,8 @@ def define_fixed_operation_constraints(
     c = as_components(n, component)
     attr_set = f"{attr}_set"
 
-    if attr_set not in c.dynamic.keys() or c.dynamic[attr_set].empty:
+    # Those internal guards should be removed and for Lines/ Transformers which are passive, the method should not even be called (clean up needed everywhere)
+    if attr_set not in c.dynamic.keys():
         return
 
     fix = c.da[attr_set].sel(snapshot=sns, name=c.active_assets)

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -326,10 +326,11 @@ def test_define_generator_constraints():
     )
 
 
-@pytest.mark.parametrize("static", [False, True])
-def test_define_fixed_operational_constraints_positive(static):
+@pytest.mark.parametrize("mode", ["dynamic", "static", "mixed"])
+def test_define_fixed_operational_constraints_positive(mode):
     """
-    Test fixed operational constraints: fix to a positive value
+    Test fixed operational constraints: fix to a positive value, set statically,
+    dynamically, or both on the same snapshot
     """
     n = pypsa.Network()
     n.add("Bus", "bus0")
@@ -338,18 +339,26 @@ def test_define_fixed_operational_constraints_positive(static):
     n.add("Generator", "gen1", bus="bus0", p_nom=5, marginal_cost=5)
     n.add("Generator", "gen2", bus="bus0", p_nom=10, marginal_cost=9)
 
-    if static:
-        n.c.generators.static.loc["gen2", "p_set"] = 8
-    else:
+    if mode == "dynamic":
         n.c.generators.dynamic.p_set["gen2"] = 8
+    elif mode == "static":
+        n.c.generators.static.loc["gen2", "p_set"] = 8
+    elif mode == "mixed":
+        n.c.generators.static.loc["gen2", "p_set"] = 8
+        n.c.generators.dynamic.p_set["gen1"] = 1
 
     n.optimize()
 
     assert n.c.generators.dynamic.p["gen2"].eq(8).all()
-    assert n.c.generators.dynamic.p["gen0"].eq(2).all()
+    if mode == "mixed":
+        assert n.c.generators.dynamic.p["gen1"].eq(1).all()
+        assert n.c.generators.dynamic.p["gen0"].eq(1).all()
+    else:
+        assert n.c.generators.dynamic.p["gen0"].eq(2).all()
 
 
-def test_define_fixed_operational_constraints_zero():
+@pytest.mark.parametrize("static", [False, True])
+def test_define_fixed_operational_constraints_zero(static):
     """
     Test fixed operational constraints: fix to a zero value
     """
@@ -360,13 +369,46 @@ def test_define_fixed_operational_constraints_zero():
     n.add("Generator", "gen1", bus="bus0", p_nom=5, marginal_cost=5)
     n.add("Generator", "gen2", bus="bus0", p_nom=10, marginal_cost=9)
 
-    n.c.generators.dynamic.p_set["gen0"] = 0
+    if static:
+        n.c.generators.static.loc["gen0", "p_set"] = 0
+    else:
+        n.c.generators.dynamic.p_set["gen0"] = 0
 
     n.optimize()
 
     assert n.c.generators.dynamic.p["gen0"].eq(0).all()
     assert n.c.generators.dynamic.p["gen1"].eq(5).all()
     assert n.c.generators.dynamic.p["gen2"].eq(5).all()
+
+
+@pytest.mark.parametrize("static", [False, True])
+def test_define_fixed_operational_constraints_storage_unit(static):
+    """
+    Test fixed operational constraints: StorageUnit p_set fixes the net power
+    p_dispatch - p_store
+    """
+    n = pypsa.Network()
+    n.add("Bus", "bus0")
+    n.add("Load", "load0", bus="bus0", p_set=10)
+    n.add("Generator", "gen0", bus="bus0", p_nom=20, marginal_cost=5)
+    n.add(
+        "StorageUnit",
+        "su0",
+        bus="bus0",
+        p_nom=10,
+        state_of_charge_initial=10,
+        marginal_cost=9,
+    )
+
+    if static:
+        n.c.storage_units.static.loc["su0", "p_set"] = 4
+    else:
+        n.c.storage_units.dynamic.p_set["su0"] = 4
+
+    n.optimize()
+
+    assert n.c.storage_units.dynamic.p["su0"].eq(4).all()
+    assert n.c.generators.dynamic.p["gen0"].eq(6).all()
 
 
 def test_define_fixed_operational_constraints_extendable():

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -326,7 +326,8 @@ def test_define_generator_constraints():
     )
 
 
-def test_define_fixed_operational_constraints_positive():
+@pytest.mark.parametrize("static", [False, True])
+def test_define_fixed_operational_constraints_positive(static):
     """
     Test fixed operational constraints: fix to a positive value
     """
@@ -337,25 +338,10 @@ def test_define_fixed_operational_constraints_positive():
     n.add("Generator", "gen1", bus="bus0", p_nom=5, marginal_cost=5)
     n.add("Generator", "gen2", bus="bus0", p_nom=10, marginal_cost=9)
 
-    n.c.generators.dynamic.p_set["gen2"] = 10
-
-    n.optimize()
-
-    assert n.c.generators.dynamic.p["gen2"].eq(10).all()
-    assert n.c.generators.dynamic.p["gen0"].eq(0).all()
-
-
-def test_define_fixed_operational_constraints_static():
-    """
-    Test fixed operational constraints: a static (scalar) p_set is honoured,
-    matching the dynamic form. Regression for #1701.
-    """
-    n = pypsa.Network()
-    n.add("Bus", "bus0")
-    n.add("Load", "load0", bus="bus0", p_set=10)
-    n.add("Generator", "gen0", bus="bus0", p_nom=4, marginal_cost=0)
-    n.add("Generator", "gen1", bus="bus0", p_nom=5, marginal_cost=5)
-    n.add("Generator", "gen2", bus="bus0", p_nom=10, marginal_cost=9, p_set=8)
+    if static:
+        n.c.generators.static.loc["gen2", "p_set"] = 8
+    else:
+        n.c.generators.dynamic.p_set["gen2"] = 8
 
     n.optimize()
 

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -345,6 +345,24 @@ def test_define_fixed_operational_constraints_positive():
     assert n.c.generators.dynamic.p["gen0"].eq(0).all()
 
 
+def test_define_fixed_operational_constraints_static():
+    """
+    Test fixed operational constraints: a static (scalar) p_set is honoured,
+    matching the dynamic form. Regression for #1701.
+    """
+    n = pypsa.Network()
+    n.add("Bus", "bus0")
+    n.add("Load", "load0", bus="bus0", p_set=10)
+    n.add("Generator", "gen0", bus="bus0", p_nom=4, marginal_cost=0)
+    n.add("Generator", "gen1", bus="bus0", p_nom=5, marginal_cost=5)
+    n.add("Generator", "gen2", bus="bus0", p_nom=10, marginal_cost=9, p_set=8)
+
+    n.optimize()
+
+    assert n.c.generators.dynamic.p["gen2"].eq(8).all()
+    assert n.c.generators.dynamic.p["gen0"].eq(2).all()
+
+
 def test_define_fixed_operational_constraints_zero():
     """
     Test fixed operational constraints: fix to a zero value


### PR DESCRIPTION
Closes #1701.

`n.optimize()` silently ignored a static (scalar) `p_set` on Generator, StorageUnit, Store, Link, and Process components, while `n.lpf()` honoured it. This contradicts the `static or series` declaration in the component CSVs and the docs. The fix drops a stale `or c.dynamic[attr_set].empty` clause from the early-return guard in `define_fixed_operation_constraints`, so the merged `c.da[attr_set]` accessor on the next line (which already combines static and dynamic) is actually reached.

Regression test added next to the existing dynamic-form tests in `test/test_lopf_basic_constraints.py`.

<details>
<summary>Reproducer and background</summary>

```python
import pypsa

n = pypsa.Network()
n.add("Bus", "B1")
n.add("Generator", "cheap", bus="B1", p_nom=200, marginal_cost=10)
n.add("Generator", "expensive", bus="B1", p_nom=200, marginal_cost=20, p_set=50)
n.add("Load", "L1", bus="B1", p_set=100)
n.optimize()
print(n.c.generators.dynamic.p)
# before: cheap=100, expensive=0   (static p_set=50 ignored)
# after:  cheap=50,  expensive=50
```

The guard was introduced by #1154, which migrated the read from `n.dynamic(c)[attr_set]` to the merged `c.da[attr_set]` accessor but left the early-return still checking only `c.dynamic`, so the new merged read never fired for the static-only case.

Note: this surfaces a separate latent bug in PyPSA-Eur (`cluster_heat_buses` aggregates `p_set` via `sum`, turning NaN into 0.0), tracked in PyPSA/PyPSA-Eur#2182. The PyPSA-Eur (master) CI check stays red until that is fixed.
</details>

## Checklist

- [x] Code changes are sufficiently documented.
- [x] Unit tests for the bug fix were added.
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
