### PR TITLE
fix: keep dynamic results of components added after previous assignment

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,7 +25,7 @@ Added compatibility with stricter dimension alignment handling in (upcoming)lino
 
 - Fix optimization results being silently zeroed for components which are not
   yet present in the existing dynamic result data. Regression introduced in
-  `v1.2.0`. (<!-- md:pr 1723 -->)
+  `v1.2.0`. (<!-- md:pr 1726 -->)
 
 - Avoid redundant traces and legends in interactive statistics bar plots when
   the color dimension duplicates an axis. (<!-- md:pr -->)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -23,6 +23,10 @@ Added compatibility with stricter dimension alignment handling in (upcoming)lino
 
 ### Bug Fixes
 
+- Fix optimization results being silently zeroed for components which are not
+  yet present in the existing dynamic result data. Regression introduced in
+  `v1.2.0`. (<!-- md:pr 1723 -->)
+
 - Avoid redundant traces and legends in interactive statistics bar plots when
   the color dimension duplicates an axis. (<!-- md:pr -->)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "pytest-cov",
     "pytest-mpl",
     "coverage",
+    "matplotlib<3.11", # remove when uv.lock is tracked
     "pypower",
     "pandapower>=2.14.11",
     "scikit-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,9 @@ filterwarnings = [
     # Ignore linopy warnings
     "default:Coordinates across variables not equal. Perform outer join.:UserWarning",
     "ignore:In a future version of xarray the default value for join will change:FutureWarning",
+
+    # Ignore pandas<3.0.3 usage of the deprecated `locs` attribute of matplotlib>=3.11
+    "ignore:The locs attribute was deprecated:DeprecationWarning",
 ]
 markers = [
     "mpl_image_compare",

--- a/pypsa/optimization/common.py
+++ b/pypsa/optimization/common.py
@@ -53,7 +53,7 @@ def _set_dynamic_data(n: Network, component: str, attr: str, df: pd.DataFrame) -
         c.dynamic[attr] = df.reindex(n.snapshots)
 
     else:
-        c.dynamic[attr].update(df)
+        c.dynamic[attr] = df.combine_first(c.dynamic[attr])
 
     # Reindex to match network snapshots and component names
     result = c.dynamic[attr].reindex(n.snapshots, level="snapshot", axis=0)

--- a/test/test_optimization_common.py
+++ b/test/test_optimization_common.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+
+import pypsa
+from pypsa.optimization.common import _set_dynamic_data
+
+
+def test_set_dynamic_data_preserves_and_extends_columns():
+    """Dynamic data of components added after a previous assignment must not be lost.
+
+    See https://github.com/PyPSA/PyPSA/issues/1723.
+    """
+    n = pypsa.Network()
+    n.set_snapshots(range(3))
+    n.add("Bus", "b")
+    n.add("Load", ["old", "new"], bus="b")
+    n.c.loads.dynamic.p = pd.DataFrame({"old": 1.0}, index=n.snapshots)
+
+    df = pd.DataFrame({"old": 3.0, "new": 2.0}, index=n.snapshots)
+    _set_dynamic_data(n, "Load", "p", df)
+
+    pd.testing.assert_frame_equal(n.c.loads.dynamic.p, df, check_names=False)


### PR DESCRIPTION
Closes #1723

Damn. Thanks @coroa. Another case of having dynamic variable attributes not checked