### PR TITLE
fix(io): correct shunt susceptance sign on pandapower import

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix `KeyError` in [`n.pf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.pf] and [`n.lpf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.lpf] when a network contains multiple sub-networks and one of them has no transformers (or otherwise lacks a passive branch component present in another sub-network). (<!-- md:pr 1754 -->)
 
+- Fix the sign of the shunt susceptance when importing from pandapower. A shunt with `q_mvar > 0` (inductive) was previously imported with the wrong sign, causing the power flow to diverge from pandapower. (<!-- md:issue 477 -->)
+
 
 ## [**v1.2.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.2) <small>25th May 2026</small> { id="v1.2.2" }
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,7 +32,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix `KeyError` in [`n.pf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.pf] and [`n.lpf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.lpf] when a network contains multiple sub-networks and one of them has no transformers (or otherwise lacks a passive branch component present in another sub-network). (<!-- md:pr 1754 -->)
 
-- Fix the sign of the shunt susceptance when importing from pandapower. A shunt with `q_mvar > 0` (inductive) was previously imported with the wrong sign, causing the power flow to diverge from pandapower. (<!-- md:issue 477 -->)
+- Fix the sign of the shunt susceptance when importing from pandapower. A shunt with `q_mvar > 0` (inductive) was previously imported with the wrong sign, causing the power flow to diverge from pandapower. (<!-- md:pr 1758 -->)
 
 
 ## [**v1.2.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.2) <small>25th May 2026</small> { id="v1.2.2" }

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -2423,7 +2423,7 @@ class NetworkIOMixin(_NetworkABC):
 
         # documented at https://docs.pypsa.org/latest/user-guide/components/shunt-impedances
         g_shunt = net.shunt.p_mw.values / net.shunt.vn_kv.values**2
-        b_shunt = net.shunt.q_mvar.values / net.shunt.vn_kv.values**2
+        b_shunt = -net.shunt.q_mvar.values / net.shunt.vn_kv.values**2
 
         d["ShuntImpedance"] = pd.DataFrame(
             {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -353,7 +353,7 @@ def pandapower_custom_network():
     # create bus elements
     pp.create_ext_grid(net, bus=bus1, vm_pu=1.02, name="Grid Connection")
     pp.create_load(net, bus=bus3, p_mw=0.100, q_mvar=0.05, name="Load")
-    pp.create_shunt(net, bus=bus3, p_mw=0.0, q_mvar=0.0, name="Shunt")
+    pp.create_shunt(net, bus=bus3, p_mw=0.02, q_mvar=0.05, name="Shunt")
     # create branch elements
     pp.create_transformer(
         net, hv_bus=bus1, lv_bus=bus2, std_type="0.4 MVA 20/0.4 kV", name="Trafo"

--- a/test/test_pf_against_pandapower.py
+++ b/test/test_pf_against_pandapower.py
@@ -51,11 +51,24 @@ def test_pandapower_custom_case(
     # compare bus voltage magnitudes
     equal(n.c.buses.dynamic.v_mag_pu.loc[DEFAULT_TIMESTAMP], net.res_bus.vm_pu)
 
-    # compare bus active power (NB: pandapower uses load signs)
-    equal(n.c.buses.dynamic.p.loc[DEFAULT_TIMESTAMP], -net.res_bus.p_mw)
+    # pandapower folds shunt impedance power into the bus totals, while PyPSA
+    # reports it on the shunt component (p positive if load, q positive if
+    # generation), so add it back in the bus injection convention before comparing
+    buses_i = n.c.buses.static.index
+    shunt = n.c.shunt_impedances
+    by_bus = shunt.static.bus
+    p_per_shunt = shunt.dynamic.p.loc[DEFAULT_TIMESTAMP]
+    q_per_shunt = shunt.dynamic.q.loc[DEFAULT_TIMESTAMP]
+    shunt_p = p_per_shunt.groupby(by_bus).sum().reindex(buses_i, fill_value=0.0)
+    shunt_q = q_per_shunt.groupby(by_bus).sum().reindex(buses_i, fill_value=0.0)
+    bus_p = n.c.buses.dynamic.p.loc[DEFAULT_TIMESTAMP] - shunt_p
+    bus_q = n.c.buses.dynamic.q.loc[DEFAULT_TIMESTAMP] + shunt_q
 
     # compare bus active power (NB: pandapower uses load signs)
-    equal(n.c.buses.dynamic.q.loc[DEFAULT_TIMESTAMP], -net.res_bus.q_mvar)
+    equal(bus_p, -net.res_bus.p_mw)
+
+    # compare bus reactive power (NB: pandapower uses load signs)
+    equal(bus_q, -net.res_bus.q_mvar)
 
     # compare branch flows
     equal(n.c.lines.dynamic.p0.loc[DEFAULT_TIMESTAMP], net.res_line.p_from_mw)


### PR DESCRIPTION
Closes #477 

## Changes proposed in this Pull Request

A shunt with q_mvar > 0 (inductive) was imported with the wrong sign, diverging from pandapower. Enable q_mvar > 0 in the test fixture and account for PyPSA reporting shunt power separately from the bus totals.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
