### PR TITLE
fix: avoid KeyError in (l)pf when a sub-network lacks a branch type

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,7 +30,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix temporal clustering producing `*_min_pu > *_max_pu` for some snapshots. Aggregated lower bounds are now clipped to their paired upper bound, both for the floating-point drift in [`segment()`][pypsa.clustering.temporal.TemporalClusteringMixin.segment] and the `e_min_pu`/`e_max_pu` crossover from min/max aggregation rules. (<!-- md:pr 1752 -->)
 
-- Fix `KeyError` in [`n.pf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.pf] and [`n.lpf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.lpf] when a network contains multiple sub-networks and one of them has no transformers (or otherwise lacks a passive branch component present in another sub-network). (<!-- md:pr 1753 -->)
+- Fix `KeyError` in [`n.pf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.pf] and [`n.lpf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.lpf] when a network contains multiple sub-networks and one of them has no transformers (or otherwise lacks a passive branch component present in another sub-network). (<!-- md:pr 1754 -->)
 
 
 ## [**v1.2.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.2) <small>25th May 2026</small> { id="v1.2.2" }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,6 +30,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix temporal clustering producing `*_min_pu > *_max_pu` for some snapshots. Aggregated lower bounds are now clipped to their paired upper bound, both for the floating-point drift in [`segment()`][pypsa.clustering.temporal.TemporalClusteringMixin.segment] and the `e_min_pu`/`e_max_pu` crossover from min/max aggregation rules. (<!-- md:pr 1752 -->)
 
+- Fix `KeyError` in [`n.pf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.pf] and [`n.lpf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.lpf] when a network contains multiple sub-networks and one of them has no transformers (or otherwise lacks a passive branch component present in another sub-network). (<!-- md:pr 1753 -->)
+
 
 ## [**v1.2.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.2) <small>25th May 2026</small> { id="v1.2.2" }
 

--- a/pypsa/network/power_flow.py
+++ b/pypsa/network/power_flow.py
@@ -1654,8 +1654,9 @@ class SubNetworkPowerFlowMixin:
 
         s0 = pd.DataFrame(v0 * np.conj(i0), columns=branches_i, index=sns)
         s1 = pd.DataFrame(v1 * np.conj(i1), columns=branches_i, index=sns)
+        branch_types = branches_i.unique("type")
         for c in self.components:
-            if c.name not in n.passive_branch_components:
+            if c.name not in branch_types:
                 continue
             s0t = s0.loc[:, c.name]
             s1t = s1.loc[:, c.name]
@@ -1844,8 +1845,9 @@ class SubNetworkPowerFlowMixin:
                 + self.p_branch_shift
             )
 
+            branch_types = branches_i.unique("type")
             for c in self.components:
-                if c.name not in n.passive_branch_components:
+                if c.name not in branch_types:
                     continue
                 f = flows.loc[:, c.name]
                 n.c[c.name].dynamic.p0.loc[sns, f.columns] = f

--- a/test/test_lpf_ac_dc.py
+++ b/test/test_lpf_ac_dc.py
@@ -57,3 +57,22 @@ def test_lpf_chunks(ac_dc_network, ac_dc_network_r):
         n.c.links.dynamic.p0[n.c.links.static.index],
         n_r.c.links.dynamic.p0[n.c.links.static.index],
     )
+
+
+@pytest.mark.parametrize("method", ["lpf", "pf"])
+def test_pf_subnetwork_without_transformer(method):
+    # https://github.com/PyPSA/PyPSA/issues/1698
+    # one sub-network has a transformer, the other only lines
+    n = pypsa.Network()
+    n.add("Bus", ["a", "c", "d"], v_nom=110)
+    n.add("Bus", "b", v_nom=220)
+    n.add("Transformer", "t", bus0="a", bus1="b", x=0.1, s_nom=100)
+    n.add("Line", "l", bus0="c", bus1="d", x=0.1, s_nom=100)
+    n.add("Generator", ["ga", "gc"], bus=["a", "c"], control="Slack")
+    n.add("Load", ["lb", "ld"], bus=["b", "d"], p_set=10)
+    n.determine_network_topology()
+
+    getattr(n, method)()
+
+    equal(n.c.transformers.dynamic.p0["t"], [10.0])
+    equal(n.c.lines.dynamic.p0["l"], [10.0])


### PR DESCRIPTION
Closes #1698.

## Changes proposed in this Pull Request

Index per-sub-network branch flows only by the branch components actually present, so a network with a transformer in one sub-network and only lines in another no longer raises KeyError: 'Transformer'. 


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
