### PR TITLE
feat: drop empty dim name in mga

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,11 @@ SPDX-License-Identifier: CC-BY-4.0
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
 -->
 
+### Features
+
+Added compatibility with stricter dimension alignment handling in (upcoming)linopy `>=0.8`.
+
+
 ### Bug Fixes
 
 - Fix the sign of [Loads](./user-guide/components/loads.md) not being taken into account in the nodal balance constraint when calling [`n.optimize()`][pypsa.optimization.OptimizationAccessor.__call__]. (<!-- md:pr 1685 -->)

--- a/pypsa/optimization/mga.py
+++ b/pypsa/optimization/mga.py
@@ -216,7 +216,6 @@ class OptimizationAbstractMGAMixin:
                     coeffs = pd.Series(coeffs)
                 if attr == nominal_attrs[c] and isinstance(coeffs, pd.Series):
                     coeffs = coeffs.reindex(self._n.c[c].extendables, fill_value=0)
-                    coeffs.index.name = ""
                 elif isinstance(coeffs, pd.Series):
                     coeffs = coeffs.reindex(columns=self._n.c[c].static.index)
                 elif isinstance(coeffs, pd.DataFrame):


### PR DESCRIPTION
In linopy v0.8 the dimension alignment will start to be stricter. full rollout in v1. the change here fixes is the only spot where the currently planned changes in linopy fail. (beyond that I honestly don't know what the original intent of the dim override was) 


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
