### PR TITLE
fix: address review findings for piecewise constraints

### DIFF
--- a/docs/user-guide/optimization/piecewise.md
+++ b/docs/user-guide/optimization/piecewise.md
@@ -17,7 +17,7 @@ Common non-linear relationships found in energy systems include:
 
 A limited set of component attributes can be defined using piecewise curves:
 
-{{ read_csv('../../../pypsa/components/piecewise.csv') }}
+{{ read_csv('../../../pypsa/data/piecewise.csv') }}
 
 For each, they can be defined when using [pypsa.Network.add][] by either providing an appropriately formatted dictionary or [pandas.DataFrame][].
 If a dictionary, keys should be x-values and values should be y-values at each of the _breakpoints_ of the curve being described.

--- a/pypsa/components/_types/mixin/multiports.py
+++ b/pypsa/components/_types/mixin/multiports.py
@@ -72,10 +72,11 @@ class _Multiport(Components):
         filtered_attrs = PIECEWISE_ATTRS.query(
             "component == @name", local_dict={"name": self.name}
         )
+        extra_rows: list[pd.Series] = []
         del_rows = []
         for idx, row in filtered_attrs.iterrows():
             if row["y"] == self._coefficient_attr:
-                extra_rows = [
+                extra_rows.extend(
                     pd.Series(
                         {
                             **row,
@@ -84,13 +85,14 @@ class _Multiport(Components):
                         }
                     )
                     for i in self._output_ports
-                ]
+                )
                 del_rows.append(idx)
-        formatted_attrs = pd.concat(
+        if not del_rows:
+            return filtered_attrs
+        return pd.concat(
             [filtered_attrs.drop(index=del_rows), pd.DataFrame(extra_rows)],
             ignore_index=True,
         )
-        return formatted_attrs
 
     @property
     @abstractmethod

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -362,6 +362,9 @@ class Components(
             equals(self.ctype, other.ctype, log_mode=log_mode, path="c.ctype")
             and equals(self.static, other.static, log_mode=log_mode, path="c.static")
             and equals(self.dynamic, other.dynamic, log_mode=log_mode, path="c.dynamic")
+            and equals(
+                self.piecewise, other.piecewise, log_mode=log_mode, path="c.piecewise"
+            )
         )
 
     @staticmethod

--- a/pypsa/data/piecewise.csv
+++ b/pypsa/data/piecewise.csv
@@ -9,8 +9,8 @@ Link,p_pu,efficiency,p{port}_piecewise,false
 Process,p_pu,marginal_cost,marginal_cost_piecewise,false
 Process,p_nom,capital_cost,capital_cost_piecewise,true
 Process,p_pu,rate,p{port}_piecewise,false
-StorageUnit,p_pu,marginal_cost,marginal_cost_piecewise,false
+StorageUnit,p_dispatch_pu,marginal_cost,marginal_cost_piecewise,false
 StorageUnit,p_nom,capital_cost,capital_cost_piecewise,true
-Store,e_pu,marginal_cost,marginal_cost_piecewise,false
+Store,p_pu,marginal_cost,marginal_cost_piecewise,false
 Store,e_nom,capital_cost,capital_cost_piecewise,true
 Transformer,s_nom,capital_cost,capital_cost_piecewise,true

--- a/pypsa/network/index.py
+++ b/pypsa/network/index.py
@@ -775,6 +775,17 @@ class NetworkIndexMixin(_NetworkABC):
         scenarios_.index = scenarios_.index.astype(str)
         scenarios_.index.name = "scenario"
 
+        if any(
+            not df.empty
+            for c in self.components.values()
+            for df in c.piecewise.values()
+        ):
+            msg = (
+                "Setting scenarios on a network with piecewise attribute data is "
+                "not yet supported."
+            )
+            raise NotImplementedError(msg)
+
         for c in self.components.values():  # Loop all components, not just empty ones
             c.static = pd.concat(
                 dict.fromkeys(scenarios_.index, c.static), names=["scenario"]

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -2165,7 +2165,13 @@ class NetworkIOMixin(_NetworkABC):
                     f"{bad.tolist()}."
                 )
                 raise ValueError(msg)
-
+        if search_attr in ["rate", "efficiency"]:
+            curve = df.xs(attr, level="attribute", axis=1)
+            is_pos = ((curve >= 0) | curve.isna()).all()
+            is_neg = ((curve <= 0) | curve.isna()).all()
+            if not (bad := curve.columns[~(is_pos | is_neg)]).empty:
+                msg = f"Cannot mix positive and negative values for piecewise {attr} curves of {c} components {bad.tolist()}"
+                raise NotImplementedError(msg)
         piecewise = self.c[cls_name].piecewise
 
         if attr not in piecewise:

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -2105,15 +2105,13 @@ class NetworkIOMixin(_NetworkABC):
         Parameters
         ----------
         df : pandas.DataFrame
-            DataFrame whose columns are ``[x_attr, attr]`` (the x-axis coordinate
-            and the y-axis attribute) and whose index is the breakpoint number.
-            This is the per-component form as passed to ``network.add()``.
+            DataFrame with MultiIndex columns ``(name, attribute)`` where the
+            attribute level holds ``[x_attr, attr]`` (the x-axis coordinate and
+            the y-axis attribute) and whose index is the breakpoint number.
         cls_name : str
             Component class name, e.g. ``"Generator"``.
         attr : str
             Piecewise y-axis attribute name, e.g. ``"efficiency"``.
-        component_name : str
-            Name of the individual component.
         is_extendable : pd.Series or None, default None
             If Series, a boolean series where True = extendable.
             if None, it is inferred from the component's extendables.

--- a/pypsa/network/transform.py
+++ b/pypsa/network/transform.py
@@ -257,11 +257,6 @@ class NetworkTransformMixin(_NetworkABC):
             return s + suffix
 
         for k, v in kwargs.items():
-            # If index/ columns are passed (pd.DataFrame or pd.Series)
-            # - cast names index to string and add suffix
-            # - check if passed index/ columns align
-            msg = "{} has an index which does not align with the passed {}."
-
             # Enable default lookup for attributes with port suffixes, e.g. efficiency1, rate2.
             search_attr = c._get_base_coeff(k) if isinstance(c, _Multiport) else k
 
@@ -280,17 +275,19 @@ class NetworkTransformMixin(_NetworkABC):
                 if isinstance(v, dict):
                     v = pd.DataFrame({x_attr: list(v.keys()), k: list(v.values())})
                 if isinstance(v, pd.DataFrame):
+                    pw_msg = "Piecewise {k} Dataframe has {lvl} column level which does not align with the passed {lvl}s: {diff}."
                     if isinstance(v.columns, pd.MultiIndex):
                         v = v.rename(columns=add_suffix, level=0)
-                        if not v.columns.unique(0).equals(names):
-                            raise ValueError(msg.format(f"Dataframe {k}", names_str))
-                        if set(v.columns.unique(1)) != {x_attr, k}:
-                            msg_seg = (
-                                f"Piecewise Dataframe {k} must have column labels "
-                                f"consisting of {x_attr} and {k}"
+                        lvls = v.columns.levels
+                        if not (diff := lvls[0].difference(names)).empty:
+                            raise ValueError(pw_msg.format(k=k, lvl="name", diff=diff))
+                        if not (
+                            diff := lvls[1].symmetric_difference([x_attr, k])
+                        ).empty:
+                            raise ValueError(
+                                pw_msg.format(k=k, lvl="attribute", diff=diff)
                             )
-                            raise ValueError(msg_seg)
-                        piecewise[k] = v
+                        piecewise[k] = v.reindex(columns=[x_attr, k], level=1)
                         continue
                     elif set(v.columns) == {x_attr, k}:
                         # Build a MultiIndex-columned DataFrame: broadcast the curve to all names
@@ -310,6 +307,10 @@ class NetworkTransformMixin(_NetworkABC):
                 )
                 raise NotImplementedError(msg)
 
+            # If index/ columns are passed (pd.DataFrame or pd.Series)
+            # - cast names index to string and add suffix
+            # - check if passed index/ columns align
+            msg = "{} has an index which does not align with the passed {}."
             if isinstance(v, pd.Series) and single_component:
                 if not v.index.equals(self.snapshots):
                     raise ValueError(msg.format(f"Series {k}", "network snapshots"))

--- a/pypsa/network/transform.py
+++ b/pypsa/network/transform.py
@@ -284,7 +284,7 @@ class NetworkTransformMixin(_NetworkABC):
                         v = v.rename(columns=add_suffix, level=0)
                         if not v.columns.unique(0).equals(names):
                             raise ValueError(msg.format(f"Dataframe {k}", names_str))
-                        if v.columns.unique(1).equals([x_attr, k]):
+                        if set(v.columns.unique(1)) != {x_attr, k}:
                             msg_seg = (
                                 f"Piecewise Dataframe {k} must have column labels "
                                 f"consisting of {x_attr} and {k}"
@@ -393,6 +393,12 @@ class NetworkTransformMixin(_NetworkABC):
         # Broadcast to scenarios if network has scenario structure
         # Skip SubNetwork components, they are handled internally in determine_topology
         if self.has_scenarios and c.name != "SubNetwork":
+            if piecewise:
+                msg = (
+                    "Piecewise attribute data is not yet supported for stochastic "
+                    "networks (scenarios)."
+                )
+                raise NotImplementedError(msg)
             static_df = pd.concat(
                 dict.fromkeys(self.scenarios, static_df), names=["scenario"]
             )
@@ -401,12 +407,6 @@ class NetworkTransformMixin(_NetworkABC):
                     dict.fromkeys(self.scenarios, v), names=["scenario"], axis=1
                 )
                 for k, v in series.items()
-            }
-            piecewise = {
-                k: pd.concat(
-                    dict.fromkeys(self.scenarios, v), names=["scenario"], axis=1
-                )
-                for k, v in piecewise.items()
             }
 
         # Load piecewise breakpoint data
