### PR TITLE
fix: fill dynamic results for components added between optimize calls (#1723)

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -23,6 +23,11 @@ Added compatibility with stricter dimension alignment handling in (upcoming)lino
 
 ### Bug Fixes
 
+- Fix dynamic optimization results (e.g. `links_t.p0`) not being filled for
+  components added between two `n.optimize()` calls. `_set_dynamic_data` only
+  updated columns already present, leaving newly added components at zero.
+  (<!-- md:pr 1723 -->)
+
 - Avoid redundant traces and legends in interactive statistics bar plots when
   the color dimension duplicates an axis. (<!-- md:pr -->)
 

--- a/pypsa/optimization/common.py
+++ b/pypsa/optimization/common.py
@@ -53,7 +53,7 @@ def _set_dynamic_data(n: Network, component: str, attr: str, df: pd.DataFrame) -
         c.dynamic[attr] = df.reindex(n.snapshots)
 
     else:
-        c.dynamic[attr].update(df)
+        c.dynamic[attr] = df.combine_first(c.dynamic[attr])
 
     # Reindex to match network snapshots and component names
     result = c.dynamic[attr].reindex(n.snapshots, level="snapshot", axis=0)

--- a/test/test_lopf_multilink.py
+++ b/test/test_lopf_multilink.py
@@ -167,3 +167,35 @@ def test_attribution_assignment(n):
 def test_optimize(n):
     status, condition = n.optimize()
     assert status == "ok"
+
+
+def test_reoptimize_added_links_fills_all_ports():
+    """Ports of links added after a first optimize must be filled on re-optimize.
+
+    See https://github.com/PyPSA/PyPSA/issues/1723.
+    """
+    n = pypsa.Network()
+    n.set_snapshots(range(3))
+    n.add("Bus", ["gas", "elec", "heat"])
+    n.add("Generator", "gas", bus="gas", p_nom=1e4, marginal_cost=1)
+    n.add("Load", "elec", bus="elec", p_set=35)
+    n.add("Link", "boiler", bus0="gas", bus1="elec", efficiency=0.5, p_nom=1e4)
+    n.optimize()
+
+    n.add("Load", "heat", bus="heat", p_set=30)
+    n.add(
+        "Link",
+        "CHP",
+        bus0="gas",
+        bus1="elec",
+        bus2="heat",
+        efficiency=0.4,
+        efficiency2=0.4,
+        p_nom=1e4,
+    )
+    status, _ = n.optimize()
+    assert status == "ok"
+
+    assert (n.links_t.p0["CHP"] > 0).all()
+    assert (n.links_t.p1["CHP"] < 0).all()
+    assert (n.links_t.p2["CHP"] < 0).all()


### PR DESCRIPTION
> [!NOTE]
> This PR's content was created with AI assistance and reviewed by me.

Closes #1723.

## Changes proposed in this Pull Request

Fixes a regression (v1.2.0–v1.2.2) where dynamic optimization results (e.g. `n.links_t.p0`) were not filled for components added between two `n.optimize()` calls, leaving them at zero. This caused the energy-balance statistics regression reported in #1723.

**Root cause** (introduced in #1617): `_set_dynamic_data` switched to `DataFrame.update`, which has left-join semantics — it only writes into columns already present in the existing dynamic frame and silently ignores new ones. So after `optimize → add components → optimize`, the newly added components' columns were missing from the pre-existing `p0`/`p1` frames and ended up zero-filled. Attributes that did not yet exist (e.g. `p2`) took the other branch and were filled correctly — explaining why a CHP could show zero `p0`/`p1` but a correct `p2`.

**Fix**: use `df.combine_first(c.dynamic[attr])` so the union of columns is kept with the new solution taking precedence.

- `pypsa/optimization/common.py`: replace `update` with `combine_first`.
- `test/test_lopf_multilink.py`: add regression test covering the optimize → add multi-output link → re-optimize scenario, asserting all ports are filled.
- `docs/release-notes.md`: add bug-fix note.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
