### PR TITLE
fix: avoid redundant interactive bar legend

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -23,6 +23,9 @@ Added compatibility with stricter dimension alignment handling in (upcoming)lino
 
 ### Bug Fixes
 
+- Avoid redundant traces and legends in interactive statistics bar plots when
+  the color dimension duplicates an axis. (<!-- md:pr -->)
+
 - Fix the sign of [Loads](./user-guide/components/loads.md) not being taken into account in the nodal balance constraint when calling [`n.optimize()`][pypsa.optimization.OptimizationAccessor.__call__]. (<!-- md:pr 1685 -->)
 
 - Fix operational constraints for non-extendable components producing `NaN` bounds when `p_nom` is infinite and `p_min_pu`/`p_max_pu` is zero. The bound now falls back to zero in this case. Relevant for linopy versions `>=0.7` where `NaN` bounds are not dropped explicitly. (<!-- md:pr 1683 -->)

--- a/pypsa/plot/statistics/charts.py
+++ b/pypsa/plot/statistics/charts.py
@@ -649,6 +649,9 @@ class ChartGenerator(PlotsGenerator, ABC):
                 ldata[y], categories=ldata[y].unique(), ordered=True
             )
 
+        if kind == "bar" and color in {x, y}:
+            color = None
+
         # Prepare color mapping if color column is provided
         if color and color_discrete_map is None and color in ldata.columns:
             color_values = ldata[color].unique()

--- a/test/test_statistics_plot_interactive.py
+++ b/test/test_statistics_plot_interactive.py
@@ -124,6 +124,15 @@ def test_iplot_stacked_parameter(ac_dc_network_r, stacked):
     assert isinstance(fig, go.Figure)
 
 
+def test_iplot_bar_drops_redundant_axis_color(ac_dc_network_r):
+    """Bar charts should not split traces when color duplicates an axis."""
+    fig = ac_dc_network_r.statistics.energy_balance.iplot.bar()
+
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == 1
+    assert fig.data[0].showlegend is False
+
+
 def test_iplot_category_orders(ac_dc_network_r):
     """Test creating a plot with specified category orders."""
     # Create plot with specified orders if applicable columns exist


### PR DESCRIPTION
Closes #1700

## Changes proposed in this Pull Request

- Avoid passing a redundant `color` dimension to Plotly bar charts when it duplicates the x or y axis.
- Add a regression test for `statistics.energy_balance.iplot.bar()` to ensure it no longer creates one trace per carrier for the default schema.
- Add a release note for the plotting fix.

## Checklist

- [x] I tested my contribution locally, and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are updated in `envs/environment.yaml`.
- [x] Changes in functionality are added to `docs/release-notes.md`.
- [x] New functions/methods are listed in `api_reference.rst`.
- [x] Changes in the component data model are added to `pypsa/data/defaults/*.csv`.
- [x] I consent to my contributions being licensed under the MIT license.

## Test plan

- `uv run pytest test/test_statistics_plot_interactive.py::test_iplot_bar_drops_redundant_axis_color -q`
- `uv run pytest test/test_statistics_plot_interactive.py -q`
