### PR TITLE
fix: do not delete solver model from test fixture (compat linopy v0.8)

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -141,7 +141,6 @@ def stochastic_network():
 def ac_dc_solved():
     n = pypsa.examples.ac_dc_meshed()
     n.optimize()
-    del n.model.solver_model
     return n
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -141,6 +141,7 @@ def stochastic_network():
 def ac_dc_solved():
     n = pypsa.examples.ac_dc_meshed()
     n.optimize()
+    n.model.solver_model = None
     return n
 
 


### PR DESCRIPTION
linopy v0.8 introduced a solver class refactoring after which explicit deletion is prohibited

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
