### PR TITLE
fix: warn when standard type overrides manual branch impedances

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix `KeyError` in [`n.pf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.pf] and [`n.lpf()`][pypsa.network.power_flow.NetworkPowerFlowMixin.lpf] when a network contains multiple sub-networks and one of them has no transformers (or otherwise lacks a passive branch component present in another sub-network). (<!-- md:pr 1754 -->)
 
+- A warning is now logged when manually set impedance parameters (`r`, `x`, `g`, `b`, `s_nom`) on transformers or lines with a standard `type` are overridden by the type during [`n.calculate_dependent_values()`][pypsa.network.power_flow.NetworkPowerFlowMixin.calculate_dependent_values], instead of silently discarding them. (<!-- md:pr 1759 -->)
+
 
 ## [**v1.2.2**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.2) <small>25th May 2026</small> { id="v1.2.2" }
 

--- a/pypsa/network/power_flow.py
+++ b/pypsa/network/power_flow.py
@@ -422,6 +422,22 @@ def sub_network_pf_singlebus(
     return 0, 0.0, True  # dummy substitute for newton raphson output
 
 
+def _warn_type_param_override(
+    component: str, current: pd.DataFrame, new: pd.DataFrame, attrs: list[str]
+) -> None:
+    """Warn if non-default manual impedance values are overridden by a standard type."""
+    differs = (current[attrs].to_numpy() != 0) & ~np.isclose(current[attrs], new[attrs])
+    overridden = current.index[differs.any(axis=1)]
+    if not overridden.empty:
+        logger.warning(
+            "%s %s have a 'type' set; the manually provided values for %s are "
+            "overridden by the standard type. Set 'type' to \"\" to keep manual values.",
+            component,
+            overridden.tolist(),
+            ", ".join(attrs),
+        )
+
+
 def apply_line_types(n: Network) -> None:
     """Calculate line electrical parameters x, r, b, g from standard types."""
     lines_with_types_b = n.c.lines.static.type != ""
@@ -466,7 +482,11 @@ def apply_line_types(n: Network) -> None:
     )
 
     # now set calculated values on live lines
-    for attr in ["r", "x", "b"]:
+    line_attrs = ["r", "x", "b"]
+    _warn_type_param_override(
+        "Line(s)", n.c.lines.static.loc[lines_with_types_b], lines, line_attrs
+    )
+    for attr in line_attrs:
         n.c.lines.static.loc[lines_with_types_b, attr] = lines[attr]
 
 
@@ -533,6 +553,12 @@ def apply_transformer_types(n: Network) -> None:
 
     # now set calculated values on live transformers
     attrs = ["r", "x", "g", "b", "phase_shift", "s_nom", "tap_side", "tap_ratio"]
+    _warn_type_param_override(
+        "Transformer(s)",
+        n.c.transformers.static.loc[trafos_with_types_b],
+        t,
+        ["r", "x", "g", "b", "s_nom"],
+    )
     n.c.transformers.static.loc[trafos_with_types_b, attrs] = t[attrs].astype(
         n.c.transformers.static[attrs].dtypes
     )

--- a/test/test_standard_types.py
+++ b/test/test_standard_types.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for deriving branch impedances from standard types."""
+
+import pytest
+
+import pypsa
+
+OVERRIDE_MSG = "overridden by the standard type"
+
+
+@pytest.fixture(params=["Transformer", "Line"])
+def typed_branch(request):
+    """Network with a single typed branch named 'branch'."""
+    component = request.param
+    n = pypsa.Network()
+    if component == "Transformer":
+        n.add("Bus", ["b0", "b1"], v_nom=[20.0, 0.4])
+        n.add("Transformer", "branch", bus0="b0", bus1="b1", type="0.25 MVA 20/0.4 kV")
+    else:
+        n.add("Bus", ["b0", "b1"], v_nom=380.0)
+        type_name = "Al/St 240/40 4-bundle 380.0"
+        n.add("Line", "branch", bus0="b0", bus1="b1", length=10.0, type=type_name)
+    return n, n.components[component].static
+
+
+def test_type_derives_impedance_silently(typed_branch, caplog):
+    n, static = typed_branch
+    n.calculate_dependent_values()
+    assert static.loc["branch", "x"] > 0
+    assert OVERRIDE_MSG not in caplog.text
+
+
+def test_manual_impedance_override_warns(typed_branch, caplog):
+    """See https://github.com/PyPSA/PyPSA/issues/1054."""
+    n, static = typed_branch
+    n.calculate_dependent_values()
+
+    static.loc["branch", ["r", "x"]] = 0.01
+    n.calculate_dependent_values()
+    assert OVERRIDE_MSG in caplog.text
+    assert static.loc["branch", "r"] != 0.01
+
+    caplog.clear()
+    n.calculate_dependent_values()
+    assert OVERRIDE_MSG not in caplog.text


### PR DESCRIPTION
Closes #1054

## Changes proposed in this Pull Request

Setting r/x/g/b/s_nom on a transformer or line with a 'type' was silently discarded by calculate_dependent_values. Emit a warning at the override site when non-default manual values are replaced.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
