### PR TITLE
Fix StorageUnit inflow with filtered MultiIndex snapshots

### DIFF
--- a/pypsa/components/array.py
+++ b/pypsa/components/array.py
@@ -105,6 +105,15 @@ def _from_xarray(da: xr.DataArray, c: Components) -> pd.DataFrame | pd.Series:
     raise UnexpectedError(msg)
 
 
+def _dynamic_dataframe_to_xarray(df: pd.DataFrame) -> xr.DataArray:
+    """Convert dynamic component data to xarray with stable dimension names."""
+    return xr.DataArray(
+        df.to_numpy(),
+        coords={"snapshot": df.index, "name": df.columns},
+        dims=("snapshot", "name"),
+    )
+
+
 class _XarrayAccessor:
     """Accessor class that provides property-like xarray access to all attributes.
 
@@ -325,9 +334,15 @@ class ComponentsArrayMixin(_ComponentsABC):
 
         """
         if attr == "active":
-            res = xr.DataArray(self.get_activity_mask())
+            if self.has_scenarios:
+                res = xr.DataArray(self.get_activity_mask())
+            else:
+                res = _dynamic_dataframe_to_xarray(self.get_activity_mask())
         elif attr in self.dynamic.keys():
-            res = xr.DataArray(self._as_dynamic(attr))
+            if self.has_scenarios:
+                res = xr.DataArray(self._as_dynamic(attr))
+            else:
+                res = _dynamic_dataframe_to_xarray(self._as_dynamic(attr))
         else:
             res = xr.DataArray(self.static[attr])
 

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -41,6 +41,15 @@ lookup = pd.read_csv(
 )
 
 
