### PR TITLE
fix: ensure upper clipping of min_pu in time segmentation

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Avoid redundant traces and legends in interactive statistics bar plots when the color dimension duplicates an axis. (<!-- md:pr 1710 -->)
 
+- Fix temporal clustering producing `*_min_pu > *_max_pu` for some snapshots. Aggregated lower bounds are now clipped to their paired upper bound, both for the floating-point drift in [`segment()`][pypsa.clustering.temporal.TemporalClusteringMixin.segment] and the `e_min_pu`/`e_max_pu` crossover from min/max aggregation rules. (<!-- md:pr 1752 -->)
+
 
 ## [**v1.2.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.2) <small>25th May 2026</small> { id="v1.2.2" }
 

--- a/pypsa/clustering/temporal.py
+++ b/pypsa/clustering/temporal.py
@@ -57,6 +57,28 @@ TEMPORAL_AGGREGATION_DEFAULTS: dict[str, str] = {
 }
 
 
+def _enforce_pu_bounds(m: Network) -> None:
+    """Clip aggregated ``*_min_pu`` series so they never exceed ``*_max_pu``.
+
+    Aggregation can lift a lower bound above its paired upper bound, either from
+    floating-point error (segmentation normalises per column) or from min/max
+    aggregation rules (``e_min_pu`` uses ``max``, ``e_max_pu`` uses ``min``).
+    """
+    for c in m.components:
+        for min_attr in [a for a in c.dynamic if a.endswith("_min_pu")]:
+            max_attr = min_attr.replace("_min_pu", "_max_pu")
+            if max_attr not in c.dynamic:
+                continue
+            min_df = c.dynamic[min_attr]
+            max_df = c.dynamic[max_attr]
+            common = min_df.columns.intersection(max_df.columns)
+            if common.empty:
+                continue
+            c.dynamic[min_attr].loc[:, common] = min_df[common].clip(
+                upper=max_df[common]
+            )
+
+
 @dataclass
 class TemporalClustering:
     """Result of temporal clustering.
@@ -73,6 +95,10 @@ class TemporalClustering:
 
     n: Network
     snapshot_map: pd.Series
+
+    def __post_init__(self) -> None:
+        """Sanitize time clustered data."""
+        _enforce_pu_bounds(self.n)
 
 
 def _get_aggregation_rule(

--- a/pypsa/clustering/temporal.py
+++ b/pypsa/clustering/temporal.py
@@ -57,14 +57,14 @@ TEMPORAL_AGGREGATION_DEFAULTS: dict[str, str] = {
 }
 
 
-def _enforce_pu_bounds(m: Network) -> None:
-    """Clip aggregated ``*_min_pu`` series so they never exceed ``*_max_pu``.
+def _enforce_pu_bounds(n: Network) -> None:
+    """Clip aggregated `*_min_pu` series so they never exceed `*_max_pu`.
 
     Aggregation can lift a lower bound above its paired upper bound, either from
     floating-point error (segmentation normalises per column) or from min/max
-    aggregation rules (``e_min_pu`` uses ``max``, ``e_max_pu`` uses ``min``).
+    aggregation rules (`e_min_pu` uses `max`, `e_max_pu` uses `min`).
     """
-    for c in m.components:
+    for c in n.components:
         for min_attr in [a for a in c.dynamic if a.endswith("_min_pu")]:
             max_attr = min_attr.replace("_min_pu", "_max_pu")
             if max_attr not in c.dynamic:

--- a/pypsa/clustering/temporal.py
+++ b/pypsa/clustering/temporal.py
@@ -70,8 +70,12 @@ def _enforce_pu_bounds(n: Network) -> None:
             if max_attr not in c.dynamic:
                 continue
             min_df = c.dynamic[min_attr]
-            upper = c.dynamic[max_attr].reindex(columns=min_df.columns)
-            c.dynamic[min_attr] = min_df.clip(upper=upper)
+            max_df = c.dynamic[max_attr]
+            common = min_df.columns.intersection(max_df.columns)
+            if common.empty:
+                continue
+            c.dynamic[min_attr].loc[:, common] = min_df[common].clip(
+                upper=max_df[common]
             )
 
 

--- a/pypsa/clustering/temporal.py
+++ b/pypsa/clustering/temporal.py
@@ -70,12 +70,8 @@ def _enforce_pu_bounds(n: Network) -> None:
             if max_attr not in c.dynamic:
                 continue
             min_df = c.dynamic[min_attr]
