### PR TITLE
Add functionality to handle binary `status` of committable components

### DIFF
--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1199,6 +1199,11 @@ def define_nodal_balance_constraints(
                     lambda p: p.component == c.name and p.attribute == coeff.name,
                     piecewise_options,
                 )
+                status = (
+                    None
+                    if c.committables.intersection(names).empty
+                    else m[f"{c.name}-status"]
+                )
                 piecewise_var = define_piecewise(
                     n.model,
                     c,
@@ -1209,6 +1214,7 @@ def define_nodal_balance_constraints(
                     sign="=",
                     cumulative_attr=False,
                     extra_options=extra_options,
+                    status=status,
                 )
 
             for d_names, delay, is_cyclic in _iter_balance_delay(c, names, port_suffix):

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -382,21 +382,21 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
 
         @pass_none_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series | None:
-            attr = "marginal_cost"
-            attr = lookup.query(f"not nominal and {attr}").loc[c].index.item()
+            cost_attr = "marginal_cost"
+            attr = lookup.query(f"not nominal and {cost_attr}").loc[c].index.item()
             if attr is None:
                 return None
             var = n.model.variables[f"{c}-{attr}"]
             sns = var.indexes["snapshot"]
 
             c_obj = n.c[c]
-            if c_obj.has_piecewise(attr):
-                add_opex = n.model.variables[c_obj._piecewise_aux_var(attr)]
+            if c_obj.has_piecewise(cost_attr):
+                add_opex = n.model.variables[c_obj._piecewise_aux_var(cost_attr)]
                 var = var.drop_sel(name=add_opex.coords["name"])
             else:
                 add_opex = 0
 
-            opex = var * n.get_switchable_as_dense(c, attr).loc[sns] + add_opex
+            opex = var * n.get_switchable_as_dense(c, cost_attr).loc[sns] + add_opex
 
             weights = n.snapshot_weightings.objective.loc[sns]
             return self._aggregate_timeseries(opex, weights, agg=groupby_time)

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -390,13 +390,13 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             sns = var.indexes["snapshot"]
 
             c_obj = n.c[c]
-            if c_obj.has_piecewise(cost_attr):
-                add_opex = n.model.variables[c_obj._piecewise_aux_var(cost_attr)]
+            if c_obj.has_piecewise(attr):
+                add_opex = n.model.variables[c_obj._piecewise_aux_var(attr)]
                 var = var.drop_sel(name=add_opex.coords["name"])
             else:
                 add_opex = 0
 
-            opex = var * n.get_switchable_as_dense(c, cost_attr).loc[sns] + add_opex
+            opex = var * n.get_switchable_as_dense(c, attr).loc[sns] + add_opex
 
             weights = n.snapshot_weightings.objective.loc[sns]
             return self._aggregate_timeseries(opex, weights, agg=groupby_time)

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -315,6 +315,11 @@ def define_primary_energy_limit(
             lambda opt: opt.component == gen_c.name and opt.attribute == "efficiency",
             piecewise_options,
         )
+        status = (
+            None
+            if gen_c.committables.intersection(gen_c.active_assets).empty
+            else m[f"{gen_c.name}-status"]
+        )
         primary_energy_pw_var = define_piecewise(
             m,
             gen_c,
@@ -326,6 +331,7 @@ def define_primary_energy_limit(
             cumulative_attr=False,
             extra_options=extra_options,
             invert_attr=True,
+            status=status,
         )
 
     for name in unique_names:

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -273,6 +273,11 @@ def define_objective(
                     lambda p: p.component == c.name and p.attribute == cost_type,
                     piecewise_options,
                 )
+                status = (
+                    None
+                    if c.committables.intersection(active_names).empty
+                    else m[f"{c.name}-status"]
+                )
                 pw_cost_var = define_piecewise(
                     m,
                     c,
@@ -280,10 +285,11 @@ def define_objective(
                     y_var=None,
                     pw_attr=cost_type,
                     aux_var_name=c._piecewise_aux_var(cost_type),
-                    active_names=c.active_assets,
+                    active_names=active_names,
                     sign=">=",
                     cumulative_attr=True,
                     extra_options=extra_options,
+                    status=status,
                 )
                 if pw_cost_var is not None:
                     opex_terms.append(

--- a/pypsa/optimization/piecewise.py
+++ b/pypsa/optimization/piecewise.py
@@ -67,6 +67,7 @@ def define_piecewise(
     sign: SIGNS_T,
     cumulative_attr: bool,
     extra_options: Iterable[PiecewiseOptions],
+    status: Variable | None = None,
     invert_attr: bool = False,
     y_var: Any | None = None,
     method: PWL_METHOD = "auto",
@@ -99,6 +100,8 @@ def define_piecewise(
         Whether the y-axis breakpoints represent marginal values.
         If True, the integral of the piecewise curve will be used to define y breakpoints.
         If False, the nominal values at each x breakpoint will be used to define y breakpoints.
+    status : linopy.Variable or None, optional
+        The optimisation variable for the binary status of the component (e.g. generator on/off).
     y_var : linopy.Variable or None, optional
         The optimisation variable for the y-axis of the piecewise constraint.
         If None, a new auxiliary variable will be created and used instead.
@@ -158,14 +161,49 @@ def define_piecewise(
         if names.empty:
             continue
 
+        if status is not None:
+            status_no_null = status.sel(name=~status.isnull().groupby("name").all(...))
+            opt_status = status_no_null.sel(
+                name=names.intersection(status_no_null.indexes["name"])
+            )
+            status_names = opt_status.indexes["name"]
+            non_status_names = names.difference(status_names)
+        else:
+            status_names = pd.Index([], name="name")
+            non_status_names = names
+
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=EvolvingAPIWarning)
-            m.add_piecewise_formulation(
-                (y_var.sel(name=names), y_breakpoints.sel(name=names), opt_sign),
-                (x_var.sel(name=names), x_breakpoints.sel(name=names)),
-                method=opt_method,
-                name=aux,
-            )
+
+            if not non_status_names.empty:
+                m.add_piecewise_formulation(
+                    (
+                        y_var.sel(name=non_status_names),
+                        y_breakpoints.sel(name=non_status_names),
+                        opt_sign,
+                    ),
+                    (
+                        x_var.sel(name=non_status_names),
+                        x_breakpoints.sel(name=non_status_names),
+                    ),
+                    method=opt_method,
+                    name=aux,
+                )
+            if not status_names.empty:
+                m.add_piecewise_formulation(
+                    (
+                        y_var.sel(name=status_names),
+                        y_breakpoints.sel(name=status_names),
+                        opt_sign,
+                    ),
+                    (
+                        x_var.sel(name=status_names),
+                        x_breakpoints.sel(name=status_names),
+                    ),
+                    method=opt_method,
+                    active=opt_status,
+                    name=aux + "_status",
+                )
         pw_names = pw_names.difference(names)
     return y_var_sel
 

--- a/pypsa/optimization/piecewise.py
+++ b/pypsa/optimization/piecewise.py
@@ -161,49 +161,24 @@ def define_piecewise(
         if names.empty:
             continue
 
-        if status is not None:
-            status_no_null = status.sel(name=~status.isnull().groupby("name").all(...))
-            opt_status = status_no_null.sel(
-                name=names.intersection(status_no_null.indexes["name"])
-            )
-            status_names = opt_status.indexes["name"]
-            non_status_names = names.difference(status_names)
+        if status is None:
+            active = None
         else:
-            status_names = pd.Index([], name="name")
-            non_status_names = names
+            masked = status.isnull().reindex(name=names, fill_value=True)
+            if masked.all():
+                active = None
+            else:
+                active = status.to_linexpr().reindex(name=names).where(~masked, 1)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=EvolvingAPIWarning)
-
-            if not non_status_names.empty:
-                m.add_piecewise_formulation(
-                    (
-                        y_var.sel(name=non_status_names),
-                        y_breakpoints.sel(name=non_status_names),
-                        opt_sign,
-                    ),
-                    (
-                        x_var.sel(name=non_status_names),
-                        x_breakpoints.sel(name=non_status_names),
-                    ),
-                    method=opt_method,
-                    name=aux,
-                )
-            if not status_names.empty:
-                m.add_piecewise_formulation(
-                    (
-                        y_var.sel(name=status_names),
-                        y_breakpoints.sel(name=status_names),
-                        opt_sign,
-                    ),
-                    (
-                        x_var.sel(name=status_names),
-                        x_breakpoints.sel(name=status_names),
-                    ),
-                    method=opt_method,
-                    active=opt_status,
-                    name=aux + "_status",
-                )
+            m.add_piecewise_formulation(
+                (y_var.sel(name=names), y_breakpoints.sel(name=names), opt_sign),
+                (x_var.sel(name=names), x_breakpoints.sel(name=names)),
+                method=opt_method,
+                name=aux,
+                active=active,
+            )
         pw_names = pw_names.difference(names)
     return y_var_sel
 

--- a/test/test_lopf_piecewise_costs.py
+++ b/test/test_lopf_piecewise_costs.py
@@ -305,6 +305,80 @@ class TestPiecewiseCostsResults:
         )
 
 
+# TODO: update to a non-zero starting x point on the piecewise curve once we handle non-zero intercepts on cumulative curves
+class TestPiecewiseCostsStatus:
+    @pytest.fixture
+    def base_network(self):
+        n = pypsa.Network()
+        n.add("Bus", "bus0")
+        n.add("Load", "load", bus="bus0", p_set=80)
+        return n
+
+    def test_piecewise_marginal_cost_considers_status(self, base_network):
+        """Piecewise marginal cost considers the binary unit commitment status of the component."""
+        n = base_network
+        n.add("Generator", "gen0", bus="bus0", p_nom=100, marginal_cost=50)
+        n.add(
+            "Generator",
+            "gen-committable",
+            bus="bus0",
+            p_nom=100,
+            # effectively setting a p_min_pu of 0.1 which shouldn't be binding because the generator is committable and can be turned off
+            marginal_cost={0.0: 60, 0.5: 75, 1.0: 100.0},
+            committable=True,
+        )
+        n.optimize()
+        assert (n.c.generators.dynamic.p["gen-committable"] == 0).all()
+
+    def test_piecewise_marginal_cost_considers_status_two_piecewise_costs(
+        self, base_network
+    ):
+        """Piecewise marginal cost considers the binary unit commitment status of the component when there is a mix of committable and non-committable piecewise generators."""
+        n = base_network
+        n.add("Generator", "gen0", bus="bus0", p_nom=100, marginal_cost=50)
+        n.add(
+            "Generator",
+            "gen1",
+            bus="bus0",
+            p_nom=100,
+            marginal_cost={0.0: 60.0, 0.1: 60.0, 0.5: 35.0, 1.0: 100.0},
+        )
+        n.add(
+            "Generator",
+            "gen-committable",
+            bus="bus0",
+            p_nom=100,
+            marginal_cost={0.0: 60, 0.5: 75, 1.0: 100.0},
+            committable=True,
+        )
+        n.optimize()
+        assert (n.c.generators.dynamic.p["gen-committable"] == 0).all()
+
+    def test_piecewise_marginal_cost_considers_status_two_committable_generators(
+        self, base_network
+    ):
+        """Piecewise marginal cost considers the binary unit commitment status of the component when there is a mix of committable and non-committable piecewise generators."""
+        n = base_network
+        n.add(
+            "Generator",
+            "gen0",
+            bus="bus0",
+            p_nom=100,
+            marginal_cost=50,
+            committable=True,
+        )
+        n.add(
+            "Generator",
+            "gen-committable",
+            bus="bus0",
+            p_nom=100,
+            marginal_cost={0.0: 60, 0.5: 75, 1.0: 100.0},
+            committable=True,
+        )
+        n.optimize()
+        assert (n.c.generators.dynamic.p["gen-committable"] == 0).all()
+
+
 class TestPiecewiseCostsErrors:
     def test_piecewise_capital_cost_with_overnight_cost_raises(self) -> None:
         """Defining overnight_cost next to a piecewise capital_cost curve is ambiguous."""

--- a/test/test_lopf_piecewise_efficiency.py
+++ b/test/test_lopf_piecewise_efficiency.py
@@ -13,124 +13,171 @@ import pytest
 import pypsa
 
 
-@pytest.fixture
-def piecewise_efficiency_network() -> pypsa.Network:
-    n = pypsa.Network()
-    n.add("Bus", "bus0")
-    n.add("Carrier", "gas", co2_emissions=1.0)
-    n.add(
-        "Generator",
-        "gen",
-        carrier="gas",
-        bus="bus0",
-        p_nom=70,
-        marginal_cost=20,
-        efficiency={0.1: 0.3, 0.5: 0.4, 1.0: 0.6},
-    )
-    n.add(
-        "GlobalConstraint",
-        "co2_limit",
-        sense="<=",
-        carrier_attribute="co2_emissions",
-        constant=160,
-    )
-    n.add("Load", "load", bus="bus0", p_set=50)
-    return n
-
-
-def test_piecewise_efficiency_uses_equality_formulation(
-    piecewise_efficiency_network: pypsa.Network,
-) -> None:
-    model = piecewise_efficiency_network.optimize.create_model(
-        include_objective_constant=False
-    )
-    formulation = model._piecewise_formulations["Generator-p_primary_piecewise"]
-    assert formulation.method == "incremental"
-
-
-def test_piecewise_efficiency_rejects_lp_equality(
-    piecewise_efficiency_network: pypsa.Network,
-) -> None:
-    with pytest.raises(ValueError, match="method='lp' requires exactly one tuple"):
-        piecewise_efficiency_network.optimize.create_model(
-            include_objective_constant=False,
-            piecewise_options=[
-                {
-                    "component": "Generator",
-                    "attribute": "efficiency",
-                    "sign": "==",
-                    "method": "lp",
-                }
-            ],
+class TestPiecewiseGeneratorEfficiency:
+    @pytest.fixture
+    def piecewise_efficiency_network(self) -> pypsa.Network:
+        n = pypsa.Network()
+        n.add("Bus", "bus0")
+        n.add("Carrier", "gas", co2_emissions=1.0)
+        n.add(
+            "Generator",
+            "gen",
+            carrier="gas",
+            bus="bus0",
+            p_nom=70,
+            marginal_cost=20,
+            efficiency={0.1: 0.3, 0.5: 0.4, 1.0: 0.6},
         )
+        n.add(
+            "GlobalConstraint",
+            "co2_limit",
+            sense="<=",
+            carrier_attribute="co2_emissions",
+            constant=160,
+        )
+        n.add("Load", "load", bus="bus0", p_set=50)
+        return n
 
+    def test_piecewise_efficiency_uses_equality_formulation(
+        self, piecewise_efficiency_network: pypsa.Network
+    ) -> None:
+        model = piecewise_efficiency_network.optimize.create_model(
+            include_objective_constant=False
+        )
+        formulation = model._piecewise_formulations["Generator-p_primary_piecewise"]
+        assert formulation.method == "incremental"
 
-def test_piecewise_efficiency_co2_constraint_with_only_segmented_gens(
-    piecewise_efficiency_network: pypsa.Network,
-) -> None:
-    """Regression: when every CO2-emitting generator has piecewise efficiency,
-    ``linear_names`` is empty and ``primary_energy`` must still be initialised."""
-    n = piecewise_efficiency_network
-    n.optimize()
-    assert n.c.generators.dynamic.p["gen"].iloc[0] == pytest.approx(50.0, rel=1e-3)
+    def test_piecewise_efficiency_rejects_lp_equality(
+        self,
+        piecewise_efficiency_network: pypsa.Network,
+    ) -> None:
+        with pytest.raises(ValueError, match="method='lp' requires exactly one tuple"):
+            piecewise_efficiency_network.optimize.create_model(
+                include_objective_constant=False,
+                piecewise_options=[
+                    {
+                        "component": "Generator",
+                        "attribute": "efficiency",
+                        "sign": "==",
+                        "method": "lp",
+                    }
+                ],
+            )
 
+    def test_piecewise_efficiency_co2_constraint_with_only_segmented_gens(
+        self, piecewise_efficiency_network: pypsa.Network
+    ) -> None:
+        """Regression: when every CO2-emitting generator has piecewise efficiency,
+        ``linear_names`` is empty and ``primary_energy`` must still be initialised."""
+        n = piecewise_efficiency_network
+        n.optimize()
+        assert n.c.generators.dynamic.p["gen"].iloc[0] == pytest.approx(50.0, rel=1e-3)
 
-def test_piecewise_efficiency_two_primary_energy_constraints(
-    piecewise_efficiency_network: pypsa.Network,
-) -> None:
-    """Regression: multiple primary-energy constraints share one piecewise aux variable."""
-    n = piecewise_efficiency_network
-    n.add(
-        "GlobalConstraint",
-        "co2_limit2",
-        sense="<=",
-        carrier_attribute="co2_emissions",
-        constant=170,
-    )
-    status, _ = n.optimize()
-    assert status == "ok"
-    assert n.generators_t.p["gen"].iloc[0] == pytest.approx(50.0, rel=1e-3)
+    def test_piecewise_efficiency_two_primary_energy_constraints(
+        self,
+        piecewise_efficiency_network: pypsa.Network,
+    ) -> None:
+        """Regression: multiple primary-energy constraints share one piecewise aux variable."""
+        n = piecewise_efficiency_network
+        n.add(
+            "GlobalConstraint",
+            "co2_limit2",
+            sense="<=",
+            carrier_attribute="co2_emissions",
+            constant=170,
+        )
+        status, _ = n.optimize()
+        assert status == "ok"
+        assert n.generators_t.p["gen"].iloc[0] == pytest.approx(50.0, rel=1e-3)
 
+    def test_piecewise_efficiency_gen(self) -> None:
+        """gen0 is cheaper but cannot meet all load without hitting co2 limit. Gen1 comes in based on its piecewise curve rate."""
+        n = pypsa.Network()
+        n.add("Bus", "bus0")
+        n.add("Carrier", "gas", co2_emissions=1.0)
+        x_points = np.array([0.1, 0.5, 1.0])
+        y_points = np.array([0.3, 0.4, 0.6])
+        n.add(
+            "Generator",
+            "gen0",
+            carrier="gas",
+            bus="bus0",
+            p_nom=70,
+            marginal_cost=15,
+            efficiency=0.35,
+        )
+        n.add(
+            "Generator",
+            "gen1",
+            carrier="gas",
+            bus="bus0",
+            p_nom=70,
+            marginal_cost=20,
+            efficiency=pd.DataFrame({"p_pu": x_points, "efficiency": y_points}),
+        )
+        n.add(
+            "GlobalConstraint",
+            "co2_limit",
+            sense="<=",
+            carrier_attribute="co2_emissions",
+            constant=160,
+        )
+        n.add("Load", "load", bus="bus0", p_set=80)
+        n.optimize()
+        p = n.generators_t.p.iloc[0]
+        fuel = p["gen0"] / 0.35 + np.interp(
+            p["gen1"], 70 * x_points, 70 * x_points / y_points
+        )
+        assert fuel <= 160 * (1 + 1e-6)
 
-def test_piecewise_efficiency_gen() -> None:
-    """gen0 is cheaper but cannot meet all load without hitting co2 limit. Gen1 comes in based on its piecewise curve rate."""
-    n = pypsa.Network()
-    n.add("Bus", "bus0")
-    n.add("Carrier", "gas", co2_emissions=1.0)
-    x_points = np.array([0.1, 0.5, 1.0])
-    y_points = np.array([0.3, 0.4, 0.6])
-    n.add(
-        "Generator",
-        "gen0",
-        carrier="gas",
-        bus="bus0",
-        p_nom=70,
-        marginal_cost=15,
-        efficiency=0.35,
-    )
-    n.add(
-        "Generator",
-        "gen1",
-        carrier="gas",
-        bus="bus0",
-        p_nom=70,
-        marginal_cost=20,
-        efficiency=pd.DataFrame({"p_pu": x_points, "efficiency": y_points}),
-    )
-    n.add(
-        "GlobalConstraint",
-        "co2_limit",
-        sense="<=",
-        carrier_attribute="co2_emissions",
-        constant=160,
-    )
-    n.add("Load", "load", bus="bus0", p_set=80)
-    n.optimize()
-    p = n.generators_t.p.iloc[0]
-    fuel = p["gen0"] / 0.35 + np.interp(
-        p["gen1"], 70 * x_points, 70 * x_points / y_points
-    )
-    assert fuel <= 160 * (1 + 1e-6)
+    def test_piecewise_efficiency_gen_with_status(self) -> None:
+        n = pypsa.Network()
+        n.add("Bus", "bus0")
+        n.add("Carrier", "gas", co2_emissions=1.0)
+        # First x point is 10%, effectively setting a p_min_pu.
+        # This should not _require_ the committable generator to be utilized, unlike the non-committable generator.
+        x_points = np.array([0.1, 0.5, 1.0])
+        y_points = np.array([0.3, 0.3, 0.3])
+        n.add(
+            "Generator",
+            "gen0",
+            carrier="gas",
+            bus="bus0",
+            p_nom=80,
+            marginal_cost=15,
+            efficiency=0.6,
+        )
+        n.add(
+            "Generator",
+            "gen-committable",
+            carrier="gas",
+            bus="bus0",
+            p_nom=70,
+            marginal_cost=20,
+            efficiency=pd.DataFrame({"p_pu": x_points, "efficiency": y_points}),
+            committable=True,
+        )
+        n.add(
+            "Generator",
+            "gen-non-committable",
+            carrier="gas",
+            bus="bus0",
+            p_nom=70,
+            marginal_cost=20,
+            efficiency=pd.DataFrame({"p_pu": x_points, "efficiency": y_points}),
+            committable=False,
+        )
+        n.add(
+            "GlobalConstraint",
+            "co2_limit",
+            sense="<=",
+            carrier_attribute="co2_emissions",
+            constant=160,
+        )
+        n.add("Load", "load", bus="bus0", p_set=80)
+        n.optimize()
+        assert n.generators_t.p["gen-committable"].sum() == 0
+        assert n.generators_t.p["gen-non-committable"].sum() > 0
 
 
 class TestPiecewiseMultiPort2Bus:
@@ -257,6 +304,33 @@ class TestPiecewiseMultiPort2Bus:
         load = pd.Series([20.0, 30.0, 40.0]).rename_axis(index="snapshot")
         supply = -n.c.processes.dynamic.p1.sum(axis=1)
         pd.testing.assert_series_equal(supply, load, check_names=False)
+
+    def test_piecewise_efficiency_with_status(
+        self, base_network: pypsa.Network, base_multiport_attrs: dict
+    ) -> None:
+        """Committable multiports shouldn't be forced to run at the first breakpoint level, unlike non-committable multiports."""
+        n = base_network
+        n.add(
+            "Link",
+            efficiency=0.5,
+            **base_multiport_attrs,
+        )
+        n.add(
+            "Link",
+            efficiency={0.1: 0.3, 0.5: 0.2, 1.0: 0.1},
+            committable=False,
+            **{**base_multiport_attrs, "name": "link-non-committable"},
+        )
+        n.add(
+            "Link",
+            efficiency={0.1: 0.3, 0.5: 0.2, 1.0: 0.1},
+            committable=True,
+            **{**base_multiport_attrs, "name": "link-committable"},
+        )
+        status, _ = n.optimize(reformulate_sos=True)
+        assert status == "ok"
+        assert n.links_t.p["link-committable"].sum() == 0
+        assert n.links_t.p["link-non-committable"].sum() > 0
 
 
 class TestPiecewiseMultiPort3Bus:

--- a/test/test_optimization_piecewise.py
+++ b/test/test_optimization_piecewise.py
@@ -419,6 +419,9 @@ class TestDefinePiecewise:
         m.add_variables(name="x_static", coords=[idx])
         m.add_variables(name="y_static", coords=[idx])
         m.add_variables(name="x_dynamic", coords=[idx, snapshots])
+        m.add_variables(
+            name="x_status", coords=[idx, snapshots], mask=idx == "gen1", binary=True
+        )
         return m
 
     @pytest.fixture(scope="class")
@@ -591,3 +594,29 @@ class TestDefinePiecewise:
         n_w_suffix = keys.str.startswith("foo_static_gen1").sum()
         n_all = keys.str.startswith("foo_static").sum()
         assert n_w_suffix == n_all / 2
+
+    def test_use_status(self, linopy_model, default_kwargs):
+        """Test that status variable is used in piecewise constraint."""
+        _ = define_piecewise(
+            x_var=linopy_model["x_static"],
+            pw_attr="marginal_cost",
+            aux_var_name="foo_static",
+            active_names=pd.Index(["gen1", "gen_extendable"], name="name"),
+            status=linopy_model["x_status"],
+            **default_kwargs,
+        )
+        assert set(
+            linopy_model.constraints["foo_static_status_active_bound"].indexes["name"]
+        ) == {"gen1"}
+
+    def test_use_status_no_active(self, linopy_model, default_kwargs):
+        """Test that status variable is used in piecewise constraint."""
+        _ = define_piecewise(
+            x_var=linopy_model["x_static"],
+            pw_attr="marginal_cost",
+            aux_var_name="foo_static",
+            active_names=pd.Index(["gen0", "gen_extendable"], name="name"),
+            status=linopy_model["x_status"],
+            **default_kwargs,
+        )
+        assert "foo_static_status_active_bound" not in linopy_model.constraints

--- a/test/test_optimization_piecewise.py
+++ b/test/test_optimization_piecewise.py
@@ -606,7 +606,7 @@ class TestDefinePiecewise:
             **default_kwargs,
         )
         assert set(
-            linopy_model.constraints["foo_static_status_active_bound"].indexes["name"]
+            linopy_model.constraints["foo_static_active_bound"].indexes["name"]
         ) == {"gen1"}
 
     def test_use_status_no_active(self, linopy_model, default_kwargs):
@@ -619,4 +619,4 @@ class TestDefinePiecewise:
             status=linopy_model["x_status"],
             **default_kwargs,
         )
-        assert "foo_static_status_active_bound" not in linopy_model.constraints
+        assert "foo_static_active_bound" not in linopy_model.constraints


### PR DESCRIPTION
Adds functionality to handle the committable `status` of components in piecewise.

@FabianHofmann I had to split the piecewise definition in two whenever `status` is used (one pw definition with `active` used, one without) as otherwise it creates unexpected results in linopy. Namely, it seems to force the dispatch of components without a `status` variable to zero (via the `_active` pw constraint). I don't have time to investigate this further right now so thought I'd check with you in case it is my misinterpretation or an actual issue with the linopy implementation. Either way, the current implementation is a workaround that passes the tests.

I'm opening this in a separate PR as we might want to leave it out of #1603 and only come to consider this when it is rebased onto `master` post-merge. I don't mind either way. If it highlights issues that should already be solved in #1603 it might be worthwhile to already merge it in there.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [ ] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [ ] I consent to the release of this PR's code under the MIT license.