+def _snapshot_name_dataarray(df: pd.DataFrame) -> DataArray:
+    """Convert snapshot-indexed data to xarray with stable dimension names."""
+    return DataArray(
+        df.to_numpy(),
+        coords={"snapshot": df.index, "name": df.columns},
+        dims=("snapshot", "name"),
+    )
+
+
 def define_operational_constraints_for_non_extendables(
     n: Network,
     sns: pd.Index,
@@ -1653,11 +1662,14 @@ def define_storage_unit_constraints(n: Network, sns: pd.Index) -> None:
 
     # elapsed hours
     elapsed_h = expand_series(n.snapshot_weightings.stores[sns], c.static.index)
-    eh = DataArray(elapsed_h)
-    try:
-        eh = eh.unstack("dim_1")
-    except ValueError:
-        pass
+    if n.has_scenarios:
+        eh = DataArray(elapsed_h)
+        try:
+            eh = eh.unstack("dim_1")
+        except ValueError:
+            pass
+    else:
+        eh = _snapshot_name_dataarray(elapsed_h)
 
     # efficiencies as xarray DataArrays
     eff_stand = (1 - c.da.standing_loss.sel(snapshot=sns, name=c.active_assets)) ** eh
@@ -1849,11 +1861,13 @@ def define_store_constraints(n: Network, sns: pd.Index) -> None:
 
     # elapsed hours
     elapsed_h = expand_series(n.snapshot_weightings.stores[sns], c.active_assets)
-    eh = DataArray(elapsed_h)
-
-    # Unstack in stochastic networks with MultiIndex snapshots
-    if n.has_scenarios and "dim_1" in eh.dims:
-        eh = eh.unstack("dim_1")
+    if n.has_scenarios:
+        eh = DataArray(elapsed_h)
+        # Unstack in stochastic networks with MultiIndex snapshots
+        if "dim_1" in eh.dims:
+            eh = eh.unstack("dim_1")
+    else:
+        eh = _snapshot_name_dataarray(elapsed_h)
 
     # standing efficiency
     eff_stand = (1 - c.da.standing_loss.sel(snapshot=sns, name=c.active_assets)) ** eh

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -419,6 +419,66 @@ def test_global_constraint_primary_energy_storage_stochastic(n_sus):
     assert n_sus.model.constraints["GlobalConstraint-co2limit"].rhs[0] == -77000.0
 
 
+def test_storage_unit_inflow_keeps_snapshot_dimension_after_reslicing():
+    """
+    StorageUnit inflow should remain selectable by snapshot after reslicing snapshots.
+
+    See https://github.com/PyPSA/PyPSA/issues/1741.
+    """
+    n = pypsa.Network()
+    n.set_investment_periods([2025, 2030])
+
+    timesteps = pd.DatetimeIndex([])
+    for period in n.investment_periods:
+        timesteps = timesteps.append(pd.date_range(f"{period}-01-01", periods=2, freq="h"))
+
+    n.set_snapshots(
+        pd.MultiIndex.from_arrays(
+            [timesteps.year, timesteps],
+            names=["period", "timestep"],
+        )
+    )
+
+    n.add("Bus", "bus")
+    n.add("Carrier", "gas", co2_emissions=0.2)
+    n.add("Carrier", "hydro", co2_emissions=0.0)
+    n.add(
+        "Generator",
+        "gen",
+        bus="bus",
+        carrier="gas",
+        marginal_cost=50,
+        p_nom=100,
+        p_nom_extendable=True,
+        build_year=2020,
+        lifetime=30,
+    )
+    n.add("Load", "load", bus="bus", p_set=80)
+    n.add(
+        "StorageUnit",
+        "storage",
+        bus="bus",
+        carrier="hydro",
+        p_nom=10,
+        max_hours=10,
+    )
+    n.storage_units_t.inflow = pd.DataFrame(
+        10.0, index=n.snapshots, columns=["storage"]
+    )
+
+    n.snapshot_weightings.loc[:, ["objective", "stores", "generators"]] = 1
+    active_snapshots = n.snapshot_weightings[
+        n.snapshot_weightings["objective"] != 0
+    ].index
+    with pypsa.option_context("debug.runtime_verification", False):
+        n.set_snapshots(active_snapshots)
+
+        assert n.c.storage_units.da.inflow.dims == ("snapshot", "name")
+
+        n.optimize.create_model(multi_investment_periods=True)
+    assert "StorageUnit-spill" in n.model.variables
+
+
 def test_global_constraint_transmission_expansion_limit(n):
     n.add(
         "GlobalConstraint",

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -430,7 +430,9 @@ def test_storage_unit_inflow_keeps_snapshot_dimension_after_reslicing():
 
     timesteps = pd.DatetimeIndex([])
     for period in n.investment_periods:
-        timesteps = timesteps.append(pd.date_range(f"{period}-01-01", periods=2, freq="h"))
+        timesteps = timesteps.append(
+            pd.date_range(f"{period}-01-01", periods=2, freq="h")
+        )
 
     n.set_snapshots(
         pd.MultiIndex.from_arrays(


### PR DESCRIPTION
Fixes #1741.

## Summary

- Preserve `snapshot` and `name` dimensions when converting non-stochastic dynamic component data and activity masks from pandas to xarray.
- Preserve the same dimension names for Store and StorageUnit elapsed-hour weightings used in storage constraints.
- Add a regression test for `StorageUnit` inflow after filtering MultiIndex snapshots in a multi-investment-period model.

## Root cause

When a dynamic DataFrame has MultiIndex snapshots named `period` and `timestep`, `xr.DataArray(df)` infers the first dimension as `dim_0` instead of `snapshot`. After `n.set_snapshots(valid_snapshots)`, `StorageUnit` inflow therefore becomes selectable by `dim_0`, while optimization code expects `.sel(snapshot=sns)`.

The same inference issue affects elapsed-hour DataArrays created from expanded snapshot weightings, which then conflict with other arrays that use `snapshot`.

## Validation

- Reproduced the issue #1741 script locally before the fix: `c.da.inflow.dims` became `('dim_0', 'name')` and `create_model()` failed in `define_spillage_variables`.
- Re-ran the issue #1741 script after the fix: `c.da.inflow.dims` is `('snapshot', 'name')`, `create_model()` succeeds, and `StorageUnit-spill` is present.
- `python -m pytest test/test_lopf_multiinvest.py::test_storage_unit_inflow_keeps_snapshot_dimension_after_reslicing -q`
- `python -m pytest test/test_lopf_multiinvest.py -q`
- `python -m pytest test/test_lopf_storage.py -q`
- `python -m pytest test/test_network_index.py test/test_indices.py -q`
- `python -m pytest test/test_optimization_common.py test/test_optimization_expressions.py -q`
- `python -m pytest test/test_lopf_basic_constraints.py -q`
- `python -m pytest test/test_collection.py -q`
- `ruff check pypsa/components/array.py pypsa/optimization/constraints.py test/test_lopf_multiinvest.py`
