### PR TITLE
fix: support netCDF export under pandas>=3 future.infer_string

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Bug Fixes
 
+- Fix `optimize()` and [`export_to_netcdf()`][pypsa.Network.export_to_netcdf] failing under pandas `>= 3.0` / `future.infer_string`. String labels are now converted back to `object` on both import and export. (<!-- md:pr 1687 -->)
+
 - Fixed the `suffix` argument of [`n.add`][pypsa.Network.add] and [`n.remove`][pypsa.Network.remove]. Passing a list to both `name` and `suffix` now raises an error instead of silently pairing them. (<!-- md:pr 1682 -->)
 
 ## [**v1.2.3**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.3) <small>12th June 2026</small> { id="v1.2.3" }
@@ -50,8 +52,6 @@ SPDX-License-Identifier: CC-BY-4.0
 - Fix operational constraints for non-extendable components producing `NaN` bounds when `p_nom` is infinite and `p_min_pu`/`p_max_pu` is zero. The bound now falls back to zero in this case. Relevant for linopy versions `>=0.7` where `NaN` bounds are not dropped explicitly. (<!-- md:pr 1683 -->)
 
 - Lift `xarray<2026.4` upper bound and bump `linopy>=0.7.0` floor. (<!-- md:pr 1686 -->)
-
-- Fix `optimize()` failing with `TypeError: Invalid array type` on networks loaded from file or built with `n.add()` when using pandas `>= 3.0` or `future.infer_string`. Component labels read in pandas' new string dtype are now converted back to `object` on import. (<!-- md:pr 1687 -->)
 
 
 ## [**v1.2.1**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.1) <small>19th May 2026</small> { id="v1.2.1" }

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1090,13 +1090,18 @@ class _ExporterNetCDF(_Exporter):
 
         Runs post-processing, compression and saving to disk.
         """
+        # pandas>=3 infer_string strings aren't netCDF-writable. Cast to object and
+        # write with the option off to keep NaNs. https://github.com/pydata/xarray/issues/10301
+        for name in list(self.ds.variables):
+            if isinstance(self.ds[name].dtype, pd.StringDtype):
+                self.ds[name] = self.ds[name].astype(object)
         if self.float32:
             self.typecast_float32()
         if self.compression:
             self.set_compression_encoding()
         if self.path is not None:
             _path = Path(self.path)
-            with _path.open("w"):
+            with _path.open("w"), pd.option_context("future.infer_string", False):
                 self.ds.to_netcdf(_path)
 
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -329,9 +329,9 @@ class TestNetcdf:
 
         with pd.option_context("future.infer_string", True):
             n = pypsa.examples.ac_dc_meshed()
-            assert (
-                type(n.c.buses.static.index.array).__name__
-                == "ArrowStringArrayNumpySemantics"
+            assert type(n.c.buses.static.index.array).__name__ in (
+                "ArrowStringArray",
+                "ArrowStringArrayNumpySemantics",
             )
             with pytest.raises(TypeError, match="Invalid array type"):
                 n.optimize()


### PR DESCRIPTION
Follow up on #1687 