### PR TITLE
fix: piecewise supply/withdrawal direction in energy balance expressions

### DIFF
--- a/pypsa/components/_types/mixin/multiports.py
+++ b/pypsa/components/_types/mixin/multiports.py
@@ -128,6 +128,10 @@ class _Multiport(Components):
     @abstractmethod
     def _coefficient_attr(self) -> str: ...
 
+    def _port_coefficient_attr(self, port: str | int) -> str:
+        """Coefficient attribute name for a port, e.g. 'efficiency2' / 'rate0'."""
+        return f"{self._coefficient_attr}{self._port_suffix(port)}"
+
     @staticmethod
     def _delay_positions(
         weights: np.ndarray, delay: int, is_cyclic: bool

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -434,17 +434,30 @@ class Components(
         pw_df = self.piecewise.get(attr)
         return pw_df is not None and not pw_df.empty
 
-    def _piecewise_schema(self, attr: str) -> pd.Series:
+    def _piecewise_schema(self, **attrs: str) -> pd.Series:
         """Get the schema row of the piecewise definition for `attr` (empty if undefined)."""
-        return self._piecewise_attrs.query("y == @attr").squeeze()
+        query = " and ".join(f"{k} == '{v}'" for k, v in attrs.items())
+        series = self._piecewise_attrs.query(query).squeeze()
+        if not (isinstance(series, pd.Series) or series.empty):
+            msg = "Expected max a single row of data when querying piecewise schema."
+            raise ValueError(msg)
+        return series
 
     def _piecewise_aux_var(self, attr: str) -> str:
         """Model-variable name of the piecewise auxiliary variable for `attr`."""
-        row = self._piecewise_schema(attr)
+        row = self._piecewise_schema(y=attr)
         if row.empty:
             msg = f"{self.name!r} has no piecewise schema for attribute {attr!r}."
             raise ValueError(msg)
         return f"{self.name}-{row.aux_variable}"
+
+    def _piecewise_x_var(self, attr: str) -> str:
+        """Model-variable name of the piecewise x variable for `attr`."""
+        row = self._piecewise_schema(y=attr)
+        if row.empty:
+            msg = f"{self.name!r} has no piecewise schema for attribute {attr!r}."
+            raise ValueError(msg)
+        return f"{self.name}-{row.x.replace('_pu', '')}"
 
     @property
     def standard_types(self) -> pd.DataFrame | None:

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -434,9 +434,13 @@ class Components(
         pw_df = self.piecewise.get(attr)
         return pw_df is not None and not pw_df.empty
 
+    def _piecewise_schema(self, attr: str) -> pd.Series:
+        """Get the schema row of the piecewise definition for `attr` (empty if undefined)."""
+        return self._piecewise_attrs.query("y == @attr").squeeze()
+
     def _piecewise_aux_var(self, attr: str) -> str:
         """Model-variable name of the piecewise auxiliary variable for `attr`."""
-        row = self._piecewise_attrs.query("y == @attr").squeeze()
+        row = self._piecewise_schema(attr)
         if row.empty:
             msg = f"{self.name!r} has no piecewise schema for attribute {attr!r}."
             raise ValueError(msg)

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -429,7 +429,7 @@ class Components(
         )
         return filtered_attrs
 
-    def is_piecewise(self, attr: str) -> bool:
+    def has_piecewise(self, attr: str) -> bool:
         """Whether this component instance has piecewise breakpoint data for `attr`."""
         pw_df = self.piecewise.get(attr)
         return pw_df is not None and not pw_df.empty

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -429,6 +429,19 @@ class Components(
         )
         return filtered_attrs
 
+    def is_piecewise(self, attr: str) -> bool:
+        """Whether this component instance has piecewise breakpoint data for `attr`."""
+        pw_df = self.piecewise.get(attr)
+        return pw_df is not None and not pw_df.empty
+
+    def _piecewise_aux_var(self, attr: str) -> str:
+        """Model-variable name of the piecewise auxiliary variable for `attr`."""
+        row = self._piecewise_attrs.query("y == @attr").squeeze()
+        if row.empty:
+            msg = f"{self.name!r} has no piecewise schema for attribute {attr!r}."
+            raise ValueError(msg)
+        return f"{self.name}-{row.aux_variable}"
+
     @property
     def standard_types(self) -> pd.DataFrame | None:
         """Get standard types of component.

--- a/pypsa/network/transform.py
+++ b/pypsa/network/transform.py
@@ -410,15 +410,16 @@ class NetworkTransformMixin(_NetworkABC):
                 for k, v in series.items()
             }
 
-        # Load piecewise breakpoint data
+        self._import_components_from_df(static_df, c.name, overwrite=overwrite)
+
+        # Load piecewise breakpoint data (after the static import, so that
+        # overwriting an existing component does not drop the new breakpoints)
         nom_attr = nominal_attrs.get(class_name)
         is_extendable = static_df.get(f"{nom_attr}_extendable")
         for k, v in piecewise.items():
             self._import_piecewise_from_df(
                 v, c.name, k, is_extendable=is_extendable, overwrite=overwrite
             )
-
-        self._import_components_from_df(static_df, c.name, overwrite=overwrite)
 
         # Load time-varying attributes as components
         for k, v in series.items():

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -957,7 +957,7 @@ def _iter_balance_coeffs(
     for port in c._output_ports:
         suffix = c._port_suffix(port)
         coeff = (
-            c.da[f"{c._coefficient_attr}{suffix}"].where(c.da.active).sel(snapshot=sns)
+            c.da[c._port_coefficient_attr(port)].where(c.da.active).sel(snapshot=sns)
         )
         if not active.empty:
             yield (f"bus{port}", coeff.sel(name=active), active, suffix)
@@ -1187,9 +1187,7 @@ def define_nodal_balance_constraints(
                 cbuses = cbuses.isel(scenario=0, drop=True)
             cbuses = cbuses[cbuses.isin(buses)].rename("Bus")
             cbuses = cbuses[cbuses != ""]
-            pw_attr = c._piecewise_attrs.query(
-                "y == @search_attr", local_dict={"search_attr": coeff.name}
-            ).squeeze()
+            pw_attr = c._piecewise_schema(coeff.name)
             p_piecewise = 0
             if not pw_attr.empty:
                 extra_options = filter(

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1193,7 +1193,7 @@ def define_nodal_balance_constraints(
             if cbuses.size == 0:
                 continue
 
-            pw_schema = c._piecewise_schema(coeff.name)
+            pw_schema = c._piecewise_schema(y=coeff.name)
             piecewise_var = None
             if not pw_schema.empty:
                 extra_options = filter(

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1187,8 +1187,12 @@ def define_nodal_balance_constraints(
                 cbuses = cbuses.isel(scenario=0, drop=True)
             cbuses = cbuses[cbuses.isin(buses)].rename("Bus")
             cbuses = cbuses[cbuses != ""]
+            if not cbuses.size:
+                continue
+
             pw_attr = c._piecewise_schema(coeff.name)
-            p_piecewise = 0
+            piecewise_var = None
+            piecewise_names = names[:0]
             if not pw_attr.empty:
                 extra_options = filter(
                     lambda p: p.component == c.name and p.attribute == coeff.name,
@@ -1205,40 +1209,29 @@ def define_nodal_balance_constraints(
                     cumulative_attr=False,
                     extra_options=extra_options,
                 )
-            if piecewise_var is not None:
-                piecewise_names = piecewise_var.coords["name"].values
-                for d_names, delay, is_cyclic in _iter_balance_delay(
-                    c, names, port_suffix
-                ):
-                    if delay > 0:
-                        p_piecewise += _apply_delay_shift(
-                            n,
-                            sns,
-                            c,
-                            piecewise_var,
-                            d_names.intersection(piecewise_names),
-                            delay,
-                            is_cyclic,
-                        )
-                    else:
-                        p_piecewise += piecewise_var.sel(
-                            name=d_names.intersection(piecewise_names)
-                        )
-
-                names = names.difference(piecewise_names)
+                if piecewise_var is not None:
+                    piecewise_names = piecewise_var.indexes["name"]
 
             for d_names, delay, is_cyclic in _iter_balance_delay(c, names, port_suffix):
-                if delay > 0:
-                    var = _apply_delay_shift(n, sns, c, var, d_names, delay, is_cyclic)
-
-            expr = var * coeff.sel(name=names) + p_piecewise
-
-            if not cbuses.size:
-                continue
-
-            expr = expr.sel(name=cbuses.coords["name"].values)
-            if expr.size:
-                exprs.append(_groupby_bus(expr, cbuses))
+                groups = [(d_names.difference(piecewise_names), var, True)]
+                if piecewise_var is not None:
+                    groups.append(
+                        (d_names.intersection(piecewise_names), piecewise_var, False)
+                    )
+                for group_names, source, multiply in groups:
+                    group_names = cbuses.indexes["name"].intersection(group_names)
+                    if group_names.empty:
+                        continue
+                    group_cbuses = cbuses.sel(name=group_names)
+                    if delay > 0:
+                        expr = _apply_delay_shift(
+                            n, sns, c, source, group_names, delay, is_cyclic
+                        )
+                    else:
+                        expr = source.sel(name=group_names)
+                    if multiply:
+                        expr = expr * coeff.sel(name=group_names)
+                    exprs.append(_groupby_bus(expr, group_cbuses))
 
     lhs = merge(exprs, join="outer").reindex(name=buses)
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1042,6 +1042,10 @@ def _apply_delay_shift(
 
     """
     sns_coords: xr.Coordinates | dict[str, Any]
+    comp_p = in_var.sel(name=names)
+    if delay <= 0:
+        return comp_p.to_linexpr()
+
     if isinstance(sns, pd.MultiIndex):
         sns_coords = xr.Coordinates.from_pandas_multiindex(sns, "snapshot")
     else:
@@ -1053,7 +1057,6 @@ def _apply_delay_shift(
         is_cyclic,
     )
     valid_mask = DataArray(valid.astype(float), dims=["snapshot"], coords=sns_coords)
-    comp_p = in_var.sel(name=names)
     shifted_p = comp_p.isel(snapshot=src_snapshot_pos).assign_coords(sns_coords)
     var = shifted_p * valid_mask
     return var
@@ -1160,7 +1163,7 @@ def define_nodal_balance_constraints(
             cbuses = cbuses.isel(scenario=0, drop=True)
         cbuses = cbuses[cbuses.isin(buses)].rename("Bus")
 
-        if not cbuses.size:
+        if cbuses.size == 0:
             continue
 
         #  drop non-existent multiport buses which are ''
@@ -1187,13 +1190,12 @@ def define_nodal_balance_constraints(
                 cbuses = cbuses.isel(scenario=0, drop=True)
             cbuses = cbuses[cbuses.isin(buses)].rename("Bus")
             cbuses = cbuses[cbuses != ""]
-            if not cbuses.size:
+            if cbuses.size == 0:
                 continue
 
-            pw_attr = c._piecewise_schema(coeff.name)
+            pw_schema = c._piecewise_schema(coeff.name)
             piecewise_var = None
-            piecewise_names = names[:0]
-            if not pw_attr.empty:
+            if not pw_schema.empty:
                 extra_options = filter(
                     lambda p: p.component == c.name and p.attribute == coeff.name,
                     piecewise_options,
@@ -1203,32 +1205,31 @@ def define_nodal_balance_constraints(
                     c,
                     x_var=m[f"{c.name}-p"],
                     pw_attr=coeff.name,
-                    aux_var_name=f"{c.name}-{pw_attr.aux_variable}",
+                    aux_var_name=f"{c.name}-{pw_schema.aux_variable}",
                     active_names=names,
                     sign="=",
                     cumulative_attr=False,
                     extra_options=extra_options,
                 )
-                if piecewise_var is not None:
-                    piecewise_names = piecewise_var.indexes["name"]
 
             for d_names, delay, is_cyclic in _iter_balance_delay(c, names, port_suffix):
-                groups = [(d_names.difference(piecewise_names), var, True)]
                 if piecewise_var is not None:
-                    groups.append(
-                        (d_names.intersection(piecewise_names), piecewise_var, False)
-                    )
+                    piecewise_names = piecewise_var.indexes["name"]
+                    groups = [
+                        (d_names.difference(piecewise_names), var, True),
+                        (d_names.intersection(piecewise_names), piecewise_var, False),
+                    ]
+                else:
+                    groups = [(d_names, var, True)]
+
                 for group_names, source, multiply in groups:
                     group_names = cbuses.indexes["name"].intersection(group_names)
                     if group_names.empty:
                         continue
                     group_cbuses = cbuses.sel(name=group_names)
-                    if delay > 0:
-                        expr = _apply_delay_shift(
-                            n, sns, c, source, group_names, delay, is_cyclic
-                        )
-                    else:
-                        expr = source.sel(name=group_names)
+                    expr = _apply_delay_shift(
+                        n, sns, c, source, group_names, delay, is_cyclic
+                    )
                     if multiply:
                         expr = expr * coeff.sel(name=group_names)
                     exprs.append(_groupby_bus(expr, group_cbuses))

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -382,22 +382,21 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
         @pass_none_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series | None:
-            attr = lookup.query("not nominal and marginal_cost").loc[c].index.item()
+            attr = "marginal_cost"
+            attr = lookup.query(f"not nominal and {attr}").loc[c].index.item()
             if attr is None:
                 return None
             var = n.model.variables[f"{c}-{attr}"]
             sns = var.indexes["snapshot"]
 
             c_obj = n.c[c]
-            if c_obj.has_piecewise("marginal_cost"):
-                add_opex = n.model.variables[c_obj._piecewise_aux_var("marginal_cost")]
+            if c_obj.has_piecewise(attr):
+                add_opex = n.model.variables[c_obj._piecewise_aux_var(attr)]
                 var = var.drop_sel(name=add_opex.coords["name"])
             else:
                 add_opex = 0
 
-            opex = (
-                var * n.get_switchable_as_dense(c, "marginal_cost").loc[sns] + add_opex
-            )
+            opex = var * n.get_switchable_as_dense(c, attr).loc[sns] + add_opex
 
             weights = n.snapshot_weightings.objective.loc[sns]
             return self._aggregate_timeseries(opex, weights, agg=groupby_time)

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -18,6 +18,7 @@ from packaging import version
 from xarray import DataArray
 
 from pypsa.common import deprecated_kwargs, pass_none_if_keyerror
+from pypsa.components._types.mixin.multiports import _Multiport
 from pypsa.statistics import (
     get_transmission_branches,
     port_efficiency,
@@ -44,6 +45,25 @@ def check_if_empty(expr: LinearExpression) -> bool:
     if USE_EMPTY_PROPERTY:
         return expr.empty
     return expr.empty()
+
+
+def _direct_piecewise(
+    c: Any, y_attr: str, sign: Any, pw: Variable, names: Any, direction: str
+) -> Variable | LinearExpression:
+    """Restrict a piecewise contribution to the requested supply/withdrawal direction.
+
+    A port's direction follows the sign of its breakpoints (``sign * y_attr``),
+    mirroring the clipping applied to linear coefficients. Mixed-sign curves are
+    rejected at ``add`` time, so each port is unambiguously supply or withdrawal.
+    """
+    if direction == "both":
+        return pw
+    y = c.piecewise[y_attr].xs(y_attr, level="attribute", axis=1)[names]
+    withdraws = (sign * y < 0).any()
+    if direction == "withdrawal":
+        return -1 * pw.sel(name=names[withdraws])
+    else:
+        return pw.sel(name=names[~withdraws])
 
 
 class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
@@ -222,16 +242,8 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
             costs = c.static[cost_attribute][capacity.indexes["name"]]
 
-            piecewise_attr = (
-                n.c[component]._piecewise_attrs.query("y == @cost_attribute").squeeze()
-            )
-            aux_var = (
-                f"{component}-{piecewise_attr.aux_variable}"
-                if not piecewise_attr.empty
-                else None
-            )
-            if aux_var in m.variables:
-                add_capex = m.variables[aux_var]
+            if c.is_piecewise(cost_attribute):
+                add_capex = m.variables[c._piecewise_aux_var(cost_attribute)]
                 capacity = capacity.drop_sel(name=add_capex.coords["name"])
             else:
                 add_capex = 0
@@ -376,16 +388,9 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             var = n.model.variables[f"{c}-{attr}"]
             sns = var.indexes["snapshot"]
 
-            piecewise_attr = (
-                n.c[c]._piecewise_attrs.query("y == 'marginal_cost'").squeeze()
-            )
-            aux_var = (
-                f"{c}-{piecewise_attr.aux_variable}"
-                if not piecewise_attr.empty
-                else None
-            )
-            if aux_var in n.model.variables:
-                add_opex = n.model.variables[aux_var]
+            c_obj = n.c[c]
+            if c_obj.is_piecewise("marginal_cost"):
+                add_opex = n.model.variables[c_obj._piecewise_aux_var("marginal_cost")]
                 var = var.drop_sel(name=add_opex.coords["name"])
             else:
                 add_opex = 0
@@ -543,14 +548,15 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             )
 
         @pass_none_if_keyerror
-        def func(n: Network, c: str, port: str) -> pd.Series:
-            var = self._get_operational_variable(c)
+        def func(n: Network, component: str, port: str) -> pd.Series:
+            c = n.c[component]
+            var = self._get_operational_variable(component)
             sns = var.indexes["snapshot"]
             # negative branch contributions are considered by the efficiency
-            dynamic_efficiency = port_efficiency(n, c, port=port, dynamic=True)
+            dynamic_efficiency = port_efficiency(n, component, port=port, dynamic=True)
             if isinstance(dynamic_efficiency, pd.DataFrame):
                 dynamic_efficiency = dynamic_efficiency.loc[sns]
-            sign = n.c[c].static.get("sign", 1.0)
+            sign = n.c[component].static.get("sign", 1.0)
             weights = n.snapshot_weightings.generators.loc[sns]
             coeffs = DataArray(dynamic_efficiency * sign)
             if direction == "supply":
@@ -563,13 +569,15 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             elif direction != "both":
                 msg = f"Got unexpected argument direction={direction}. Must be 'supply', 'withdrawal' or 'both'."
                 raise ValueError(msg)
-            piecewise_efficiency = port_efficiency(n, c, port=port, piecewise=True)
-            if isinstance(piecewise_efficiency, pd.DataFrame):
-                pw_var = sign * n.model.variables[f"{c}-p{port}_piecewise"]
-                pw_var = -1 * pw_var if direction == "withdrawal" else pw_var
-                coeffs.loc[{"name": pw_var.coords["name"]}] = 0
-            else:
-                pw_var = 0
+
+            pw_var = 0
+            if isinstance(c, _Multiport) and c.is_piecewise(
+                y_attr := c._port_coefficient_attr(port)
+            ):
+                pw = sign * n.model.variables[c._piecewise_aux_var(y_attr)]
+                names = pw.coords["name"].values
+                coeffs.loc[{"name": names}] = 0
+                pw_var = _direct_piecewise(c, y_attr, sign, pw, names, direction)
 
             p = var.where(coeffs != 0) * coeffs + pw_var
             return self._aggregate_timeseries(p, weights, agg=groupby_time)

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -242,7 +242,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
             costs = c.static[cost_attribute][capacity.indexes["name"]]
 
-            if c.is_piecewise(cost_attribute):
+            if c.has_piecewise(cost_attribute):
                 add_capex = m.variables[c._piecewise_aux_var(cost_attribute)]
                 capacity = capacity.drop_sel(name=add_capex.coords["name"])
             else:
@@ -389,7 +389,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             sns = var.indexes["snapshot"]
 
             c_obj = n.c[c]
-            if c_obj.is_piecewise("marginal_cost"):
+            if c_obj.has_piecewise("marginal_cost"):
                 add_opex = n.model.variables[c_obj._piecewise_aux_var("marginal_cost")]
                 var = var.drop_sel(name=add_opex.coords["name"])
             else:
@@ -571,7 +571,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
                 raise ValueError(msg)
 
             pw_var = 0
-            if isinstance(c, _Multiport) and c.is_piecewise(
+            if isinstance(c, _Multiport) and c.has_piecewise(
                 y_attr := c._port_coefficient_attr(port)
             ):
                 pw = sign * n.model.variables[c._piecewise_aux_var(y_attr)]

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -132,7 +132,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
     def _aggregate_components_concat_values(
         self, exprs: list[LinearExpression], agg: Callable | str
     ) -> LinearExpression:
-        res = ln.merge(exprs)
+        res = ln.merge(exprs, join="outer")
         if not (index := res.indexes[res.dims[0]]).is_unique:
             if agg != "sum":
                 msg = f"Aggregation method {agg} not supported."

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -308,7 +308,7 @@ def define_primary_energy_limit(
 
     gen_c = n.c.generators
     var_name = "Generator-p"
-    pw_attr_eff = gen_c._piecewise_schema("efficiency")
+    pw_attr_eff = gen_c._piecewise_schema(y="efficiency")
     primary_energy_pw_var = None
     if not unique_names.empty and not pw_attr_eff.empty and var_name in m.variables:
         extra_options = filter(

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -308,7 +308,7 @@ def define_primary_energy_limit(
 
     gen_c = n.c.generators
     var_name = "Generator-p"
-    pw_attr_eff = gen_c._piecewise_attrs.query("y == 'efficiency'").squeeze()
+    pw_attr_eff = gen_c._piecewise_schema("efficiency")
     primary_energy_pw_var = None
     if not unique_names.empty and not pw_attr_eff.empty and var_name in m.variables:
         extra_options = filter(

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -268,13 +268,8 @@ def define_objective(
             if c.static.empty:
                 continue
             active_names = c.active_assets
-            pw_attrs = c._piecewise_attrs.query("y == @cost_type")
-            for _, pw_attr in pw_attrs.iterrows():
-                var_name = f"{pw_attr.component}-{pw_attr.x.replace('_pu', '')}"
-                if var_name not in m.variables:
-                    continue
-
-                x_var = m[var_name].sel(snapshot=sns)
+            if c.has_piecewise(cost_type):
+                x_var = m[c._piecewise_x_var(cost_type)].sel(snapshot=sns)
                 extra_options = filter(
                     lambda p: p.component == c.name and p.attribute == cost_type,
                     piecewise_options,
@@ -285,7 +280,7 @@ def define_objective(
                     x_var=x_var,
                     y_var=None,
                     pw_attr=cost_type,
-                    aux_var_name=f"{c.name}-{pw_attr.aux_variable}",
+                    aux_var_name=c._piecewise_var(cost_type, "aux"),
                     active_names=c.active_assets,
                     sign=">=",
                     cumulative_attr=True,
@@ -366,7 +361,7 @@ def define_objective(
             cost_weight = c.da.active.sel(name=ext_i).any(dim="snapshot")
 
         y_attr = "capital_cost"
-        pw_attr = c._piecewise_schema(y_attr)
+        pw_attr = c._piecewise_schema(y=y_attr)
         if not pw_attr.empty:
             x_var = m[f"{c.name}-{pw_attr.x}"]
             extra_options = filter(
@@ -1028,16 +1023,16 @@ class OptimizationAccessor(OptimizationAbstractMixin):
                 )
                 continue
             c = n.c[_c_name]
-            pw_attrs = c._piecewise_attrs.query("aux_variable == @attr").squeeze()
+            pw_schema = c._piecewise_schema(aux_variable=attr)
             # Piecewise variables are auxiliary and need to be processed before being passed back as a solution.
-            if not pw_attrs.empty:
+            if not pw_schema.empty:
                 if (
                     isinstance(c, _Multiport)
-                    and c._get_base_coeff(pw_attrs.y) == c._coefficient_attr
+                    and c._get_base_coeff(pw_schema.y) == c._coefficient_attr
                 ):
                     # We deal with these variables below when processing the `p` attr.
                     continue
-                x_var = m.variables[f"{c.name}-{pw_attrs.x.removesuffix('_pu')}"]
+                x_var = m.variables[c._piecewise_x_var(pw_schema.y)]
                 sol = sol / x_var.solution
                 if "snapshot" in sol.dims:
                     attr += "_opt"

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -1062,7 +1062,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
                         eff_attr = c._port_coefficient_attr(i)
                         eff = n.get_switchable_as_dense(c.name, eff_attr, sns)
                         port_df = -df * eff
-                        if c.is_piecewise(eff_attr):
+                        if c.has_piecewise(eff_attr):
                             df_piecewise = _from_xarray(
                                 m.variables[f"{_c_name}-{attr}{i}_piecewise"].solution,
                                 c,

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -366,7 +366,7 @@ def define_objective(
             cost_weight = c.da.active.sel(name=ext_i).any(dim="snapshot")
 
         y_attr = "capital_cost"
-        pw_attr = c._piecewise_attrs.query("y == @y_attr").squeeze()
+        pw_attr = c._piecewise_schema(y_attr)
         if not pw_attr.empty:
             x_var = m[f"{c.name}-{pw_attr.x}"]
             extra_options = filter(
@@ -1059,10 +1059,10 @@ class OptimizationAccessor(OptimizationAbstractMixin):
 
                     for i in ports:
                         i_suffix = c._port_suffix(i)
-                        eff_attr = f"{c._coefficient_attr}{i_suffix}"
+                        eff_attr = c._port_coefficient_attr(i)
                         eff = n.get_switchable_as_dense(c.name, eff_attr, sns)
                         port_df = -df * eff
-                        if not c.piecewise.get(eff_attr, pd.DataFrame()).empty:
+                        if c.is_piecewise(eff_attr):
                             df_piecewise = _from_xarray(
                                 m.variables[f"{_c_name}-{attr}{i}_piecewise"].solution,
                                 c,

--- a/pypsa/optimization/piecewise.py
+++ b/pypsa/optimization/piecewise.py
@@ -209,7 +209,7 @@ def _get_breakpoints(
 ) -> tuple[xr.DataArray, xr.DataArray]:
     """Convert piecewise data to linopy breakpoints for piecewise constraint."""
     piecewise_df = c.piecewise[pw_attr][pw_names]
-    piecewise_attrs = c._piecewise_schema(pw_attr)
+    piecewise_attrs = c._piecewise_schema(y=pw_attr)
 
     # pw_attr stores the marginal value (slope) at each breakpoint.
     normalised_piecewise_df = _normalize_breakpoints(piecewise_df, piecewise_attrs)

--- a/pypsa/optimization/piecewise.py
+++ b/pypsa/optimization/piecewise.py
@@ -209,7 +209,7 @@ def _get_breakpoints(
 ) -> tuple[xr.DataArray, xr.DataArray]:
     """Convert piecewise data to linopy breakpoints for piecewise constraint."""
     piecewise_df = c.piecewise[pw_attr][pw_names]
-    piecewise_attrs = c._piecewise_attrs.query("y == @pw_attr").squeeze()
+    piecewise_attrs = c._piecewise_schema(pw_attr)
 
     # pw_attr stores the marginal value (slope) at each breakpoint.
     normalised_piecewise_df = _normalize_breakpoints(piecewise_df, piecewise_attrs)

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -69,14 +69,10 @@ def port_efficiency(
     c_name: str,
     port: int | str = 0,
     dynamic: bool = False,
-    piecewise: bool = False,
 ) -> pd.Series | pd.DataFrame:
     """Get the efficiency of a component at a specific port."""
     c = n.c[c_name]
     port = c._as_port(port)
-    if piecewise and dynamic:
-        err = "Cannot request piecewise and dynamic efficiencies together."
-        raise ValueError(err)
 
     ones = pd.Series(1, index=c.static.index)
     if c.name in n.one_port_components:
@@ -86,29 +82,14 @@ def port_efficiency(
     elif c.name == "Link":
         if port == 0:
             return -ones
-        key = f"{c._coefficient_attr}{c._port_suffix(port)}"
-        if (
-            piecewise
-            and (pw_attr := c.piecewise.get(key)) is not None
-            and not pw_attr.empty
-        ):
-            return pw_attr
-
+        key = c._port_coefficient_attr(port)
         if dynamic and key in c.static:
             return n.get_switchable_as_dense(c.name, key)
-
         return c.static.get(key, ones)
     elif c.name == "Process":
-        key = f"{c._coefficient_attr}{c._port_suffix(port)}"
-        if (
-            piecewise
-            and (pw_attr := c.piecewise.get(key)) is not None
-            and not pw_attr.empty
-        ):
-            return pw_attr
+        key = c._port_coefficient_attr(port)
         if dynamic and key in c.static:
             return n.get_switchable_as_dense(c.name, key)
-
         return c.static.get(key, ones)
     else:
         msg = f"port_efficiency has not been implemented for: {c.name}"

--- a/test/test_add_piecewise.py
+++ b/test/test_add_piecewise.py
@@ -322,14 +322,14 @@ def test_remove_drops_piecewise_data(base_network):
 class TestPiecewiseHelpers:
     """Schema-vs-data primitives on the component class."""
 
-    def test_is_piecewise_tracks_data_not_schema(self, base_network):
-        """`is_piecewise` reflects breakpoint data, not the schema definition."""
+    def test_has_piecewise_tracks_data_not_schema(self, base_network):
+        """`has_piecewise` reflects breakpoint data, not the schema definition."""
         n = base_network
         c = n.c.generators
-        assert not c.is_piecewise("marginal_cost")
+        assert not c.has_piecewise("marginal_cost")
         n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=CURVE_DICT)
-        assert c.is_piecewise("marginal_cost")
-        assert not c.is_piecewise("capital_cost")
+        assert c.has_piecewise("marginal_cost")
+        assert not c.has_piecewise("capital_cost")
 
     def test_aux_var_is_schema_lookup(self, base_network):
         """`_piecewise_aux_var` resolves from the schema, independent of data."""

--- a/test/test_add_piecewise.py
+++ b/test/test_add_piecewise.py
@@ -319,6 +319,34 @@ def test_remove_drops_piecewise_data(base_network):
     assert n.c.generators.piecewise["marginal_cost"].empty
 
 
+class TestPiecewiseHelpers:
+    """Schema-vs-data primitives on the component class."""
+
+    def test_is_piecewise_tracks_data_not_schema(self, base_network):
+        """`is_piecewise` reflects breakpoint data, not the schema definition."""
+        n = base_network
+        c = n.c.generators
+        assert not c.is_piecewise("marginal_cost")
+        n.add("Generator", "gen", bus="bus_ac", p_nom=100, marginal_cost=CURVE_DICT)
+        assert c.is_piecewise("marginal_cost")
+        assert not c.is_piecewise("capital_cost")
+
+    def test_aux_var_is_schema_lookup(self, base_network):
+        """`_piecewise_aux_var` resolves from the schema, independent of data."""
+        n = base_network
+        assert (
+            n.c.generators._piecewise_aux_var("marginal_cost")
+            == "Generator-marginal_cost_piecewise"
+        )
+        assert n.c.links._piecewise_aux_var("efficiency") == "Link-p1_piecewise"
+        assert n.c.processes._piecewise_aux_var("rate0") == "Process-p0_piecewise"
+
+    def test_aux_var_raises_on_unknown_attr(self, base_network):
+        """A non-piecewise attribute fails fast instead of returning None."""
+        with pytest.raises(ValueError, match="no piecewise schema"):
+            base_network.c.generators._piecewise_aux_var("not_an_attr")
+
+
 class TestPiecewiseScenarios:
     def test_add_piecewise_on_stochastic_network_raises(self, base_network):
         n = base_network

--- a/test/test_add_piecewise.py
+++ b/test/test_add_piecewise.py
@@ -322,6 +322,14 @@ def test_remove_drops_piecewise_data(base_network):
 class TestPiecewiseHelpers:
     """Schema-vs-data primitives on the component class."""
 
+    @pytest.fixture(scope="class")
+    def base_network(self) -> pypsa.Network:
+        """Minimal network with buses required by all component tests."""
+        n = pypsa.Network()
+        n.add("Bus", ["bus_ac", "bus_ac2", "bus_dc"], carrier=["AC", "AC", "DC"])
+        n.add("Link", "link", bus0="bus_ac", bus1="bus_ac2", bus2="bus_dc")
+        return n
+
     def test_has_piecewise_tracks_data_not_schema(self, base_network):
         """`has_piecewise` reflects breakpoint data, not the schema definition."""
         n = base_network
@@ -331,20 +339,68 @@ class TestPiecewiseHelpers:
         assert c.has_piecewise("marginal_cost")
         assert not c.has_piecewise("capital_cost")
 
-    def test_aux_var_is_schema_lookup(self, base_network):
+    @pytest.mark.parametrize(
+        ("comp", "attr", "expected"),
+        [
+            ("Generator", "marginal_cost", "Generator-marginal_cost_piecewise"),
+            ("Process", "rate0", "Process-p0_piecewise"),
+            ("Process", "rate1", "Process-p1_piecewise"),
+            ("Link", "efficiency", "Link-p1_piecewise"),
+            ("Link", "efficiency2", "Link-p2_piecewise"),
+        ],
+    )
+    def test_aux_var_is_schema_lookup(self, base_network, comp, attr, expected):
         """`_piecewise_aux_var` resolves from the schema, independent of data."""
-        n = base_network
-        assert (
-            n.c.generators._piecewise_aux_var("marginal_cost")
-            == "Generator-marginal_cost_piecewise"
-        )
-        assert n.c.links._piecewise_aux_var("efficiency") == "Link-p1_piecewise"
-        assert n.c.processes._piecewise_aux_var("rate0") == "Process-p0_piecewise"
+        assert base_network.c[comp]._piecewise_aux_var(attr) == expected
 
     def test_aux_var_raises_on_unknown_attr(self, base_network):
         """A non-piecewise attribute fails fast instead of returning None."""
         with pytest.raises(ValueError, match="no piecewise schema"):
             base_network.c.generators._piecewise_aux_var("not_an_attr")
+
+    @pytest.mark.parametrize(
+        ("comp", "attr", "expected"),
+        [
+            ("Generator", "marginal_cost", "Generator-p"),
+            ("Process", "rate0", "Process-p"),
+            ("Process", "rate1", "Process-p"),
+            ("Link", "efficiency", "Link-p"),
+            ("Link", "efficiency2", "Link-p"),
+        ],
+    )
+    def test_x_var_is_schema_lookup(self, base_network, comp, attr, expected):
+        """`_piecewise_x_var` resolves from the schema, independent of data."""
+        assert base_network.c[comp]._piecewise_x_var(attr) == expected
+
+    def test_x_var_raises_on_unknown_attr(self, base_network):
+        """A non-piecewise attribute fails fast instead of returning None."""
+        with pytest.raises(ValueError, match="no piecewise schema"):
+            base_network.c.generators._piecewise_x_var("not_an_attr")
+
+    @pytest.mark.parametrize(
+        ("comp", "attr", "val"),
+        [
+            ("Generator", "y", "marginal_cost"),
+            ("Generator", "aux_variable", "marginal_cost_piecewise"),
+            ("Link", "y", "efficiency"),
+            ("Link", "aux_variable", "p1_piecewise"),
+        ],
+    )
+    def test_piecewise_schema(self, base_network, comp, attr, val):
+        """`_piecewise_schema` returns a series with the expected columns."""
+        schema = base_network.c[comp]._piecewise_schema(**{attr: val})
+        assert isinstance(schema, pd.Series)
+        assert not schema.empty
+
+    def test_piecewise_schema_empty(self, base_network):
+        """`_piecewise_schema` returns an empty series when no match."""
+        schema = base_network.c.generators._piecewise_schema(y="foo")
+        assert schema.empty
+
+    def test_piecewise_schema_raises(self, base_network):
+        """`_piecewise_schema` raises when multiple rows match."""
+        with pytest.raises(ValueError, match="Expected max a single row"):
+            base_network.c.generators._piecewise_schema(component="Generator")
 
 
 class TestPiecewiseScenarios:

--- a/test/test_optimization_expressions.py
+++ b/test/test_optimization_expressions.py
@@ -300,6 +300,50 @@ class TestExpressionsWithPiecewise:
         )
         assert "piecewise" not in str(expr.sel(component=["Link", "StorageUnit"]))
 
+    def test_supply_minus_withdrawal_equals_energy_balance(self):
+        """supply - withdrawal must reconstruct the net energy balance at the optimum."""
+        n = pypsa.Network()
+        n.set_snapshots(range(2))
+        n.add("Bus", ["bus0", "bus1"])
+        n.add("Generator", "gen0", bus="bus0", p_nom=300, marginal_cost=5)
+        n.add(
+            "Link",
+            "link",
+            bus0="bus0",
+            bus1="bus1",
+            p_nom=100,
+            efficiency={0.0: 0.4, 0.5: 0.5, 1.0: 0.6},
+        )
+        n.add("Load", "load", bus="bus1", p_set=[20, 30])
+        n.optimize.create_model(include_objective_constant=False)
+        exprs = {
+            k: getattr(n.optimize.expressions, k)().sum()
+            for k in ("supply", "withdrawal", "energy_balance")
+        }
+        n.optimize.solve_model()
+        s, w, eb = (
+            exprs[k].solution.item() for k in ("supply", "withdrawal", "energy_balance")
+        )
+        assert s - w == pytest.approx(eb)
+
+    def test_capex_schema_without_data_is_linear(self):
+        """A piecewise schema without breakpoint data costs linearly (no KeyError)."""
+        n = pypsa.Network()
+        n.add("Bus", "bus")
+        n.add(
+            "Link",
+            "link",
+            bus0="bus",
+            bus1="bus",
+            p_nom_extendable=True,
+            capital_cost=100,
+        )
+        n.optimize.create_model(include_objective_constant=False)
+        assert not n.c.links.is_piecewise("capital_cost")
+        expr = n.optimize.expressions.capex().unstack("group")
+        assert "piecewise" not in str(expr)
+        assert "Link-p_nom" in str(expr)
+
     def test_expressions_energy_balance(self, piecewise_network_built):
         n = piecewise_network_built
         expr = n.optimize.expressions.energy_balance().unstack("group")

--- a/test/test_optimization_expressions.py
+++ b/test/test_optimization_expressions.py
@@ -339,7 +339,7 @@ class TestExpressionsWithPiecewise:
             capital_cost=100,
         )
         n.optimize.create_model(include_objective_constant=False)
-        assert not n.c.links.is_piecewise("capital_cost")
+        assert not n.c.links.has_piecewise("capital_cost")
         expr = n.optimize.expressions.capex().unstack("group")
         assert "piecewise" not in str(expr)
         assert "Link-p_nom" in str(expr)

--- a/test/test_optimization_piecewise.py
+++ b/test/test_optimization_piecewise.py
@@ -175,6 +175,7 @@ class TestGetPiecewiseNames:
 class TestGetBreakpoints:
     @pytest.fixture
     def component(self) -> SimpleNamespace:
+        attrs = PIECEWISE_ATTRS.query("component == 'Generator'")
         return SimpleNamespace(
             piecewise={
                 y: _piecewise_df(
@@ -187,7 +188,8 @@ class TestGetBreakpoints:
             ),
             name="Generator",
             extendables=pd.Index([], name="name"),
-            _piecewise_attrs=PIECEWISE_ATTRS.query("component == 'Generator'"),
+            _piecewise_attrs=attrs,
+            _piecewise_schema=lambda attr: attrs.query("y == @attr").squeeze(),
         )
 
     @pytest.fixture
@@ -371,6 +373,7 @@ class TestDefinePiecewise:
 
     @pytest.fixture
     def component(self) -> SimpleNamespace:
+        attrs = PIECEWISE_ATTRS.query("component == 'Generator'")
         component = SimpleNamespace(
             piecewise={
                 "marginal_cost": _piecewise_df(
@@ -392,7 +395,8 @@ class TestDefinePiecewise:
             ),
             name="Generator",
             extendables=pd.Index(["gen_extendable"], name="name"),
-            _piecewise_attrs=PIECEWISE_ATTRS.query("component == 'Generator'"),
+            _piecewise_attrs=attrs,
+            _piecewise_schema=lambda attr: attrs.query("y == @attr").squeeze(),
         )
         component.piecewise["efficiency"] = pd.DataFrame()
         return component

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -712,7 +712,7 @@ class TestStatisticsWithPiecewise:
 
 
 class TestPortEfficiency:
-    """Tests for port_efficiency, including the piecewise parameter."""
+    """Tests for port_efficiency (static and dynamic numeric efficiencies)."""
 
     @pytest.fixture(scope="class")
     def base_network(self):
@@ -820,11 +820,6 @@ class TestPortEfficiency:
         result = port_efficiency(base_network, "Generator", port=0)
         assert (result == 1).all()
 
-    def test_one_port_piecewise_flag_ignored(self, base_network):
-        """piecewise=True on a one-port component still returns ones (not an error)."""
-        result = port_efficiency(base_network, "Generator", port=0, piecewise=True)
-        assert (result == 1).all()
-
     # --- passive branches ---
 
     def test_passive_branch_port0_returns_minus_ones(self, ac_dc_network):
@@ -872,33 +867,13 @@ class TestPortEfficiency:
         expected = dynamic_link_eff.components[component].dynamic[f"{eff_param}2"]
         pd.testing.assert_frame_equal(result, expected)
 
-    # --- Link piecewise efficiency ---
+    # --- piecewise efficiency is not port_efficiency's concern ---
 
-    @pytest.mark.parametrize("port", [1, 2])
-    def test_piecewise_and_dynamic_raises(self, piecewise_link_eff, component, port):
-        with pytest.raises(ValueError, match="piecewise and dynamic"):
-            port_efficiency(
-                piecewise_link_eff, component, port=port, piecewise=True, dynamic=True
-            )
-
-    def test_piecewise_link_returns_dataframe(self, piecewise_link_eff, component):
-        """When a Link has piecewise efficiency, piecewise=True returns a DataFrame."""
-        result = port_efficiency(piecewise_link_eff, component, port=1, piecewise=True)
-        assert isinstance(result, pd.DataFrame)
-
-    def test_piecewise_link_values_within_breakpoints(
+    def test_piecewise_link_returns_static_fallback(
         self, piecewise_link_eff, component, eff1
     ):
-        """Piecewise efficiency values should lie within the piecewise bounds."""
-        result = port_efficiency(piecewise_link_eff, component, port=1, piecewise=True)
-        expected = piecewise_link_eff.components[component].piecewise[eff1]
-        pd.testing.assert_frame_equal(result, expected)
-
-    def test_piecewise_link_no_piecewise_returns_series(
-        self, piecewise_link_eff, component, eff1
-    ):
-        """Without piecewise=True, port_efficiency falls back to the static value."""
-        result = port_efficiency(piecewise_link_eff, component, port=1, piecewise=False)
+        """port_efficiency ignores piecewise data and returns the static fallback."""
+        result = port_efficiency(piecewise_link_eff, component, port=1)
         expected = pd.Series(
             1.0,
             index=piecewise_link_eff.components[component].static.index,
@@ -912,57 +887,34 @@ class TestPortEfficiency:
         result = port_efficiency(mixed_link_eff, component, port=0)
         assert (result == -1).all()
 
-    @pytest.mark.parametrize(
-        ("piecewise", "dynamic"), [(True, False), (False, True), (False, False)]
-    )
+    @pytest.mark.parametrize("dynamic", [True, False])
     def test_mixed_link_port1_static(
-        self, mixed_link_eff, default_dynamic_eff, piecewise, dynamic, component
+        self, mixed_link_eff, default_dynamic_eff, dynamic, component
     ):
-        result = port_efficiency(
-            mixed_link_eff, component, port=1, piecewise=piecewise, dynamic=dynamic
-        )
+        result = port_efficiency(mixed_link_eff, component, port=1, dynamic=dynamic)
         if dynamic:
             pd.testing.assert_frame_equal(result, default_dynamic_eff * 0.5)
         else:
             assert result.item() == 0.5
 
-    def test_mixed_link_port2_piecewise_request_static(self, mixed_link_eff, component):
-        result = port_efficiency(
-            mixed_link_eff, component, port=2, dynamic=False, piecewise=False
-        )
+    def test_mixed_link_port2_static_request(self, mixed_link_eff, component):
+        """A piecewise-only port has no scalar static value, so it falls back to one."""
+        result = port_efficiency(mixed_link_eff, component, port=2, dynamic=False)
         assert result.item() == 1
 
-    def test_mixed_link_port2_piecewise_request_dynamic(
+    def test_mixed_link_port2_dynamic_request(
         self, mixed_link_eff, default_dynamic_eff, component
     ):
-        result = port_efficiency(
-            mixed_link_eff, component, port=2, dynamic=True, piecewise=False
-        )
+        result = port_efficiency(mixed_link_eff, component, port=2, dynamic=True)
         pd.testing.assert_frame_equal(result, default_dynamic_eff)
 
-    def test_mixed_link_port2_piecewise_request_piecewise(
-        self, mixed_link_eff, component, eff_param
-    ):
-        result = port_efficiency(
-            mixed_link_eff, component, port=2, dynamic=False, piecewise=True
-        )
-        expected = mixed_link_eff.components[component].piecewise[f"{eff_param}2"]
-        pd.testing.assert_frame_equal(result, expected)
-
-    @pytest.mark.parametrize("piecewise", [True, False])
-    def test_mixed_link_port3_dynamic_request_piecewise_static(
-        self, mixed_link_eff, piecewise, component
-    ):
-        result = port_efficiency(
-            mixed_link_eff, component, port=3, dynamic=False, piecewise=piecewise
-        )
+    def test_mixed_link_port3_static_request(self, mixed_link_eff, component):
+        result = port_efficiency(mixed_link_eff, component, port=3, dynamic=False)
         assert result.item() == 1
 
     def test_mixed_link_port3_dynamic_dynamic(
         self, mixed_link_eff, component, eff_param
     ):
-        result = port_efficiency(
-            mixed_link_eff, component, port=3, dynamic=True, piecewise=False
-        )
+        result = port_efficiency(mixed_link_eff, component, port=3, dynamic=True)
         expected = mixed_link_eff.components[component].dynamic[f"{eff_param}3"]
         pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
> [!Note]
> AI written summary and partly code

Follow-up to #1603. Fixes the supply/withdrawal decomposition for piecewise multiport ports and tidies the surrounding data model.

## Problem
`supply() - withdrawal()` did not equal `energy_balance()` for piecewise ports: the piecewise auxiliary variable was added in every direction unfiltered, while the linear coefficients were direction-clipped. A port's piecewise contribution leaked into both `supply()` and `withdrawal()`.

## Fix
- Restrict each port's piecewise contribution to the direction implied by the sign of its breakpoints (`_direct_piecewise`), mirroring the clipping applied to linear coefficients. Mixed-sign curves are already rejected at `add` time, so each port is unambiguously supply or withdrawal.
- Introduce a clear schema-vs-data model: `Component.is_piecewise(attr)` / `Component._piecewise_aux_var(attr)` and `_Multiport._port_coefficient_attr(port)`, replacing ad-hoc name templates (`f"{c}-p{port}_piecewise"`) and `aux_var in m.variables` membership checks in `capex`/`opex`/`energy_balance`.
- Drop the `piecewise` flag from `port_efficiency`; it now returns static/dynamic efficiency only (single responsibility).

## Helper reuse & deduplication
The helpers introduced above are now leveraged across the optimization module, removing the remaining ad-hoc patterns:
- `_port_coefficient_attr(port)` replaces the raw `f"{c._coefficient_attr}{c._port_suffix(port)}"` construction in `optimize.py`, `constraints.py`, and `statistics/expressions.py`. The helper body is now the single source of that template.
- `is_piecewise(attr)` replaces the `not c.piecewise.get(attr, pd.DataFrame()).empty` data-check in the solution-assignment loop in `optimize.py`.
- New `Component._piecewise_schema(attr)` centralizes the recurring `_piecewise_attrs.query("y == @attr").squeeze()` schema lookup. `_piecewise_aux_var` is routed through it, and four scattered call-sites (`optimize.py`, `global_constraints.py`, `constraints.py`, `piecewise.py`) now delegate to it (dropping a `local_dict` workaround in the process).

Schema-vs-data semantics are kept distinct: `is_piecewise` (has data) is only used for genuine data-checks; `_piecewise_schema(...).empty` (schema gate) is left in place where the gate is schema-based. The only remaining `query("y == ...")` call is the deliberate multi-row `.iterrows()` case for costs in `optimize.py`, which is not the single-row squeeze pattern.

## Tests
- `test_supply_minus_withdrawal_equals_energy_balance` — numerical identity regression (the strongest guard).
- Updated `port_efficiency` and piecewise helper tests for the new contract.
- `SimpleNamespace` fakes in `test_optimization_piecewise.py` updated to faithfully expose `_piecewise_schema`.

Verified: ruff + mypy clean; affected suites green.