@@ -500,6 +500,11 @@ class NetworkTransformMixin(_NetworkABC):
         # Drop from time-varying components
         for df in c.dynamic.values():
             df.drop(df.columns.intersection(names), axis=1, inplace=True)
+
+        # Drop piecewise breakpoint data
+        for df in c.piecewise.values():
+            stale = df.columns[df.columns.get_level_values("name").isin(names)]
+            df.drop(columns=stale, inplace=True)
 
     def merge(
         self,

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -927,10 +927,10 @@ def _get_delay_config(
     return config
 
 
-def _iter_balance_args(
+def _iter_balance_coeffs(
     c: _Multiport, sns: Sequence
-) -> Iterator[tuple[str, Any, pd.Index, int, bool]]:
-    """Iterate over all balance arguments, separating immediate and delayed.
+) -> Iterator[tuple[str, Any, pd.Index, str]]:
+    """Iterate over all balance arguments to get coefficient values per port.
 
     Parameters
     ----------
@@ -947,43 +947,65 @@ def _iter_balance_args(
         Coefficient values for the component
     names : pd.Index
         Component names with this delay configuration
-    delay : int
-        Delay in time units (0 for immediate, >0 for delayed)
-    is_cyclic : bool
-        Whether delay wraps around the horizon
 
     """
     if c.empty:
         return
 
     active = c.active_assets
-    delay_config = _get_delay_config(c)
 
     for port in c._output_ports:
         suffix = c._port_suffix(port)
         coeff = (
             c.da[f"{c._coefficient_attr}{suffix}"].where(c.da.active).sel(snapshot=sns)
         )
-        delays, cyclics = delay_config[suffix]
+        if not active.empty:
+            yield (f"bus{port}", coeff.sel(name=active), active, suffix)
 
-        for (d, cyc), group in c.static.assign(_delay=delays, _cyclic=cyclics).groupby(
-            ["_delay", "_cyclic"]
-        ):
-            delay_int = int(d)
 
-            names = group.index
-            if isinstance(names, pd.MultiIndex):
-                names = names.get_level_values("name").unique()
-            names = names.intersection(active)
+def _iter_balance_delay(
+    c: _Multiport, active: pd.Index, suffix: str
+) -> Iterator[tuple[pd.Index, int, bool]]:
+    """Iterate over all balance arguments, separating immediate and delayed.
 
-            if not names.empty:
-                yield (
-                    f"bus{port}",
-                    coeff.sel(name=names),
-                    names,
-                    delay_int,
-                    bool(cyc),
-                )
+    Parameters
+    ----------
+    c : _Multiport
+        _Multiport component (Link or Process).
+    active : pd.Index
+        Active component names
+    suffix : str
+        Port suffix (e.g., "", "1", "2") for which to get delay configuration
+
+    Yields
+    ------
+    names : pd.Index
+        Component names with this delay configuration
+    delay : int
+        Delay in time units (0 for immediate, >0 for delayed)
+    is_cyclic : bool
+        Whether delay wraps around the horizon
+
+    """
+    delay_config = _get_delay_config(c)
+    delays, cyclics = delay_config[suffix]
+
+    for (d, cyc), group in c.static.assign(_delay=delays, _cyclic=cyclics).groupby(
+        ["_delay", "_cyclic"]
+    ):
+        delay_int = int(d)
+
+        names = group.index
+        if isinstance(names, pd.MultiIndex):
+            names = names.get_level_values("name").unique()
+        names = names.intersection(active)
+
+        if not names.empty:
+            yield (
+                names,
+                delay_int,
+                bool(cyc),
+            )
 
 
 def _apply_delay_shift(
@@ -1156,11 +1178,9 @@ def define_nodal_balance_constraints(
     for component in ("Process", "Link"):
         c = n.c[component]
 
-        for bus_col, coeff, names, delay, is_cyclic in _iter_balance_args(c, sns):
+        for bus_col, coeff, names, port_suffix in _iter_balance_coeffs(c, sns):
             var = m[f"{c.name}-p"]
 
-            if delay > 0:
-                var = _apply_delay_shift(n, sns, c, var, names, delay, is_cyclic)
             cbuses = c._as_xarray(bus_col)
             cbuses = cbuses.sel(name=names)
             if n.has_scenarios:
@@ -1187,14 +1207,32 @@ def define_nodal_balance_constraints(
                     cumulative_attr=False,
                     extra_options=extra_options,
                 )
-                if piecewise_var is not None:
-                    piecewise_names = piecewise_var.coords["name"].values
+            if piecewise_var is not None:
+                piecewise_names = piecewise_var.coords["name"].values
+                for d_names, delay, is_cyclic in _iter_balance_delay(
+                    c, names, port_suffix
+                ):
                     if delay > 0:
-                        piecewise_var = _apply_delay_shift(
-                            n, sns, c, piecewise_var, piecewise_names, delay, is_cyclic
+                        p_piecewise += _apply_delay_shift(
+                            n,
+                            sns,
+                            c,
+                            piecewise_var,
+                            d_names.intersection(piecewise_names),
+                            delay,
+                            is_cyclic,
                         )
-                    p_piecewise += piecewise_var
-                    names = names.difference(piecewise_names)
+                    else:
+                        p_piecewise += piecewise_var.sel(
+                            name=d_names.intersection(piecewise_names)
+                        )
+
+                names = names.difference(piecewise_names)
+
+            for d_names, delay, is_cyclic in _iter_balance_delay(c, names, port_suffix):
+                if delay > 0:
+                    var = _apply_delay_shift(n, sns, c, var, d_names, delay, is_cyclic)
+
             expr = var * coeff.sel(name=names) + p_piecewise
 
             if not cbuses.size:

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -27,6 +27,7 @@ from pypsa.optimization.piecewise import PiecewiseOptions, define_piecewise
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 
+    from linopy import LinearExpression, Variable
     from xarray import DataArray  # noqa: TC004
 
     from pypsa import Network
@@ -985,13 +986,64 @@ def _iter_balance_args(
                 )
 
 
+def _apply_delay_shift(
+    n: Network,
+    sns: pd.Index,
+    c: _Multiport,
+    in_var: Variable,
+    names: pd.Index,
+    delay: int,
+    is_cyclic: bool,
+) -> LinearExpression:
+    """Apply delay shift to a mulitport dispatch variable.
+
+    Parameters
+    ----------
+    n : Network
+        Network instance containing the model and component data
+    sns : pd.Index
+        Set of snapshots for which to define the constraints
+    c : _Multiport
+        _Multiport component (Link or Process)
+    in_var : Variable
+        Input variable to be shifted
+    names : pd.Index
+        Names of components for which to apply the delay shift
+    delay : int
+        Delay in time units (0 for immediate, >0 for delayed)
+    is_cyclic : bool
+        Whether delay wraps around the horizon
+
+    Returns
+    -------
+    LinearExpression
+
+    """
+    sns_coords: xr.Coordinates | dict[str, Any]
+    if isinstance(sns, pd.MultiIndex):
+        sns_coords = xr.Coordinates.from_pandas_multiindex(sns, "snapshot")
+    else:
+        sns_coords = {"snapshot": sns}
+    src_snapshot_pos, valid = c.get_delay_source_indexer(
+        sns,
+        n.snapshot_weightings.generators.loc[sns],
+        delay,
+        is_cyclic,
+    )
+    valid_mask = DataArray(valid.astype(float), dims=["snapshot"], coords=sns_coords)
+    comp_p = in_var.sel(name=names)
+    shifted_p = comp_p.isel(snapshot=src_snapshot_pos).assign_coords(sns_coords)
+    var = shifted_p * valid_mask
+    return var
+
+
 def define_nodal_balance_constraints(
     n: Network,
     sns: pd.Index,
+    piecewise_options: list[PiecewiseOptions],
     transmission_losses: bool | int | dict = False,
     buses: Sequence | None = None,
     suffix: str = "",
-    piecewise_options: list[PiecewiseOptions] | None = None,
 ) -> None:
     """Define energy balance constraints at each node.
 
@@ -1021,14 +1073,14 @@ def define_nodal_balance_constraints(
         Network instance containing the model and component data
     sns : pd.Index
         Set of snapshots for which to define the constraints
+    piecewise_options : list[PiecewiseOptions]
+        Options to override default piecewise constraint settings.
     transmission_losses : int | dict, default 0
         If truthy, transmission losses are considered in the power balance.
     buses : Sequence | None, default None
         Subset of buses for which to define constraints; if None, all buses are used
     suffix : str, default ""
         Optional suffix to append to constraint names and dimensions
-    piecewise_options : list[PiecewiseOptions], optional
-        Options to override default piecewise constraint settings.
 
     Notes
     -----
@@ -1042,16 +1094,8 @@ def define_nodal_balance_constraints(
 
     """
     m = n.model
-    if piecewise_options is None:
-        piecewise_options = []
     if buses is None:
         buses = n.c.buses.static.index.unique("name")
-
-    sns_coords: xr.Coordinates | dict[str, Any]
-    if isinstance(sns, pd.MultiIndex):
-        sns_coords = xr.Coordinates.from_pandas_multiindex(sns, "snapshot")
-    else:
-        sns_coords = {"snapshot": sns}
 
     args: list[Any] = [
         ["Generator", "p", "bus", 1],
@@ -1111,28 +1155,12 @@ def define_nodal_balance_constraints(
 
     for component in ("Process", "Link"):
         c = n.c[component]
-        port_pw_vars: dict[str, Any] = {}
 
         for bus_col, coeff, names, delay, is_cyclic in _iter_balance_args(c, sns):
-            if delay <= 0:
-                var = m[f"{c.name}-p"]
+            var = m[f"{c.name}-p"]
 
-            else:
-                src_snapshot_pos, valid = c.get_delay_source_indexer(
-                    sns,
-                    n.snapshot_weightings.generators.loc[sns],
-                    delay,
-                    is_cyclic,
-                )
-                valid_mask = DataArray(
-                    valid.astype(float), dims=["snapshot"], coords=sns_coords
-                )
-                comp_p = m[f"{c.name}-p"].sel(name=names)
-                shifted_p = comp_p.isel(snapshot=src_snapshot_pos).assign_coords(
-                    sns_coords
-                )
-                var = shifted_p * valid_mask
-
+            if delay > 0:
+                var = _apply_delay_shift(n, sns, c, var, names, delay, is_cyclic)
             cbuses = c._as_xarray(bus_col)
             cbuses = cbuses.sel(name=names)
             if n.has_scenarios:
@@ -1151,7 +1179,7 @@ def define_nodal_balance_constraints(
                 piecewise_var = define_piecewise(
                     n.model,
                     c,
-                    x_var=var,
+                    x_var=m[f"{c.name}-p"],
                     pw_attr=coeff.name,
                     aux_var_name=f"{c.name}-{pw_attr.aux_variable}",
                     active_names=names,
@@ -1160,8 +1188,13 @@ def define_nodal_balance_constraints(
                     extra_options=extra_options,
                 )
                 if piecewise_var is not None:
+                    piecewise_names = piecewise_var.coords["name"].values
+                    if delay > 0:
+                        piecewise_var = _apply_delay_shift(
+                            n, sns, c, piecewise_var, piecewise_names, delay, is_cyclic
+                        )
                     p_piecewise += piecewise_var
-                    names = names.difference(piecewise_var.coords["name"].values)
+                    names = names.difference(piecewise_names)
             expr = var * coeff.sel(name=names) + p_piecewise
 
             if not cbuses.size:

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -988,10 +988,10 @@ def _iter_balance_args(
 def define_nodal_balance_constraints(
     n: Network,
     sns: pd.Index,
-    piecewise_options: list[PiecewiseOptions],
     transmission_losses: bool | int | dict = False,
     buses: Sequence | None = None,
     suffix: str = "",
+    piecewise_options: list[PiecewiseOptions] | None = None,
 ) -> None:
     """Define energy balance constraints at each node.
 
@@ -1027,7 +1027,7 @@ def define_nodal_balance_constraints(
         Subset of buses for which to define constraints; if None, all buses are used
     suffix : str, default ""
         Optional suffix to append to constraint names and dimensions
-    piecewise_options : list[PiecewiseOptions]
+    piecewise_options : list[PiecewiseOptions], optional
         Options to override default piecewise constraint settings.
 
     Notes
@@ -1042,6 +1042,8 @@ def define_nodal_balance_constraints(
 
     """
     m = n.model
+    if piecewise_options is None:
+        piecewise_options = []
     if buses is None:
         buses = n.c.buses.static.index.unique("name")
 
@@ -1074,7 +1076,6 @@ def define_nodal_balance_constraints(
         )
 
     exprs = []
-    piecewise_y_vars = {}
 
     for component, attr, column, sign in args:
         c = n.c[component]
@@ -1105,13 +1106,12 @@ def define_nodal_balance_constraints(
             cbuses = cbuses[cbuses != ""]
 
         expr = expr.sel(name=cbuses.coords["name"].values)
-        if component in ("Process", "Link"):
-            piecewise_y_vars[c.name] = expr
         if expr.size:
             exprs.append(_groupby_bus(expr, cbuses))
 
     for component in ("Process", "Link"):
         c = n.c[component]
+        port_pw_vars: dict[str, Any] = {}
 
         for bus_col, coeff, names, delay, is_cyclic in _iter_balance_args(c, sns):
             if delay <= 0:
@@ -1139,29 +1139,46 @@ def define_nodal_balance_constraints(
                 cbuses = cbuses.isel(scenario=0, drop=True)
             cbuses = cbuses[cbuses.isin(buses)].rename("Bus")
             cbuses = cbuses[cbuses != ""]
-            pw_attr = c._piecewise_attrs.query(
-                "y == @search_attr", local_dict={"search_attr": coeff.name}
-            ).squeeze()
-            p_piecewise = 0
-            if not pw_attr.empty:
-                extra_options = filter(
-                    lambda p: p.component == c.name and p.attribute == coeff.name,
-                    piecewise_options,
-                )
-                piecewise_var = define_piecewise(
-                    n.model,
-                    c,
-                    x_var=var,
-                    pw_attr=coeff.name,
-                    aux_var_name=f"{c.name}-{pw_attr.aux_variable}",
-                    active_names=names,
-                    sign="=",
-                    marginal_attr=False,
-                    extra_options=extra_options,
-                )
-                if piecewise_var is not None:
-                    p_piecewise += piecewise_var
-                    names = names.difference(piecewise_var.coords["name"].values)
+
+            if coeff.name not in port_pw_vars:
+                pw_attr = c._piecewise_attrs.query(
+                    "y == @search_attr", local_dict={"search_attr": coeff.name}
+                ).squeeze()
+                if pw_attr.empty:
+                    port_pw_vars[coeff.name] = None
+                else:
+                    extra_options = filter(
+                        lambda opt: (
+                            opt.component == c.name and opt.attribute == coeff.name
+                        ),
+                        piecewise_options,
+                    )
+                    port_pw_vars[coeff.name] = define_piecewise(
+                        n.model,
+                        c,
+                        x_var=m[f"{c.name}-p"],
+                        pw_attr=coeff.name,
+                        aux_var_name=f"{c.name}-{pw_attr.aux_variable}",
+                        active_names=c.active_assets,
+                        sign="=",
+                        marginal_attr=False,
+                        extra_options=extra_options,
+                    )
+
+            piecewise_var = port_pw_vars[coeff.name]
+            p_piecewise: Any = 0
+            if piecewise_var is not None:
+                pw_names = names.intersection(piecewise_var.indexes["name"])
+                if not pw_names.empty:
+                    p_piecewise = piecewise_var.sel(name=pw_names)
+                    if delay > 0:
+                        p_piecewise = (
+                            p_piecewise.isel(snapshot=src_snapshot_pos).assign_coords(
+                                sns_coords
+                            )
+                            * valid_mask
+                        )
+                    names = names.difference(pw_names)
             expr = var * coeff.sel(name=names) + p_piecewise
 
             if not cbuses.size:

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -563,11 +563,40 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             elif direction != "both":
                 msg = f"Got unexpected argument direction={direction}. Must be 'supply', 'withdrawal' or 'both'."
                 raise ValueError(msg)
-            # TODO-1603: work out sign of pw_var depending on direction
             piecewise_efficiency = port_efficiency(n, c, port=port, piecewise=True)
             if isinstance(piecewise_efficiency, pd.DataFrame):
                 pw_var = n.model.variables[f"{c}-p{port}_piecewise"]
                 coeffs.loc[{"name": pw_var.coords["name"]}] = 0
+                if direction != "both":
+                    # Classify piecewise ports like linear ones: by the sign of
+                    # the (curve) coefficients. Withdrawal is reported positive.
+                    comp = n.c[c]
+                    key = f"{comp._coefficient_attr}{comp._port_suffix(port)}"
+                    curve = piecewise_efficiency.xs(key, level="attribute", axis=1)
+                    is_pos = ((curve >= 0) | curve.isna()).all()
+                    is_neg = ((curve <= 0) | curve.isna()).all()
+                    if not (is_pos | is_neg).all():
+                        bad = curve.columns[~(is_pos | is_neg)].tolist()
+                        msg = (
+                            f"Piecewise curves of {c} components {bad} at port "
+                            f"{port} mix positive and negative values; cannot "
+                            "split into supply and withdrawal."
+                        )
+                        raise NotImplementedError(msg)
+                    sign_factor = is_pos.astype(float) - is_neg.astype(float)
+                    if direction == "supply":
+                        factor = sign_factor.clip(lower=0.0)
+                    else:
+                        factor = sign_factor.clip(upper=0.0)
+                    factor = factor.reindex(pw_var.indexes["name"]).loc[
+                        lambda s: s != 0
+                    ]
+                    if factor.empty:
+                        pw_var = 0
+                    else:
+                        pw_var = pw_var.sel(name=factor.index) * DataArray(
+                            factor.rename_axis("name")
+                        )
             else:
                 pw_var = 0
             p = var.where(coeffs != 0) * coeffs + pw_var

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -568,36 +568,6 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
                 pw_var = sign * n.model.variables[f"{c}-p{port}_piecewise"]
                 pw_var = -1 * pw_var if direction == "withdrawal" else pw_var
                 coeffs.loc[{"name": pw_var.coords["name"]}] = 0
-                if direction != "both":
-                    # Classify piecewise ports like linear ones: by the sign of
-                    # the (curve) coefficients. Withdrawal is reported positive.
-                    comp = n.c[c]
-                    key = f"{comp._coefficient_attr}{comp._port_suffix(port)}"
-                    curve = piecewise_efficiency.xs(key, level="attribute", axis=1)
-                    is_pos = ((curve >= 0) | curve.isna()).all()
-                    is_neg = ((curve <= 0) | curve.isna()).all()
-                    if not (is_pos | is_neg).all():
-                        bad = curve.columns[~(is_pos | is_neg)].tolist()
-                        msg = (
-                            f"Piecewise curves of {c} components {bad} at port "
-                            f"{port} mix positive and negative values; cannot "
-                            "split into supply and withdrawal."
-                        )
-                        raise NotImplementedError(msg)
-                    sign_factor = is_pos.astype(float) - is_neg.astype(float)
-                    if direction == "supply":
-                        factor = sign_factor.clip(lower=0.0)
-                    else:
-                        factor = sign_factor.clip(upper=0.0)
-                    factor = factor.reindex(pw_var.indexes["name"]).loc[
-                        lambda s: s != 0
-                    ]
-                    if factor.empty:
-                        pw_var = 0
-                    else:
-                        pw_var = pw_var.sel(name=factor.index) * DataArray(
-                            factor.rename_axis("name")
-                        )
             else:
                 pw_var = 0
 

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -272,7 +272,7 @@ def define_growth_limit(n: Network, sns: pd.Index) -> None:
 
 
 def define_primary_energy_limit(
-    n: Network, sns: pd.Index, piecewise_options: list[PiecewiseOptions]
+    n: Network, sns: pd.Index, piecewise_options: list[PiecewiseOptions] | None = None
 ) -> None:
     """Define primary energy constraints.
 
@@ -285,11 +285,13 @@ def define_primary_energy_limit(
         The network to apply constraints to.
     sns : list-like
         Set of snapshots to which the constraint should be applied.
-    piecewise_options : list[PiecewiseOptions]
+    piecewise_options : list[PiecewiseOptions], optional
         Options to override defaults in piecewise constraint formulation.
         List is of the form ``[PiecewiseOptions(...), ...]``.
 
     """
+    if piecewise_options is None:
+        piecewise_options = []
     m = n.model
     weightings = n.snapshot_weightings.loc[sns]
     glcs = n.c.global_constraints.static.query('type == "primary_energy"')
@@ -305,6 +307,31 @@ def define_primary_energy_limit(
         )
 
     unique_names = glcs.index.unique("name")
+
+    gen_c = n.c.generators
+    pw_attr_eff = gen_c._piecewise_attrs.query("y == 'efficiency'").squeeze()
+    primary_energy_pw_var = None
+    if (
+        not unique_names.empty
+        and not pw_attr_eff.empty
+        and "Generator-p" in m.variables
+    ):
+        extra_options = filter(
+            lambda opt: opt.component == gen_c.name and opt.attribute == "efficiency",
+            piecewise_options,
+        )
+        primary_energy_pw_var = define_piecewise(
+            m,
+            gen_c,
+            x_var=m["Generator-p"],
+            pw_attr="efficiency",
+            aux_var_name=f"{gen_c.name}-{pw_attr_eff.aux_variable}",
+            active_names=gen_c.active_assets,
+            sign="=",
+            marginal_attr=False,
+            extra_options=extra_options,
+            invert_attr=True,
+        )
 
     for name in unique_names:
         if n.has_scenarios:
@@ -350,36 +377,20 @@ def define_primary_energy_limit(
                 if n.has_scenarios:
                     p = p.sel(scenario=scenario, drop=True)
 
-                extra_options = filter(
-                    lambda p: (
-                        p.component == n.c.generators.name
-                        and p.attribute == "efficiency"
-                    ),
-                    piecewise_options,
-                )
-                pw_attr = n.c.generators._piecewise_attrs.query(
-                    "y == 'efficiency'"
-                ).squeeze()
                 linear_names = gens.index
                 to_sum = []
-                if not pw_attr.empty:
-                    piecewise_var = define_piecewise(
-                        m,
-                        n.c.generators,
-                        x_var=p,
-                        pw_attr="efficiency",
-                        aux_var_name=f"{n.c.generators.name}-{pw_attr.aux_variable}",
-                        active_names=gens.index,
-                        sign="=",
-                        marginal_attr=False,
-                        extra_options=extra_options,
-                        invert_attr=True,
+                if primary_energy_pw_var is not None:
+                    pw_names = gens.index.intersection(
+                        primary_energy_pw_var.indexes["name"]
                     )
-                    if piecewise_var is not None:
-                        to_sum.append(piecewise_var)
-                        linear_names = linear_names.difference(
-                            piecewise_var.indexes["name"]
+                    if not pw_names.empty:
+                        pw_var = primary_energy_pw_var.sel(
+                            name=pw_names, snapshot=sns[sns_sel]
                         )
+                        if n.has_scenarios:
+                            pw_var = pw_var.sel(scenario=scenario, drop=True)
+                        to_sum.append(pw_var)
+                        linear_names = linear_names.difference(pw_names)
 
                 if not linear_names.empty:
                     efficiency = (

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -272,7 +272,7 @@ def define_growth_limit(n: Network, sns: pd.Index) -> None:
 
 
 def define_primary_energy_limit(
-    n: Network, sns: pd.Index, piecewise_options: list[PiecewiseOptions] | None = None
+    n: Network, sns: pd.Index, piecewise_options: list[PiecewiseOptions]
 ) -> None:
     """Define primary energy constraints.
 
@@ -285,13 +285,11 @@ def define_primary_energy_limit(
         The network to apply constraints to.
     sns : list-like
         Set of snapshots to which the constraint should be applied.
-    piecewise_options : list[PiecewiseOptions], optional
+    piecewise_options : list[PiecewiseOptions]
         Options to override defaults in piecewise constraint formulation.
         List is of the form ``[PiecewiseOptions(...), ...]``.
 
     """
-    if piecewise_options is None:
-        piecewise_options = []
     m = n.model
     weightings = n.snapshot_weightings.loc[sns]
     glcs = n.c.global_constraints.static.query('type == "primary_energy"')

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -307,13 +307,10 @@ def define_primary_energy_limit(
     unique_names = glcs.index.unique("name")
 
     gen_c = n.c.generators
+    var_name = "Generator-p"
     pw_attr_eff = gen_c._piecewise_attrs.query("y == 'efficiency'").squeeze()
     primary_energy_pw_var = None
-    if (
-        not unique_names.empty
-        and not pw_attr_eff.empty
-        and "Generator-p" in m.variables
-    ):
+    if not unique_names.empty and not pw_attr_eff.empty and var_name in m.variables:
         extra_options = filter(
             lambda opt: opt.component == gen_c.name and opt.attribute == "efficiency",
             piecewise_options,
@@ -321,7 +318,7 @@ def define_primary_energy_limit(
         primary_energy_pw_var = define_piecewise(
             m,
             gen_c,
-            x_var=m["Generator-p"],
+            x_var=m[var_name],
             pw_attr="efficiency",
             aux_var_name=f"{gen_c.name}-{pw_attr_eff.aux_variable}",
             active_names=gen_c.active_assets,
@@ -370,7 +367,7 @@ def define_primary_energy_limit(
             if not gens.empty:
                 gens = gens.loc[scenario]
 
-                p = m["Generator-p"].sel(name=gens.index, snapshot=sns[sns_sel])
+                p = m[var_name].sel(name=gens.index, snapshot=sns[sns_sel])
 
                 if n.has_scenarios:
                     p = p.sel(scenario=scenario, drop=True)
@@ -385,8 +382,6 @@ def define_primary_energy_limit(
                         pw_var = primary_energy_pw_var.sel(
                             name=pw_names, snapshot=sns[sns_sel]
                         )
-                        if n.has_scenarios:
-                            pw_var = pw_var.sel(scenario=scenario, drop=True)
                         to_sum.append(pw_var)
                         linear_names = linear_names.difference(pw_names)
 

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -144,7 +144,7 @@ def define_objective(
     n: Network,
     sns: pd.Index,
     include_objective_constant: bool,
-    piecewise_options: list[PiecewiseOptions] | None = None,
+    piecewise_options: list[PiecewiseOptions],
 ) -> None:
     """Define and write the optimization objective function.
 
@@ -173,7 +173,7 @@ def define_objective(
         Snapshots (and, for multi-investment, periods) over which to build the objective.
     include_objective_constant : bool
         Whether to include the objective constant as a variable in the objective function.
-    piecewise_options : list[PiecewiseOptions], optional
+    piecewise_options : list[PiecewiseOptions]
         Options to override defaults in piecewise constraint formulation.
         List is of the form ``[PiecewiseOptions(...), ...]``.
 
@@ -184,8 +184,6 @@ def define_objective(
     - For a stochastic problem, scenario probabilities are applied as weightings to all cost (includes *both* investment terms).
 
     """
-    if piecewise_options is None:
-        piecewise_options = []
     weighted_cost: xr.DataArray | int
     m = n.model
     # Separate lists to distinguish CAPEX and OPEX terms

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -144,7 +144,7 @@ def define_objective(
     n: Network,
     sns: pd.Index,
     include_objective_constant: bool,
-    piecewise_options: list[PiecewiseOptions],
+    piecewise_options: list[PiecewiseOptions] | None = None,
 ) -> None:
     """Define and write the optimization objective function.
 
@@ -184,6 +184,8 @@ def define_objective(
     - For a stochastic problem, scenario probabilities are applied as weightings to all cost (includes *both* investment terms).
 
     """
+    if piecewise_options is None:
+        piecewise_options = []
     weighted_cost: xr.DataArray | int
     m = n.model
     # Separate lists to distinguish CAPEX and OPEX terms
@@ -385,7 +387,17 @@ def define_objective(
                 extra_options=extra_options,
             )
             if piecewise_var is not None:
-                ext_i = ext_i.difference(piecewise_var.indexes["name"])
+                pw_names = piecewise_var.indexes["name"]
+                overnight = c.static["overnight_cost"].loc[pw_names]
+                if overnight.notna().any():
+                    bad = overnight[overnight.notna()].index.tolist()
+                    msg = (
+                        f"Components {bad} of type {c.name} define both a piecewise "
+                        "'capital_cost' curve and 'overnight_cost'. The piecewise "
+                        "curve must already be periodized; remove 'overnight_cost'."
+                    )
+                    raise ValueError(msg)
+                ext_i = ext_i.difference(pw_names)
                 capex_terms.append((piecewise_var * cost_weight).sum(dim=sum_dim))
 
         periodic_cost = c.periodized_cost.sel(name=ext_i)
@@ -1021,7 +1033,10 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             pw_attrs = c._piecewise_attrs.query("aux_variable == @attr").squeeze()
             # Piecewise variables are auxiliary and need to be processed before being passed back as a solution.
             if not pw_attrs.empty:
-                if isinstance(c, _Multiport) and pw_attrs.y == c._coefficient_attr:
+                if (
+                    isinstance(c, _Multiport)
+                    and c._get_base_coeff(pw_attrs.y) == c._coefficient_attr
+                ):
                     # We deal with these variables below when processing the `p` attr.
                     continue
                 x_var = m.variables[f"{c.name}-{pw_attrs.x.removesuffix('_pu')}"]

--- a/pypsa/optimization/piecewise.py
+++ b/pypsa/optimization/piecewise.py
@@ -18,8 +18,6 @@ from linopy.constants import BREAKPOINT_DIM, PWL_METHOD, EvolvingAPIWarning
 
 from pypsa.descriptors import nominal_attrs
 
-warnings.filterwarnings("ignore", category=EvolvingAPIWarning)
-
 if TYPE_CHECKING:
     from collections.abc import Iterable
 logger = logging.getLogger(__name__)
@@ -37,7 +35,7 @@ class PiecewiseOptions:
     """Component attribute for which piecewise data is defined."""
     sign: SIGNS_T
     """Sign for the piecewise constraint, interpreted as y <sign> f(x)."""
-    name: tuple[str, ...] = field(default_factory=tuple)
+    name: str | Iterable[str] | None = field(default_factory=tuple)
     """Optional filter for a component name to apply the piecewise constraint to, e.g. a specific generator."""
     method: str = "auto"
     """The method to use for the piecewise constraint formulation, passed to linopy's add_piecewise_formulation method."""
@@ -48,7 +46,7 @@ class PiecewiseOptions:
     If False, the nominal values at each x breakpoint will be used to define y breakpoints."""
 
     def __post_init__(self) -> None:
-        """Ensure that name is stored as a list for consistent processing later."""
+        """Ensure that name is stored as a tuple for consistent processing later."""
         list_names = (
             ()
             if self.name is None
@@ -138,7 +136,9 @@ def define_piecewise(
     if y_var is None:
         y_var = _create_y_var(m, x_var, pw_names, aux_var_name)
     y_var_sel = y_var.sel(name=pw_names)
-    sorted_options = sorted(extra_options, key=lambda x: x.name, reverse=True)
+    sorted_options = sorted(
+        extra_options, key=lambda x: tuple(x.name or ()), reverse=True
+    )
     for option in [*sorted_options, None]:
         if option is None:
             names, aux, opt_method, opt_sign = (
@@ -148,10 +148,7 @@ def define_piecewise(
                 sign,
             )
         elif option.name:
-            names = pd.Index(
-                [option.name] if isinstance(option.name, str) else option.name,
-                name="name",
-            ).intersection(pw_names)
+            names = pd.Index(option.name, name="name").intersection(pw_names)
             aux_suffix = (
                 "_".join(names) if len(names) <= 3 else f"{names[0]}_..._{names[-1]}"
             )
@@ -250,12 +247,14 @@ def _get_breakpoints(
             raise ValueError(msg)
         x_da = x_da * nom_attr_da
     x_da = x_da.where(valid_breakpoints)
-    x_breakpoints = breakpoints(x_da)
-    if marginal_attr:
-        slopes = y_da.shift({BREAKPOINT_DIM: -1})
-        y_breakpoints = Slopes(slopes, y0=0).to_breakpoints(x_da)
-    else:
-        y_breakpoints = breakpoints((y_da * x_da).where(valid_breakpoints))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=EvolvingAPIWarning)
+        x_breakpoints = breakpoints(x_da)
+        if marginal_attr:
+            slopes = y_da.shift({BREAKPOINT_DIM: -1})
+            y_breakpoints = Slopes(slopes, y0=0).to_breakpoints(x_da)
+        else:
+            y_breakpoints = breakpoints((y_da * x_da).where(valid_breakpoints))
     return x_breakpoints, y_breakpoints
 
 

--- a/pypsa/optimization/piecewise.py
+++ b/pypsa/optimization/piecewise.py
@@ -298,10 +298,8 @@ def _create_y_var(
     aux_var_name: str,
 ) -> Variable:
     """Create auxiliary y variable for piecewise constraint."""
-    extra_dims = [d for d in x_var.dims if d != "name"]
-    coords = [x_var.coords[d].values for d in extra_dims] + [pw_names]
-    dims = extra_dims + ["name"]
-    y_var = m.add_variables(coords=coords, dims=dims, name=aux_var_name)
+    coords = x_var.coords.drop_dims("name", errors="ignore").assign(name=pw_names)
+    y_var = m.add_variables(coords=coords, name=aux_var_name)
     return y_var
 
 

--- a/pypsa/optimization/piecewise.py
+++ b/pypsa/optimization/piecewise.py
@@ -35,7 +35,7 @@ class PiecewiseOptions:
     """Component attribute for which piecewise data is defined."""
     sign: SIGNS_T
     """Sign for the piecewise constraint, interpreted as y <sign> f(x)."""
-    name: str | Iterable[str] | None = field(default_factory=tuple)
+    name: tuple[str, ...] = field(default_factory=tuple)
     """Optional filter for a component name to apply the piecewise constraint to, e.g. a specific generator."""
     method: str = "auto"
     """The method to use for the piecewise constraint formulation, passed to linopy's add_piecewise_formulation method."""
@@ -136,9 +136,7 @@ def define_piecewise(
     if y_var is None:
         y_var = _create_y_var(m, x_var, pw_names, aux_var_name)
     y_var_sel = y_var.sel(name=pw_names)
-    sorted_options = sorted(
-        extra_options, key=lambda x: tuple(x.name or ()), reverse=True
-    )
+    sorted_options = sorted(extra_options, key=lambda x: x.name, reverse=True)
     for option in [*sorted_options, None]:
         if option is None:
             names, aux, opt_method, opt_sign = (

--- a/test/test_add_piecewise.py
+++ b/test/test_add_piecewise.py
@@ -237,18 +237,54 @@ class TestPiecewiseErrors:
         n = base_network
         mi_df = _make_multiindex_df("WRONG_X", "marginal_cost", ["gen"])
         with pytest.raises(
-            ValueError, match="Piecewise marginal_cost Dataframe has name column"
+            ValueError, match="Piecewise marginal_cost Dataframe has attribute column"
         ):
             n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=mi_df)
 
     def test_multiindex_df_wrong_attribute_labels_raises_y(self, base_network):
-        """MultiIndex input with wrong attribute-level labels is rejected."""
+        """MultiIndex input with wrong name-level labels is rejected."""
         n = base_network
         mi_df = _make_multiindex_df("p_pu", "WRONG_Y", ["gen"])
         with pytest.raises(
             ValueError, match="Piecewise marginal_cost Dataframe has attribute column"
         ):
             n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=mi_df)
+
+    def test_multiindex_df_wrong_attribute_labels_raises_name(self, base_network):
+        """MultiIndex input with wrong attribute-level labels is rejected."""
+        n = base_network
+        mi_df = _make_multiindex_df("p_pu", "marginal_cost", ["WRONG_NAME"])
+        with pytest.raises(
+            ValueError, match="Piecewise marginal_cost Dataframe has name column"
+        ):
+            n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=mi_df)
+
+    @pytest.mark.parametrize(
+        ("component", "attr"),
+        [
+            ("Process", "rate0"),
+            ("Process", "rate1"),
+            ("Link", "efficiency"),
+            ("Link", "efficiency2"),
+        ],
+    )
+    def test_multiport_pos_neg_mix_raises(self, base_network, component, attr):
+        """Multi-port piecewise attrs must not mix positive and negative values."""
+        n = base_network
+        curve = pd.DataFrame({"p_pu": [0.0, 0.5, 1.0], attr: [1.0, -0.7, 0.4]})
+        with pytest.raises(
+            NotImplementedError,
+            match=f"Cannot mix positive and negative values for piecewise {attr} curves",
+        ):
+            n.add(
+                component,
+                "foo",
+                bus0="bus_ac",
+                bus1="bus_ac2",
+                bus2="bus_dc",
+                p_nom=100,
+                **{attr: curve},
+            )
 
     @pytest.mark.parametrize(
         ("comp", "extendable_kwargs", "attr"), EXTENDABLE_PU_RAISES_PARAMS

--- a/test/test_add_piecewise.py
+++ b/test/test_add_piecewise.py
@@ -232,11 +232,22 @@ class TestPiecewiseErrors:
         with pytest.raises(NotImplementedError, match="Dictionaries are not supported"):
             n.add("Generator", "gen", bus="bus_ac", p_nom={0: 100})
 
-    def test_multiindex_df_wrong_attribute_labels_raises(self, base_network):
+    def test_multiindex_df_wrong_attribute_labels_raises_x(self, base_network):
         """MultiIndex input with wrong attribute-level labels is rejected."""
         n = base_network
         mi_df = _make_multiindex_df("WRONG_X", "marginal_cost", ["gen"])
-        with pytest.raises(ValueError, match="must have column labels"):
+        with pytest.raises(
+            ValueError, match="Piecewise marginal_cost Dataframe has name column"
+        ):
+            n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=mi_df)
+
+    def test_multiindex_df_wrong_attribute_labels_raises_y(self, base_network):
+        """MultiIndex input with wrong attribute-level labels is rejected."""
+        n = base_network
+        mi_df = _make_multiindex_df("p_pu", "WRONG_Y", ["gen"])
+        with pytest.raises(
+            ValueError, match="Piecewise marginal_cost Dataframe has attribute column"
+        ):
             n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=mi_df)
 
     @pytest.mark.parametrize(

--- a/test/test_add_piecewise.py
+++ b/test/test_add_piecewise.py
@@ -232,6 +232,13 @@ class TestPiecewiseErrors:
         with pytest.raises(NotImplementedError, match="Dictionaries are not supported"):
             n.add("Generator", "gen", bus="bus_ac", p_nom={0: 100})
 
+    def test_multiindex_df_wrong_attribute_labels_raises(self, base_network):
+        """MultiIndex input with wrong attribute-level labels is rejected."""
+        n = base_network
+        mi_df = _make_multiindex_df("WRONG_X", "marginal_cost", ["gen"])
+        with pytest.raises(ValueError, match="must have column labels"):
+            n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=mi_df)
+
     @pytest.mark.parametrize(
         ("comp", "extendable_kwargs", "attr"), EXTENDABLE_PU_RAISES_PARAMS
     )
@@ -253,3 +260,27 @@ class TestPiecewiseErrors:
         n = base_network
         n.add(comp, "c1", **extendable_kwargs, **{attr: CURVE_DICT})
         assert not n.components[comp].piecewise[attr].empty
+
+
+def test_remove_drops_piecewise_data(base_network):
+    """Removed components must not leave stale piecewise curves behind."""
+    n = base_network
+    n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=CURVE_DICT)
+    n.remove("Generator", "gen")
+    assert n.c.generators.piecewise["marginal_cost"].empty
+    n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=5.0)
+    assert n.c.generators.piecewise["marginal_cost"].empty
+
+
+class TestPiecewiseScenarios:
+    def test_add_piecewise_on_stochastic_network_raises(self, base_network):
+        n = base_network
+        n.set_scenarios({"low": 0.5, "high": 0.5})
+        with pytest.raises(NotImplementedError, match="not yet supported"):
+            n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=CURVE_DICT)
+
+    def test_set_scenarios_with_piecewise_data_raises(self, base_network):
+        n = base_network
+        n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=CURVE_DICT)
+        with pytest.raises(NotImplementedError, match="not yet supported"):
+            n.set_scenarios({"low": 0.5, "high": 0.5})

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -103,7 +103,7 @@ class TestCSVDir:
         fn = tmpdir / "csv_piecewise"
         piecewise_network.export_to_csv_folder(fn)
         imported = pypsa.Network(fn)
-        custom_equals(piecewise_network, imported)
+        assert custom_equals(piecewise_network, imported)
 
     def test_csv_io_multiindexed(self, ac_dc_periods, tmpdir):
         fn = tmpdir / "csv_export"
@@ -194,7 +194,7 @@ class TestNetcdf:
         ds = piecewise_network.export_to_netcdf(path=None)
         imported = pypsa.Network()
         imported.import_from_netcdf(ds)
-        custom_equals(piecewise_network, imported)
+        assert custom_equals(piecewise_network, imported)
 
     def test_netcdf_io_datetime(self, tmpdir):
         fn = tmpdir / "temp.nc"
@@ -340,7 +340,7 @@ class TestHDF5:
         fn = tmpdir / "hdf5_piecewise.h5"
         piecewise_network.export_to_hdf5(fn)
         imported = pypsa.Network(fn)
-        custom_equals(piecewise_network, imported)
+        assert custom_equals(piecewise_network, imported)
 
     def test_hdf5_io_multiindexed(self, ac_dc_periods, tmpdir):
         fn = tmpdir / "hdf5_export.h5"
@@ -431,7 +431,7 @@ class TestExcelIO:
         fn = tmpdir / "excel_piecewise.xlsx"
         piecewise_network.export_to_excel(fn)
         imported = pypsa.Network(fn)
-        custom_equals(piecewise_network, imported)
+        assert custom_equals(piecewise_network, imported)
 
     def test_excel_io_datetime(self, tmpdir):
         fn = tmpdir / "temp.xlsx"

--- a/test/test_lopf_piecewise_costs.py
+++ b/test/test_lopf_piecewise_costs.py
@@ -231,3 +231,98 @@ class TestPiecewiseCostsResults:
         assert n.c.generators.static.capital_cost_piecewise_opt.equals(
             pd.Series({"gen0": 0.0, "gen1": 1.4})
         )
+
+
+def test_storage_unit_piecewise_marginal_cost() -> None:
+    """Regression: StorageUnit piecewise marginal cost applies to the dispatch variable."""
+    n = pypsa.Network()
+    n.set_snapshots(range(2))
+    n.add("Bus", "bus0")
+    n.add("Generator", "gen0", bus="bus0", p_nom=100, marginal_cost=50)
+    n.add(
+        "StorageUnit",
+        "su0",
+        bus="bus0",
+        p_nom=100,
+        max_hours=1,
+        state_of_charge_initial=100,
+        marginal_cost={0.0: 10.0, 1.0: 10.0},
+    )
+    n.add("Load", "load", bus="bus0", p_set=50)
+    status, _ = n.optimize()
+    assert status == "ok"
+    assert "StorageUnit-marginal_cost_piecewise" in n.model.variables
+    assert n.objective == pytest.approx(10 * 50 * 2, rel=1e-6)
+    assert n.c.storage_units.dynamic.p["su0"].sum() == pytest.approx(100.0, rel=1e-6)
+
+
+def test_store_piecewise_marginal_cost_applies_to_dispatch() -> None:
+    """Store piecewise marginal cost prices dispatch ``p``, not the storage level."""
+    n = pypsa.Network()
+    n.set_snapshots(range(2))
+    n.add("Bus", "bus0")
+    n.add("Generator", "gen0", bus="bus0", p_nom=100, marginal_cost=50)
+    n.add(
+        "Store",
+        "store0",
+        bus="bus0",
+        e_nom=100,
+        e_initial=100,
+        marginal_cost={0.0: 10.0, 1.0: 10.0},
+    )
+    n.add("Load", "load", bus="bus0", p_set=50)
+    status, _ = n.optimize()
+    assert status == "ok"
+    assert "Store-marginal_cost_piecewise" in n.model.variables
+    assert n.objective == pytest.approx(10 * 50 * 2, rel=1e-6)
+    assert n.c.stores.dynamic.p["store0"].sum() == pytest.approx(100.0, rel=1e-6)
+
+
+def test_multi_invest_piecewise_capital_cost() -> None:
+    """A constant-slope piecewise capital cost matches its linear equivalent."""
+
+    def build(piecewise: bool) -> pypsa.Network:
+        n = pypsa.Network(snapshots=range(2))
+        n.investment_periods = [2020, 2030]
+        n.add("Bus", "bus0")
+        capital_cost: Any = {0.0: 2.0, 100.0: 2.0} if piecewise else 2.0
+        n.add(
+            "Generator",
+            "gen0",
+            bus="bus0",
+            p_nom_extendable=True,
+            p_nom_max=100,
+            build_year=2020,
+            lifetime=30,
+            capital_cost=capital_cost,
+            marginal_cost=1,
+        )
+        n.add("Load", "load", bus="bus0", p_set=50)
+        n.optimize(multi_investment_periods=True)
+        return n
+
+    n_pw = build(piecewise=True)
+    n_lin = build(piecewise=False)
+    assert n_pw.objective == pytest.approx(n_lin.objective)
+    assert n_pw.c.generators.static.p_nom_opt.item() == pytest.approx(
+        n_lin.c.generators.static.p_nom_opt.item()
+    )
+
+
+def test_piecewise_capital_cost_with_overnight_cost_raises() -> None:
+    """Defining overnight_cost next to a piecewise capital_cost curve is ambiguous."""
+    n = pypsa.Network(snapshots=range(2))
+    n.add("Bus", "bus0")
+    n.add(
+        "Generator",
+        "gen0",
+        bus="bus0",
+        p_nom_extendable=True,
+        p_nom_max=100,
+        capital_cost={0.0: 2.0, 100.0: 2.0},
+        overnight_cost=1000,
+        lifetime=20,
+    )
+    n.add("Load", "load", bus="bus0", p_set=50)
+    with pytest.raises(ValueError, match="overnight_cost"):
+        n.optimize.create_model(include_objective_constant=False)

--- a/test/test_lopf_piecewise_costs.py
+++ b/test/test_lopf_piecewise_costs.py
@@ -232,97 +232,94 @@ class TestPiecewiseCostsResults:
             pd.Series({"gen0": 0.0, "gen1": 1.4})
         )
 
-
-def test_storage_unit_piecewise_marginal_cost() -> None:
-    """Regression: StorageUnit piecewise marginal cost applies to the dispatch variable."""
-    n = pypsa.Network()
-    n.set_snapshots(range(2))
-    n.add("Bus", "bus0")
-    n.add("Generator", "gen0", bus="bus0", p_nom=100, marginal_cost=50)
-    n.add(
-        "StorageUnit",
-        "su0",
-        bus="bus0",
-        p_nom=100,
-        max_hours=1,
-        state_of_charge_initial=100,
-        marginal_cost={0.0: 10.0, 1.0: 10.0},
-    )
-    n.add("Load", "load", bus="bus0", p_set=50)
-    status, _ = n.optimize()
-    assert status == "ok"
-    assert "StorageUnit-marginal_cost_piecewise" in n.model.variables
-    assert n.objective == pytest.approx(10 * 50 * 2, rel=1e-6)
-    assert n.c.storage_units.dynamic.p["su0"].sum() == pytest.approx(100.0, rel=1e-6)
-
-
-def test_store_piecewise_marginal_cost_applies_to_dispatch() -> None:
-    """Store piecewise marginal cost prices dispatch ``p``, not the storage level."""
-    n = pypsa.Network()
-    n.set_snapshots(range(2))
-    n.add("Bus", "bus0")
-    n.add("Generator", "gen0", bus="bus0", p_nom=100, marginal_cost=50)
-    n.add(
-        "Store",
-        "store0",
-        bus="bus0",
-        e_nom=100,
-        e_initial=100,
-        marginal_cost={0.0: 10.0, 1.0: 10.0},
-    )
-    n.add("Load", "load", bus="bus0", p_set=50)
-    status, _ = n.optimize()
-    assert status == "ok"
-    assert "Store-marginal_cost_piecewise" in n.model.variables
-    assert n.objective == pytest.approx(10 * 50 * 2, rel=1e-6)
-    assert n.c.stores.dynamic.p["store0"].sum() == pytest.approx(100.0, rel=1e-6)
-
-
-def test_multi_invest_piecewise_capital_cost() -> None:
-    """A constant-slope piecewise capital cost matches its linear equivalent."""
-
-    def build(piecewise: bool) -> pypsa.Network:
-        n = pypsa.Network(snapshots=range(2))
-        n.investment_periods = [2020, 2030]
+    def test_storage_unit_piecewise_marginal_cost(self) -> None:
+        """StorageUnit piecewise marginal cost applies to the dispatch variable."""
+        n = pypsa.Network()
+        n.set_snapshots(range(2))
         n.add("Bus", "bus0")
-        capital_cost: Any = {0.0: 2.0, 100.0: 2.0} if piecewise else 2.0
+        n.add("Generator", "gen0", bus="bus0", p_nom=100, marginal_cost=50)
+        n.add(
+            "StorageUnit",
+            "su0",
+            bus="bus0",
+            p_nom=100,
+            max_hours=1,
+            state_of_charge_initial=75,
+            marginal_cost={0.0: 0.0, 0.5: 3.0, 1.0: 10.0},
+        )
+        n.add("Load", "load", bus="bus0", p_set=50)
+        n.optimize()
+
+        mc = n.c.storage_units.dynamic.marginal_cost_piecewise_opt["su0"]
+        p = n.c.storage_units.dynamic.p["su0"]
+        assert n.objective == pytest.approx((mc * p).sum() + (25 * 50), rel=1e-6)
+
+    def test_store_piecewise_marginal_cost_applies_to_dispatch(self) -> None:
+        """Store piecewise marginal cost prices dispatch ``p``, not the storage level."""
+        n = pypsa.Network()
+        n.set_snapshots(range(2))
+        n.add("Bus", "bus0")
+        n.add("Generator", "gen0", bus="bus0", p_nom=100, marginal_cost=50)
+        n.add(
+            "Store",
+            "store0",
+            bus="bus0",
+            e_nom=100,
+            e_initial=75,
+            marginal_cost={0.0: 0.0, 0.5: 3.0, 1.0: 10.0},
+        )
+        n.add("Load", "load", bus="bus0", p_set=50)
+        n.optimize()
+        mc = n.c.stores.dynamic.marginal_cost_piecewise_opt["store0"]
+        p = n.c.stores.dynamic.p["store0"]
+        assert n.objective == pytest.approx((mc * p).sum() + (25 * 50), rel=1e-6)
+
+    def test_multi_invest_piecewise_capital_cost(self) -> None:
+        """A constant-slope piecewise capital cost matches its linear equivalent."""
+
+        def build(piecewise: bool) -> pypsa.Network:
+            n = pypsa.Network(snapshots=range(2))
+            n.investment_periods = [2020, 2030]
+            n.add("Bus", "bus0")
+            capital_cost: Any = {0.0: 2.0, 100.0: 2.0} if piecewise else 2.0
+            n.add(
+                "Generator",
+                "gen0",
+                bus="bus0",
+                p_nom_extendable=True,
+                p_nom_max=100,
+                build_year=2020,
+                lifetime=30,
+                capital_cost=capital_cost,
+                marginal_cost=1,
+            )
+            n.add("Load", "load", bus="bus0", p_set=50)
+            n.optimize(multi_investment_periods=True)
+            return n
+
+        n_pw = build(piecewise=True)
+        n_lin = build(piecewise=False)
+        assert n_pw.objective == pytest.approx(n_lin.objective)
+        assert n_pw.c.generators.static.p_nom_opt.item() == pytest.approx(
+            n_lin.c.generators.static.p_nom_opt.item()
+        )
+
+
+class TestPiecewiseCostsErrors:
+    def test_piecewise_capital_cost_with_overnight_cost_raises(self) -> None:
+        """Defining overnight_cost next to a piecewise capital_cost curve is ambiguous."""
+        n = pypsa.Network(snapshots=range(2))
+        n.add("Bus", "bus0")
         n.add(
             "Generator",
             "gen0",
             bus="bus0",
             p_nom_extendable=True,
             p_nom_max=100,
-            build_year=2020,
-            lifetime=30,
-            capital_cost=capital_cost,
-            marginal_cost=1,
+            capital_cost={0.0: 2.0, 100.0: 2.0},
+            overnight_cost=1000,
+            lifetime=20,
         )
         n.add("Load", "load", bus="bus0", p_set=50)
-        n.optimize(multi_investment_periods=True)
-        return n
-
-    n_pw = build(piecewise=True)
-    n_lin = build(piecewise=False)
-    assert n_pw.objective == pytest.approx(n_lin.objective)
-    assert n_pw.c.generators.static.p_nom_opt.item() == pytest.approx(
-        n_lin.c.generators.static.p_nom_opt.item()
-    )
-
-
-def test_piecewise_capital_cost_with_overnight_cost_raises() -> None:
-    """Defining overnight_cost next to a piecewise capital_cost curve is ambiguous."""
-    n = pypsa.Network(snapshots=range(2))
-    n.add("Bus", "bus0")
-    n.add(
-        "Generator",
-        "gen0",
-        bus="bus0",
-        p_nom_extendable=True,
-        p_nom_max=100,
-        capital_cost={0.0: 2.0, 100.0: 2.0},
-        overnight_cost=1000,
-        lifetime=20,
-    )
-    n.add("Load", "load", bus="bus0", p_set=50)
-    with pytest.raises(ValueError, match="overnight_cost"):
-        n.optimize.create_model(include_objective_constant=False)
+        with pytest.raises(ValueError, match="overnight_cost"):
+            n.optimize.create_model(include_objective_constant=False)

--- a/test/test_lopf_piecewise_efficiency.py
+++ b/test/test_lopf_piecewise_efficiency.py
@@ -97,13 +97,15 @@ def test_piecewise_efficiency_gen() -> None:
     n = pypsa.Network()
     n.add("Bus", "bus0")
     n.add("Carrier", "gas", co2_emissions=1.0)
+    x_points = np.array([0.1, 0.5, 1.0])
+    y_points = np.array([0.3, 0.4, 0.6])
     n.add(
         "Generator",
         "gen0",
         carrier="gas",
         bus="bus0",
         p_nom=70,
-        marginal_cost=20,
+        marginal_cost=25,
         efficiency=0.5,
     )
     n.add(
@@ -113,7 +115,7 @@ def test_piecewise_efficiency_gen() -> None:
         bus="bus0",
         p_nom=70,
         marginal_cost=20,
-        efficiency={0.1: 0.3, 0.5: 0.4, 1.0: 0.6},
+        efficiency=pd.DataFrame({"p_pu": x_points, "efficiency": y_points}),
     )
     n.add(
         "GlobalConstraint",
@@ -125,11 +127,9 @@ def test_piecewise_efficiency_gen() -> None:
     n.add("Load", "load", bus="bus0", p_set=80)
     n.optimize()
     p = n.generators_t.p.iloc[0]
-    assert p.sum() == pytest.approx(80.0, rel=1e-6)
-    assert n.objective == pytest.approx(20 * 80, rel=1e-6)
-    x_points = np.array([0.1, 0.5, 1.0]) * 70
-    fuel_points = x_points / np.array([0.3, 0.4, 0.6])
-    fuel = p["gen0"] / 0.5 + np.interp(p["gen1"], x_points, fuel_points)
+    fuel = p["gen0"] / 0.5 + np.interp(
+        p["gen1"], 70 * x_points, 70 * x_points / y_points
+    )
     assert fuel <= 160 * (1 + 1e-6)
 
 

--- a/test/test_lopf_piecewise_efficiency.py
+++ b/test/test_lopf_piecewise_efficiency.py
@@ -93,7 +93,7 @@ def test_piecewise_efficiency_two_primary_energy_constraints(
 
 
 def test_piecewise_efficiency_gen() -> None:
-    """The dispatch split is cost-degenerate, so only assert properties unique to the optimum."""
+    """gen0 is cheaper but cannot meet all load without hitting co2 limit. Gen1 comes in based on its piecewise curve rate."""
     n = pypsa.Network()
     n.add("Bus", "bus0")
     n.add("Carrier", "gas", co2_emissions=1.0)
@@ -105,8 +105,8 @@ def test_piecewise_efficiency_gen() -> None:
         carrier="gas",
         bus="bus0",
         p_nom=70,
-        marginal_cost=25,
-        efficiency=0.5,
+        marginal_cost=15,
+        efficiency=0.35,
     )
     n.add(
         "Generator",
@@ -127,7 +127,7 @@ def test_piecewise_efficiency_gen() -> None:
     n.add("Load", "load", bus="bus0", p_set=80)
     n.optimize()
     p = n.generators_t.p.iloc[0]
-    fuel = p["gen0"] / 0.5 + np.interp(
+    fuel = p["gen0"] / 0.35 + np.interp(
         p["gen1"], 70 * x_points, 70 * x_points / y_points
     )
     assert fuel <= 160 * (1 + 1e-6)

--- a/test/test_lopf_piecewise_efficiency.py
+++ b/test/test_lopf_piecewise_efficiency.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -74,8 +75,25 @@ def test_piecewise_efficiency_co2_constraint_with_only_segmented_gens(
     assert n.generators_t.p["gen"].iloc[0] == pytest.approx(50.0, rel=1e-3)
 
 
+def test_piecewise_efficiency_two_primary_energy_constraints(
+    piecewise_efficiency_network: pypsa.Network,
+) -> None:
+    """Regression: multiple primary-energy constraints share one piecewise aux variable."""
+    n = piecewise_efficiency_network
+    n.add(
+        "GlobalConstraint",
+        "co2_limit2",
+        sense="<=",
+        carrier_attribute="co2_emissions",
+        constant=170,
+    )
+    status, _ = n.optimize()
+    assert status == "ok"
+    assert n.generators_t.p["gen"].iloc[0] == pytest.approx(50.0, rel=1e-3)
+
+
 def test_piecewise_efficiency_gen() -> None:
-    """We get a somewhat arbitrary solution as the optimisation problem aims to hit the CO2 limit exactly."""
+    """The dispatch split is cost-degenerate, so only assert properties unique to the optimum."""
     n = pypsa.Network()
     n.add("Bus", "bus0")
     n.add("Carrier", "gas", co2_emissions=1.0)
@@ -106,8 +124,13 @@ def test_piecewise_efficiency_gen() -> None:
     )
     n.add("Load", "load", bus="bus0", p_set=80)
     n.optimize()
-    assert n.generators_t.p["gen1"].item() == pytest.approx(50.0, rel=1e-3)
-    assert n.generators_t.p["gen0"].item() == pytest.approx(30.0, rel=1e-3)
+    p = n.generators_t.p.iloc[0]
+    assert p.sum() == pytest.approx(80.0, rel=1e-6)
+    assert n.objective == pytest.approx(20 * 80, rel=1e-6)
+    x_points = np.array([0.1, 0.5, 1.0]) * 70
+    fuel_points = x_points / np.array([0.3, 0.4, 0.6])
+    fuel = p["gen0"] / 0.5 + np.interp(p["gen1"], x_points, fuel_points)
+    assert fuel <= 160 * (1 + 1e-6)
 
 
 class TestPiecewiseMultiPort2Bus:
@@ -211,6 +234,30 @@ class TestPiecewiseMultiPort2Bus:
         expected_p1 = -1 * expected_p
         pd.testing.assert_series_equal(n.c[comp].dynamic.p1.squeeze(), expected_p1)
 
+    def test_piecewise_efficiency_with_delay(
+        self, base_network: pypsa.Network, base_multiport_attrs: dict
+    ) -> None:
+        """Regression: piecewise port relations are defined once on the undelayed
+        dispatch variable; mixed delay groups must not collide and the delayed
+        group shifts the auxiliary variable in time."""
+        n = base_network
+        n.add(
+            "Process",
+            rate1={0.1: 0.3, 0.5: 0.4, 1.0: 0.6},
+            delay1=1,
+            **base_multiport_attrs,
+        )
+        n.add(
+            "Process",
+            rate1={0.1: 0.3, 0.5: 0.4, 1.0: 0.6},
+            **{**base_multiport_attrs, "name": "multiport2"},
+        )
+        status, _ = n.optimize()
+        assert status == "ok"
+        load = pd.Series([20.0, 30.0, 40.0]).rename_axis(index="snapshot")
+        supply = -n.c.processes.dynamic.p1.sum(axis=1)
+        pd.testing.assert_series_equal(supply, load, check_names=False)
+
 
 class TestPiecewiseMultiPort3Bus:
     @pytest.fixture
@@ -289,3 +336,5 @@ class TestPiecewiseMultiPort3Bus:
             -1 * n.model.variables[f"{comp}-p2_piecewise"].solution.to_pandas()
         )
         pd.testing.assert_frame_equal(n.c[comp].dynamic.p2, expected_p2)
+        # The auxiliary variable feeds p2; it must not leak as its own output.
+        assert "p2_piecewise_opt" not in n.c[comp].dynamic

--- a/test/test_optimization_expressions.py
+++ b/test/test_optimization_expressions.py
@@ -309,3 +309,33 @@ class TestExpressionsWithPiecewise:
         assert "piecewise" not in str(
             expr.sel(component=["Generator", "StorageUnit", "Load"])
         )
+
+    def test_expressions_supply_withdrawal(self, piecewise_network_built):
+        """A positive piecewise port counts as supply, never as withdrawal."""
+        n = piecewise_network_built
+        supply = n.optimize.expressions.supply().unstack("group")
+        assert "Link-p1_piecewise" in str(supply.sel(component="Link", carrier="AC"))
+        withdrawal = n.optimize.expressions.withdrawal().unstack("group")
+        assert "piecewise" not in str(withdrawal.sel(component="Link", carrier="AC"))
+
+    def test_supply_withdrawal_with_negative_piecewise_port(self):
+        """A negative piecewise port counts as withdrawal, reported positive."""
+        n = pypsa.Network()
+        n.set_snapshots(range(2))
+        n.add("Bus", ["bus0", "bus1"])
+        n.add("Generator", "gen0", bus="bus0", p_nom=150, marginal_cost=5)
+        n.add(
+            "Process",
+            "proc",
+            bus0="bus0",
+            bus1="bus1",
+            p_nom=100,
+            rate0={0.1: -1 / 0.3, 0.5: -1 / 0.4, 1.0: -1 / 0.6},
+            rate1=1,
+        )
+        n.add("Load", "load", bus="bus1", p_set=[20, 30])
+        n.optimize.create_model(include_objective_constant=False)
+        withdrawal = n.optimize.expressions.withdrawal().unstack("group")
+        supply = n.optimize.expressions.supply().unstack("group")
+        assert "-1 Process-p0_piecewise" in str(withdrawal.sel(component="Process"))
+        assert "p0_piecewise" not in str(supply.sel(component="Process"))


### PR DESCRIPTION
Iterating with Claude on bugs (may still include false positives). All combined here

> [!Note]
> AI generated summary and code

Targets #1603. Addresses the must-fix findings from a structured review of the branch diff, plus three follow-up design decisions.

## Crashes fixed
- **≥2 `primary_energy` constraints + piecewise efficiency**: `define_piecewise` was called per constraint/scenario with a fixed aux name → duplicate-variable error. The primary-energy relation is now defined once and each constraint selects from it.
- **Piecewise port coefficients + delays**: duplicate aux var per delay group, and the delayed branch passed a `LinearExpression` as `x_var` (`_term` dim crash). Nodal balance now defines each port's piecewise relation once on the *undelayed* dispatch variable and time-shifts the aux variable for delayed groups — consistent with what `assign_solution` already assumed.
- Latent `NameError` in `_Multiport._piecewise_attrs` (`extra_rows` rebound/unbound).

## Silent wrong results fixed
- **StorageUnit piecewise `marginal_cost`** was accepted but silently dropped from the objective (looked up nonexistent `StorageUnit-p`); now wired to `p_dispatch` end-to-end.
- **Store piecewise `marginal_cost`** applied to the storage level `e`; now applies to dispatch `p`, consistent with linear `marginal_cost` (x per unit `e_nom`).
- **Spurious `p{i}_piecewise_opt` outputs** (efficiency ratios mislabeled as power) for Link ports ≥2 and all Process ports — `assign_solution` skip condition now uses `_get_base_coeff`.
- **`remove()` left stale piecewise curves**; a re-added component silently inherited the old curve.
- **`overnight_cost` + piecewise `capital_cost`** silently skipped annuitization → now a `ValueError` (the curve must already be periodized).
- **`TODO-1603` supply/withdrawal sign resolved**: piecewise ports are classified like linear ones by curve sign — positive → supply, negative → withdrawal (reported positive), mixed-sign → `NotImplementedError`.

## Fail fast instead of crash
- **Scenarios + piecewise** crashed in both orders (add-then-`set_scenarios` and reverse); both now raise `NotImplementedError` until stochastic support lands.
- **Dead/inverted MultiIndex column validation** in `n.add` (`Index.equals(list)` is always `False`) fixed to a set comparison.

## API
- `piecewise_options` is no longer a required positional parameter of the public `define_nodal_balance_constraints` (was inserted mid-signature), `define_objective`, `define_primary_energy_limit` — now `| None = None` appended at the end (backward compatible).
- `PiecewiseOptions.name` annotation matches accepted inputs (`str | Iterable[str] | None`).
- Removed module-level `warnings.filterwarnings` mutating global state on `import pypsa` (scoped suppression retained); removed write-only `piecewise_y_vars`; fixed stale `_import_piecewise_from_df` docstring and the broken docs CSV include path.

## Tests
- The four piecewise IO round-trip tests asserted nothing: `Components.equals` now compares `piecewise` and the tests assert the result.
- `test_piecewise_efficiency_gen` asserted an arbitrary vertex of a cost-degenerate optimum; now asserts load balance, objective, and CO2 feasibility.
- Multi-invest + piecewise capex verified consistent with the linear path and pinned by test (constant-slope curve ≡ linear equivalent).
- New regression tests: two primary-energy constraints, piecewise+delay with mixed groups, no leaked `p{i}_piecewise_opt`, StorageUnit/Store dispatch pricing, supply/withdrawal for positive and negative curves, remove-then-re-add, scenario fail-fasts, malformed MultiIndex input, overnight-cost conflict.

## Deferred (nice-to-haves, not in this PR)
Duplicated capex/opex aux-var lookup block; byte-identical Link/Process branches in `port_efficiency`; dead committable `cost_piecewise_opt` term; dead Excel sheet-name mappings (long `*_piecewise_opt` names still unmapped); sign-only statistics assertions; linopy-repr string assertions; `ComponentsData.piecewise` required field; `_Importer.get_piecewise` not declared on the ABC; unvalidated `sign`/`method` at the dict boundary (docs example uses `"sign": "=="`).

## Checklist
- [x] Unit tests for new features were added.
- [ ] Release notes — covered by #1603 itself.
- [x] I consent to the release of this PR's code under the MIT license.