-            max_df = c.dynamic[max_attr]
-            common = min_df.columns.intersection(max_df.columns)
-            if common.empty:
-                continue
-            c.dynamic[min_attr].loc[:, common] = min_df[common].clip(
-                upper=max_df[common]
+            upper = c.dynamic[max_attr].reindex(columns=min_df.columns)
+            c.dynamic[min_attr] = min_df.clip(upper=upper)
             )
 
 

--- a/test/test_temporal_clustering.py
+++ b/test/test_temporal_clustering.py
@@ -12,6 +12,7 @@ from pypsa.clustering.temporal import (
     downsample,
     from_snapshot_map,
     resample,
+    segment,
 )
 
 
@@ -444,6 +445,26 @@ class TestAggregationRulesDetailed:
 
         assert "e_max_pu" in result.n.c.storage_units.dynamic
 
+    def test_e_min_pu_clipped_below_e_max_pu(self, simple_network):
+        n = simple_network
+        rng = np.random.default_rng(0)
+        e_max_pu = rng.uniform(0.3, 0.7, 168)
+        e_min_pu = np.minimum(rng.uniform(0.3, 0.7, 168), e_max_pu)
+        n.add(
+            "Store",
+            "store0",
+            bus="bus0",
+            e_nom=100,
+            e_min_pu=e_min_pu,
+            e_max_pu=e_max_pu,
+        )
+
+        result = resample(n, "24h")
+
+        clustered_min = result.n.c.stores.dynamic["e_min_pu"]["store0"]
+        clustered_max = result.n.c.stores.dynamic["e_max_pu"]["store0"]
+        assert (clustered_min <= clustered_max).all()
+
 
 class TestAccessorFullResultsExtended:
     def test_get_from_snapshot_map_result(self, simple_network):
@@ -461,7 +482,6 @@ class TestAccessorFullResultsExtended:
 
 class TestSegmentErrors:
     def test_segment_invalid_num_segments(self, simple_network):
-        from pypsa.clustering.temporal import segment
 
         n = simple_network
         with pytest.raises(ValueError, match="num_segments must be >= 1"):
@@ -478,8 +498,6 @@ class TestSegmentErrors:
             p_max_pu=np.random.default_rng(42).uniform(0.5, 1.0, 48),
         )
 
-        from pypsa.clustering.temporal import segment
-
         with pytest.raises(NotImplementedError, match="does not yet support"):
             segment(n, 5)
 
@@ -490,8 +508,6 @@ class TestSegmentErrors:
         n.add("Bus", "bus0")
         n.add("Generator", "gen0", bus="bus0", p_nom=100)
 
-        from pypsa.clustering.temporal import segment
-
         with pytest.raises(ValueError, match="No time-varying data"):
             segment(n, 5)
 
@@ -500,8 +516,6 @@ class TestSegmentFunctionality:
     def test_segment_basic(self, simple_network):
         pytest.importorskip("tsam")
         n = simple_network
-
-        from pypsa.clustering.temporal import segment
 
         result = segment(n, 10)
 
@@ -520,6 +534,31 @@ class TestSegmentFunctionality:
 
         assert isinstance(m, pypsa.Network)
         assert len(m.snapshots) == 10
+
+    def test_segment_p_min_pu_not_above_p_max_pu(self, simple_network):
+        pytest.importorskip("tsam")
+        n = simple_network
+
+        rng = np.random.default_rng(0)
+        base = rng.uniform(0.3, 0.95, 168)
+        p_max_pu = base.copy()
+        p_min_pu = base.copy()
+        p_max_pu[0] = 1.0
+        p_min_pu[:2] = [0.1, 0.05]
+        n.add(
+            "Generator",
+            "gen_eq",
+            bus="bus0",
+            p_nom=100,
+            p_min_pu=p_min_pu,
+            p_max_pu=p_max_pu,
+        )
+
+        m = segment(n, 30).n
+
+        clustered_min = m.c.generators.dynamic["p_min_pu"]["gen_eq"]
+        clustered_max = m.c.generators.dynamic["p_max_pu"]["gen_eq"]
+        assert (clustered_min <= clustered_max).all()
 
     def test_get_segment_result(self, simple_network):
         pytest.importorskip("tsam")
@@ -558,7 +597,6 @@ class TestStochasticNotSupported:
 
     def test_segment_stochastic_raises(self, stochastic_network):
         pytest.importorskip("tsam")
-        from pypsa.clustering.temporal import segment
 
         with pytest.raises(NotImplementedError, match="stochastic networks"):
             segment(stochastic_network, 10)


### PR DESCRIPTION
Closes #1633

Add a post init sanitization layer to the time clustering module fixing min_pu/max_pu numerical flaws.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
