### PR TITLE
Use standard removeprefix function

### DIFF
--- a/pypsa/_options.py
+++ b/pypsa/_options.py
@@ -301,7 +301,7 @@ class OptionsNode:
                 continue
 
             # PYPSA_GENERAL__ALLOW_NETWORK_REQUESTS -> general.allow_network_requests
-            option_path = env_var[len(prefix) :].replace("__", ".").lower()
+            option_path = env_var.removeprefix(prefix).replace("__", ".").lower()
 
             lower_value = env_value.lower()
             # Handle common booleans


### PR DESCRIPTION
## Changes proposed in this Pull Request

Use the standard `str.removeprefix()` method instead of error-prone substring indexing.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
