### PR TITLE
feat: model unit scaling 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,62 @@ jobs:
           python${{ matrix.python-version }},
           api-${{ matrix.api }}
 
+  test-scaling:
+    name: Test scaling
+    needs: [build]
+    runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg # https://github.com/orgs/community/discussions/26434
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0   # Needed for setuptools_scm
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
+      with:
+        python-version: 3.13
+
+    - name: Download package
+      uses: actions/download-artifact@v8
+      with:
+        name: Packages
+        path: dist
+
+    - name: Install package and dependencies
+      run: |
+        python -m pip install uv
+        uv sync --all-extras --no-install-project
+        uv pip install "$(ls dist/*.whl)"
+
+    - name: Run unit tests with scaling
+      run: >
+        uv run pytest --scaling
+        --cov=pypsa --junitxml=junit.xml -o junit_family=legacy
+        && uv run coverage xml
+
+    - name: Upload code coverage report
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: >
+          unit-tests,
+          os-ubuntu-latest,
+          python3.13,
+          api-scaling
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: >
+          unit-tests,
+          os-ubuntu-latest,
+          python3.13,
+          api-scaling
+
   test-plots:
     # Run the matplotlib image-comparison tests once, on a single instance.
     # Baselines are generated on Linux; see test/test_statistics_plot.py.

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -125,6 +125,11 @@ optimize.include_objective_constant:
         objective. Setting False sets n.objective_constant to zero and improves LP
         numerical conditioning. None defaults to True with a FutureWarning (changes to
         False in v2.0).
+optimize.scaling:
+    Default: False
+    Description: Default value for the 'scaling' parameter in optimization. False means
+        no scaling, True uses energy/1e3, cost/1e3, emissions/1e6, and a dict overrides
+        any subset. See n.optimize(scaling=...).
 consistency.numerical_tolerance:
     Default: 1e-09
     Description: Tolerance for numerical comparisons in consistency checks (e.g. p_min_pu > p_max_pu).

--- a/pypsa/_options.py
+++ b/pypsa/_options.py
@@ -477,6 +477,13 @@ options._add_option(
     "Setting False sets n.objective_constant to zero and improves LP numerical "
     "conditioning. None defaults to True with a FutureWarning (changes to False in v2.0).",
 )
+options._add_option(
+    "params.optimize.scaling",
+    False,
+    "Default value for the 'scaling' parameter in optimization. False means no "
+    "scaling, True uses energy/1e3, cost/1e3, emissions/1e6, and a dict overrides "
+    "any subset. See n.optimize(scaling=...).",
+)
 
 options._add_option(
     "params.consistency.numerical_tolerance",

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -54,6 +54,7 @@ from pypsa.network.power_flow import (
 )
 from pypsa.network.transform import NetworkTransformMixin
 from pypsa.optimization.optimize import OptimizationAccessor
+from pypsa.optimization.scaling import Scaler
 from pypsa.plot.accessor import PlotAccessor
 from pypsa.plot.maps import explore
 from pypsa.statistics.expressions import StatisticsAccessor
@@ -65,7 +66,6 @@ if TYPE_CHECKING:
     from scipy.sparse import spmatrix
 
     from pypsa.components.legacy import Component
-    from pypsa.optimization.scaling import Scaler
 
 
 logger = logging.getLogger(__name__)
@@ -532,6 +532,7 @@ class Network(
             PlotAccessor,
             AbstractStatisticsAccessor,
             linopy.Model,
+            Scaler,
         ]
         not_equal = False
         if isinstance(other, self.__class__):

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -91,6 +91,7 @@ class Network(
     _multi_invest: int
     _linearized_uc: int
     _committable_big_m: float | None
+    _scaling: dict[str, float]
     iteration: int
 
     # ----------------
@@ -162,6 +163,7 @@ class Network(
         self._objective_constant: float | None = None
         self._multi_invest: int = 0
         self._committable_big_m: float | None = None
+        self._scaling: dict[str, float] = {"energy": 1.0, "cost": 1.0, "emissions": 1.0}
 
         # Initialize accessors
         self.optimize: OptimizationAccessor = OptimizationAccessor(self)

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     from scipy.sparse import spmatrix
 
     from pypsa.components.legacy import Component
+    from pypsa.optimization.scaling import Scaler
 
 
 logger = logging.getLogger(__name__)
@@ -92,6 +93,7 @@ class Network(
     _linearized_uc: int
     _committable_big_m: float | None
     _scaling: dict[str, float]
+    _scaler: Scaler | None
     iteration: int
 
     # ----------------
@@ -164,6 +166,7 @@ class Network(
         self._multi_invest: int = 0
         self._committable_big_m: float | None = None
         self._scaling: dict[str, float] = {"energy": 1.0, "cost": 1.0, "emissions": 1.0}
+        self._scaler: Scaler | None = None
 
         # Initialize accessors
         self.optimize: OptimizationAccessor = OptimizationAccessor(self)

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -692,6 +692,11 @@ def _define_ramp_limit_big_m(
         p_init = c.da.p_init.sel(name=idx).where(initially_up, 0)
         s_init = initially_up
 
+    # scale the raw p_init constant like the p variable it is compared to
+    scale = n._scaling["energy"]
+    if scale != 1:
+        p_init = p_init / scale
+
     p_prev_ce = p.shift(snapshot=1) + p_init.fillna(0) * filter_first_sn
     status_prev_ce = status.shift(snapshot=1) + s_init.fillna(0) * filter_first_sn
 
@@ -833,6 +838,11 @@ def define_ramp_limit_constraints(
         p_init = c.da.p_init.where(initially_up, 0)
         s_init = initially_up
         mask[0] = p_init.notnull()
+
+    # scale the raw p_init constant like the p variable it is compared to
+    scale = n._scaling["energy"]
+    if scale != 1:
+        p_init = p_init / scale
 
     # skip starts of periods except the first where p_init is used
     boundary = _period_start_mask(sns)
@@ -2018,7 +2028,8 @@ def define_tangent_loss_constraints(
         )
         raise ValueError(msg)
 
-    r_pu_eff = c.da.r_pu_eff
+    scale = n._scaling["energy"]
+    r_pu_eff = c.da.r_pu_eff * scale if scale != 1 else c.da.r_pu_eff
 
     # Calculate upper bound on losses
     upper_limit = r_pu_eff * (s_max_pu * s_nom_max) ** 2
@@ -2125,7 +2136,12 @@ def define_secant_loss_constraints(
         )
         raise ValueError(msg)
 
-    r_pu_eff = c.da.r_pu_eff
+    scale = n._scaling["energy"]
+    if scale != 1:
+        r_pu_eff = c.da.r_pu_eff * scale
+        atol = atol / scale
+    else:
+        r_pu_eff = c.da.r_pu_eff
 
     # Calculate upper bound on losses
     upper_limit = r_pu_eff * (s_max_pu * s_nom_max) ** 2

--- a/pypsa/optimization/mga.py
+++ b/pypsa/optimization/mga.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import signal
 import tempfile
+from contextlib import nullcontext
 from multiprocessing import get_context
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -262,6 +263,10 @@ class OptimizationAbstractMGAMixin:
             ).sum()
             fixed_cost = (n.statistics.installed_capex().sum() * w).sum()
 
+        # Scale the unscaled cost constants to match the model's scaled objective.
+        optimal_cost /= n._scaling["energy"]
+        fixed_cost /= n._scaling["energy"]
+
         # Add constraint
         objective = n.model.objective
         if not isinstance(objective, (LinearExpression | QuadraticExpression)):
@@ -346,9 +351,6 @@ class OptimizationAbstractMGAMixin:
             **model_kwargs,
         )
 
-        # add budget constraint
-        self._n.optimize._add_near_opt_constraint(multi_investment_periods, slack)
-
         # parse optimization sense
         if (
             isinstance(sense, str)
@@ -368,8 +370,11 @@ class OptimizationAbstractMGAMixin:
             msg = f"Could not parse optimization sense {sense}"
             raise ValueError(msg)
 
-        # build alternate objective
-        m.objective = self.build_linexpr_from_weights(weights, model=m) * sense
+        # Build budget constraint and objective in the model's scaled units.
+        factors = n._scaler
+        with factors.applied(n) if factors else nullcontext():
+            self._n.optimize._add_near_opt_constraint(multi_investment_periods, slack)
+            m.objective = self.build_linexpr_from_weights(weights, model=m) * sense
 
         status, condition = self._n.optimize.solve_model(**kwargs)
 
@@ -504,16 +509,18 @@ class OptimizationAbstractMGAMixin:
             **model_kwargs,
         )
 
-        # build budget constraint
-        self._n.optimize._add_near_opt_constraint(multi_investment_periods, slack)
-
-        # Build objective as linear combination of direction and
-        # dimensions. Flip the sign in order to maximize in the given
-        # direction.
-        m.objective = -sum(
-            direction[key] * self.build_linexpr_from_weights(dimensions[key], model=m)
-            for key in direction.keys()
-        )
+        # Build budget constraint and objective in the model's scaled units.
+        factors = self._n._scaler
+        with factors.applied(self._n) if factors else nullcontext():
+            self._n.optimize._add_near_opt_constraint(multi_investment_periods, slack)
+            # Build objective as linear combination of direction and
+            # dimensions. Flip the sign in order to maximize in the given
+            # direction.
+            m.objective = -sum(
+                direction[key]
+                * self.build_linexpr_from_weights(dimensions[key], model=m)
+                for key in direction.keys()
+            )
 
         status, condition = self._n.optimize.solve_model(**kwargs)
         coordinates = self.project_solved(dimensions) if status == "ok" else None

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -460,7 +460,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         include_objective_constant: bool | None = None,
         committable_big_m: float | None = None,
         meshed_thresholds: Sequence[int] | None = None,
-        scaling: bool | dict = False,
+        scaling: bool | dict | None = None,
         **kwargs: Any,
     ) -> tuple[str, str]:
         """Optimize the pypsa network using linopy.
@@ -530,10 +530,11 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         meshed_thresholds : Sequence[int] | None, default: None
             Thresholds for splitting buses into nodal-balance constraint groups by
             bus connectivity count. Defaults to ``[30, 100, 400]``.
-        scaling : bool | dict, default False
+        scaling : bool | dict | None, default None
             Rescale to better conditioned units before solving, then convert
             results back. `True` uses `energy`/1e3, `cost`/1e3, `emissions`/1e6.
-            Pass a dict to override any subset.
+            Pass a dict to override any subset. When None, defaults to module
+            wide option `options.params.optimize.scaling`.
         **kwargs:
             Keyword argument used by `linopy.Model.solve`, such as `solver_name`,
             `problem_fn` or solver options directly passed to the solver.
@@ -562,6 +563,8 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         include_objective_constant = _resolve_include_objective_constant(
             include_objective_constant
         )
+        if scaling is None:
+            scaling = options.params.optimize.scaling
 
         n = self._n
         sns = as_index(n, snapshots, "snapshots")

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -550,21 +550,9 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             [linopy.constants.TerminationCondition](https://linopy.readthedocs.io/en/latest/generated/linopy.constants.TerminationCondition.html)
 
         """
-        # Handle default parameters from options
+        # Handle default parameters from options (rest resolves in solve_model)
         if model_kwargs is None:
             model_kwargs = options.params.optimize.model_kwargs.copy()
-        if solver_name is None:
-            solver_name = options.params.optimize.solver_name
-        if solver_options is None:
-            solver_options = options.params.optimize.solver_options.copy()
-        if log_to_console is None:
-            log_to_console = options.params.optimize.log_to_console
-
-        include_objective_constant = _resolve_include_objective_constant(
-            include_objective_constant
-        )
-        if scaling is None:
-            scaling = options.params.optimize.scaling
 
         n = self._n
         sns = as_index(n, snapshots, "snapshots")
@@ -573,36 +561,27 @@ class OptimizationAccessor(OptimizationAbstractMixin):
 
         n.consistency_check(strict=["unknown_buses"])
 
-        factors = Scaler.resolve(scaling)
-        with factors.applied(n) if factors else nullcontext():
-            m = n.optimize.create_model(
-                sns,
-                multi_investment_periods,
-                transmission_losses,
-                linearized_unit_commitment,
-                consistency_check=False,
-                include_objective_constant=include_objective_constant,
-                committable_big_m=committable_big_m,
-                meshed_thresholds=meshed_thresholds,
-                **model_kwargs,
-            )
-            if extra_functionality:
-                extra_functionality(n, sns)
-            if log_to_console is not None:
-                kwargs["log_to_console"] = log_to_console
-            status, condition = m.solve(
-                solver_name=solver_name,
-                **solver_options,
-                **kwargs,
-            )
-
-            if status == "ok":
-                n.optimize.assign_solution(factors)
-                n.optimize.assign_duals(assign_all_duals, factors)
-
-        # Runs after restore since post_processing copies p_set into Load p unscaled.
-        if status == "ok":
-            n.optimize.post_processing(factors)
+        n.optimize.create_model(
+            sns,
+            multi_investment_periods,
+            transmission_losses,
+            linearized_unit_commitment,
+            consistency_check=False,
+            include_objective_constant=include_objective_constant,
+            committable_big_m=committable_big_m,
+            meshed_thresholds=meshed_thresholds,
+            scaling=scaling,
+            **model_kwargs,
+        )
+        # solve_model owns the solve, scaling, assign and post lifecycle
+        status, condition = n.optimize.solve_model(
+            extra_functionality=extra_functionality,
+            solver_name=solver_name,
+            solver_options=solver_options,
+            log_to_console=log_to_console,
+            assign_all_duals=assign_all_duals,
+            **kwargs,
+        )
 
         if (
             condition == "infeasible"
@@ -623,6 +602,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         include_objective_constant: bool | None = None,
         committable_big_m: float | None = None,
         meshed_thresholds: Sequence[int] | None = None,
+        scaling: bool | dict | None = None,
         **kwargs: Any,
     ) -> Model:
         """Create a linopy.Model instance from a pypsa network.
@@ -665,6 +645,11 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         meshed_thresholds : Sequence[int] | None, default: None
             Thresholds for splitting buses into nodal-balance constraint groups by
             bus connectivity count. Defaults to ``[30, 100, 400]``.
+        scaling : bool | dict | None, default None
+            Rescale to better conditioned units before solving, then convert
+            results back. `True` uses `energy`/1e3, `cost`/1e3, `emissions`/1e6.
+            Pass a dict to override any subset. When None, defaults to module
+            wide option `options.params.optimize.scaling`.
         **kwargs:
             Keyword arguments used by `linopy.Model()`, such as `solver_dir` or `chunk`.
 
@@ -689,6 +674,11 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             include_objective_constant
         )
 
+        if scaling is None:
+            scaling = options.params.optimize.scaling
+        factors = Scaler.resolve(scaling)
+        n._scaler = factors
+
         if "meshed_threshold" in kwargs:
             meshed_threshold = kwargs.pop("meshed_threshold")
             warnings.warn(
@@ -701,133 +691,136 @@ class OptimizationAccessor(OptimizationAbstractMixin):
                 meshed_thresholds = [meshed_threshold]
 
         kwargs.setdefault("force_dim_names", True)
-        n._model = Model(**kwargs)
-        n.model.parameters = n.model.parameters.assign(snapshots=sns)
+        with factors.applied(n) if factors else nullcontext():
+            n._model = Model(**kwargs)
+            n.model.parameters = n.model.parameters.assign(snapshots=sns)
 
-        # Define variables
-        for c, attr in lookup.query("nominal").index:
-            define_nominal_variables(n, c, attr)
-            define_modular_variables(n, c, attr)
+            # Define variables
+            for c, attr in lookup.query("nominal").index:
+                define_nominal_variables(n, c, attr)
+                define_modular_variables(n, c, attr)
 
-        for c, attr in lookup.query("not nominal and not handle_separately").index:
-            define_operational_variables(n, sns, c, attr)
-            define_status_variables(n, sns, c, linearized_unit_commitment)
-            define_start_up_variables(n, sns, c, linearized_unit_commitment)
-            define_shut_down_variables(n, sns, c, linearized_unit_commitment)
-            define_committability_variables_constraints_with_fixed_upper_limit(
-                n, sns, c, attr
-            )
-
-        define_spillage_variables(n, sns)
-        define_operational_variables(n, sns, "Store", "p")
-
-        # CVaR auxiliary variables (only when stochastic + risk preference is set)
-        define_cvar_variables(n)
-
-        if transmission_losses:
-            for c in n.passive_branch_components:
-                define_loss_variables(n, sns, c)
-
-        # Define constraints
-        for c, attr in lookup.query("nominal").index:
-            define_nominal_constraints_for_extendables(n, c, attr)
-            define_fixed_nominal_constraints(n, c, attr)
-            define_modular_constraints(n, c, attr)
-            define_committability_variables_constraints_with_variable_upper_limit(
-                n, sns, c, attr
-            )
-
-        for c, attr in lookup.query("not nominal and not handle_separately").index:
-            define_operational_constraints_for_non_extendables(
-                n, sns, c, attr, transmission_losses
-            )
-            define_operational_constraints_for_extendables(
-                n, sns, c, attr, transmission_losses
-            )
-            define_operational_constraints_for_committables(n, sns, c)
-            define_ramp_limit_constraints(n, sns, c, attr)
-            define_fixed_operation_constraints(n, sns, c, attr)
-
-        # Handle StorageUnit p_set separately (fixes p_dispatch - p_store = p_set)
-        define_fixed_operation_constraints(n, sns, "StorageUnit", "p")
-        # Handle Store p_set
-        define_fixed_operation_constraints(n, sns, "Store", "p")
-
-        thresholds = (
-            sorted(set(meshed_thresholds))
-            if meshed_thresholds is not None
-            else [30, 100, 400]
-        )
-        bus_counts = get_bus_counts(n).reindex(n.c.buses.names, fill_value=0)
-        prev: float = 0
-        for t in thresholds + [float("inf")]:
-            if t == float("inf"):
-                mask = bus_counts > prev
-            else:
-                mask = (bus_counts > prev) & (bus_counts <= t)
-            buses = bus_counts.index[mask]
-            suffix = f"-meshed-{prev}" if prev > 0 else ""
-            if not buses.empty:
-                define_nodal_balance_constraints(
-                    n,
-                    sns,
-                    transmission_losses=transmission_losses,
-                    buses=buses,
-                    suffix=suffix,
+            for c, attr in lookup.query("not nominal and not handle_separately").index:
+                define_operational_variables(n, sns, c, attr)
+                define_status_variables(n, sns, c, linearized_unit_commitment)
+                define_start_up_variables(n, sns, c, linearized_unit_commitment)
+                define_shut_down_variables(n, sns, c, linearized_unit_commitment)
+                define_committability_variables_constraints_with_fixed_upper_limit(
+                    n, sns, c, attr
                 )
-            prev = t
 
-        define_kirchhoff_voltage_constraints(n, sns)
-        define_storage_unit_constraints(n, sns)
-        define_store_constraints(n, sns)
-        define_total_supply_constraints(n, sns)
+            define_spillage_variables(n, sns)
+            define_operational_variables(n, sns, "Store", "p")
 
-        if transmission_losses:
-            if isinstance(transmission_losses, bool):
-                transmission_losses = {"mode": "secants"}
-            elif isinstance(transmission_losses, int):
-                equivalent = {"mode": "tangents", "segments": transmission_losses}
-                warnings.warn(
-                    "Passing an int for `transmission_losses` is deprecated "
-                    "and will be removed in PyPSA 2.0. Explicitly pass "
-                    f"{equivalent} (current behavior) or use the new "
-                    "secant-based losses via `transmission_losses=True`.",
-                    FutureWarning,
-                    stacklevel=2,
+            # CVaR auxiliary variables (only when stochastic + risk preference is set)
+            define_cvar_variables(n)
+
+            if transmission_losses:
+                for c in n.passive_branch_components:
+                    define_loss_variables(n, sns, c)
+
+            # Define constraints
+            for c, attr in lookup.query("nominal").index:
+                define_nominal_constraints_for_extendables(n, c, attr)
+                define_fixed_nominal_constraints(n, c, attr)
+                define_modular_constraints(n, c, attr)
+                define_committability_variables_constraints_with_variable_upper_limit(
+                    n, sns, c, attr
                 )
-                transmission_losses = {
-                    "mode": "tangents",
-                    "segments": transmission_losses,
-                }
-            # Don't mutate passed dict
-            transmission_losses = dict(transmission_losses)
-            mode = transmission_losses.pop("mode", "secants")
-            if mode == "tangents" and "segments" not in transmission_losses:
-                msg = (
-                    "The 'tangents' mode requires a 'segments' key, e.g. "
-                    "transmission_losses={'mode': 'tangents', 'segments': 3}"
-                )
-                raise ValueError(msg)
 
-            for c in n.passive_branch_components:
-                if mode == "secants":
-                    define_secant_loss_constraints(n, sns, c, **transmission_losses)
-                elif mode == "tangents":
-                    define_tangent_loss_constraints(n, sns, c, **transmission_losses)
+            for c, attr in lookup.query("not nominal and not handle_separately").index:
+                define_operational_constraints_for_non_extendables(
+                    n, sns, c, attr, transmission_losses
+                )
+                define_operational_constraints_for_extendables(
+                    n, sns, c, attr, transmission_losses
+                )
+                define_operational_constraints_for_committables(n, sns, c)
+                define_ramp_limit_constraints(n, sns, c, attr)
+                define_fixed_operation_constraints(n, sns, c, attr)
+
+            # Handle StorageUnit p_set separately (fixes p_dispatch - p_store = p_set)
+            define_fixed_operation_constraints(n, sns, "StorageUnit", "p")
+            # Handle Store p_set
+            define_fixed_operation_constraints(n, sns, "Store", "p")
+
+            thresholds = (
+                sorted(set(meshed_thresholds))
+                if meshed_thresholds is not None
+                else [30, 100, 400]
+            )
+            bus_counts = get_bus_counts(n).reindex(n.c.buses.names, fill_value=0)
+            prev: float = 0
+            for t in thresholds + [float("inf")]:
+                if t == float("inf"):
+                    mask = bus_counts > prev
                 else:
-                    msg = f"Unknown transmission_losses mode: {mode!r}"
+                    mask = (bus_counts > prev) & (bus_counts <= t)
+                buses = bus_counts.index[mask]
+                suffix = f"-meshed-{prev}" if prev > 0 else ""
+                if not buses.empty:
+                    define_nodal_balance_constraints(
+                        n,
+                        sns,
+                        transmission_losses=transmission_losses,
+                        buses=buses,
+                        suffix=suffix,
+                    )
+                prev = t
+
+            define_kirchhoff_voltage_constraints(n, sns)
+            define_storage_unit_constraints(n, sns)
+            define_store_constraints(n, sns)
+            define_total_supply_constraints(n, sns)
+
+            if transmission_losses:
+                if isinstance(transmission_losses, bool):
+                    transmission_losses = {"mode": "secants"}
+                elif isinstance(transmission_losses, int):
+                    equivalent = {"mode": "tangents", "segments": transmission_losses}
+                    warnings.warn(
+                        "Passing an int for `transmission_losses` is deprecated "
+                        "and will be removed in PyPSA 2.0. Explicitly pass "
+                        f"{equivalent} (current behavior) or use the new "
+                        "secant-based losses via `transmission_losses=True`.",
+                        FutureWarning,
+                        stacklevel=2,
+                    )
+                    transmission_losses = {
+                        "mode": "tangents",
+                        "segments": transmission_losses,
+                    }
+                # Don't mutate passed dict
+                transmission_losses = dict(transmission_losses)
+                mode = transmission_losses.pop("mode", "secants")
+                if mode == "tangents" and "segments" not in transmission_losses:
+                    msg = (
+                        "The 'tangents' mode requires a 'segments' key, e.g. "
+                        "transmission_losses={'mode': 'tangents', 'segments': 3}"
+                    )
                     raise ValueError(msg)
 
-        # Define global constraints
-        define_primary_energy_limit(n, sns)
-        define_transmission_expansion_cost_limit(n, sns)
-        define_transmission_volume_expansion_limit(n, sns)
-        define_tech_capacity_expansion_limit(n, sns)
-        define_operational_limit(n, sns)
-        define_nominal_constraints_per_bus_carrier(n, sns)
-        define_growth_limit(n, sns)
+                for c in n.passive_branch_components:
+                    if mode == "secants":
+                        define_secant_loss_constraints(n, sns, c, **transmission_losses)
+                    elif mode == "tangents":
+                        define_tangent_loss_constraints(
+                            n, sns, c, **transmission_losses
+                        )
+                    else:
+                        msg = f"Unknown transmission_losses mode: {mode!r}"
+                        raise ValueError(msg)
 
-        define_objective(n, sns, include_objective_constant)
+            # Define global constraints
+            define_primary_energy_limit(n, sns)
+            define_transmission_expansion_cost_limit(n, sns)
+            define_transmission_volume_expansion_limit(n, sns)
+            define_tech_capacity_expansion_limit(n, sns)
+            define_operational_limit(n, sns)
+            define_nominal_constraints_per_bus_carrier(n, sns)
+            define_growth_limit(n, sns)
+
+            define_objective(n, sns, include_objective_constant)
 
         return n.model
 
@@ -892,21 +885,28 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             log_to_console = options.params.optimize.log_to_console
 
         n = self._n
-        if extra_functionality:
-            extra_functionality(n, n.snapshots)
+        # Scaling was set at create_model time, now re apply
+        factors = n._scaler
         m = n.model
-        if log_to_console is not None:
-            kwargs["log_to_console"] = log_to_console
-        status, condition = m.solve(
-            solver_name=solver_name,
-            **solver_options,
-            **kwargs,
-        )
+        sns = m.parameters.snapshots.to_index()
+        with factors.applied(n) if factors else nullcontext():
+            if extra_functionality:
+                extra_functionality(n, sns)
+            if log_to_console is not None:
+                kwargs["log_to_console"] = log_to_console
+            status, condition = m.solve(
+                solver_name=solver_name,
+                **solver_options,
+                **kwargs,
+            )
 
+            if status == "ok":
+                n.optimize.assign_solution(factors)
+                n.optimize.assign_duals(assign_all_duals, factors)
+
+        # Runs after restore since post_processing copies p_set into Load p unscaled
         if status == "ok":
-            self._n.optimize.assign_solution()
-            self._n.optimize.assign_duals(assign_all_duals)
-            self._n.optimize.post_processing()
+            n.optimize.post_processing(factors)
 
         # Optional runtime verification
         if options.debug.runtime_verification:

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -532,7 +532,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             bus connectivity count. Defaults to ``[30, 100, 400]``.
         scaling : bool | dict, default False
             Rescale to better conditioned units before solving, then convert
-            results back. `True` uses `energy`/1e3, `cost`/1e6, `emissions`/1e6.
+            results back. `True` uses `energy`/1e3, `cost`/1e3, `emissions`/1e6.
             Pass a dict to override any subset.
         **kwargs:
             Keyword argument used by `linopy.Model.solve`, such as `solver_name`,

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -1031,7 +1031,8 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         n._objective = m.objective.value
         if factors is not None:
             n._objective *= factors.cost
-            n._objective_constant *= factors.cost
+            if n._objective_constant is not None:
+                n._objective_constant *= factors.cost
 
     def assign_duals(
         self, assign_all_duals: bool = False, factors: Scaler | None = None

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -55,6 +56,7 @@ from pypsa.optimization.global_constraints import (
     define_transmission_expansion_cost_limit,
     define_transmission_volume_expansion_limit,
 )
+from pypsa.optimization.scaling import Scaler
 from pypsa.optimization.variables import (
     define_cvar_variables,
     define_loss_variables,
@@ -458,6 +460,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         include_objective_constant: bool | None = None,
         committable_big_m: float | None = None,
         meshed_thresholds: Sequence[int] | None = None,
+        scaling: bool | dict = False,
         **kwargs: Any,
     ) -> tuple[str, str]:
         """Optimize the pypsa network using linopy.
@@ -527,6 +530,10 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         meshed_thresholds : Sequence[int] | None, default: None
             Thresholds for splitting buses into nodal-balance constraint groups by
             bus connectivity count. Defaults to ``[30, 100, 400]``.
+        scaling : bool | dict, default False
+            Rescale to better conditioned units before solving, then convert
+            results back. `True` uses `energy`/1e3, `cost`/1e6, `emissions`/1e6.
+            Pass a dict to override any subset.
         **kwargs:
             Keyword argument used by `linopy.Model.solve`, such as `solver_name`,
             `problem_fn` or solver options directly passed to the solver.
@@ -562,31 +569,37 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         n._linearized_uc = linearized_unit_commitment
 
         n.consistency_check(strict=["unknown_buses"])
-        m = n.optimize.create_model(
-            sns,
-            multi_investment_periods,
-            transmission_losses,
-            linearized_unit_commitment,
-            consistency_check=False,
-            include_objective_constant=include_objective_constant,
-            committable_big_m=committable_big_m,
-            meshed_thresholds=meshed_thresholds,
-            **model_kwargs,
-        )
-        if extra_functionality:
-            extra_functionality(n, sns)
-        if log_to_console is not None:
-            kwargs["log_to_console"] = log_to_console
-        status, condition = m.solve(
-            solver_name=solver_name,
-            **solver_options,
-            **kwargs,
-        )
 
+        factors = Scaler.resolve(scaling)
+        with factors.applied(n) if factors else nullcontext():
+            m = n.optimize.create_model(
+                sns,
+                multi_investment_periods,
+                transmission_losses,
+                linearized_unit_commitment,
+                consistency_check=False,
+                include_objective_constant=include_objective_constant,
+                committable_big_m=committable_big_m,
+                meshed_thresholds=meshed_thresholds,
+                **model_kwargs,
+            )
+            if extra_functionality:
+                extra_functionality(n, sns)
+            if log_to_console is not None:
+                kwargs["log_to_console"] = log_to_console
+            status, condition = m.solve(
+                solver_name=solver_name,
+                **solver_options,
+                **kwargs,
+            )
+
+            if status == "ok":
+                n.optimize.assign_solution(factors)
+                n.optimize.assign_duals(assign_all_duals, factors)
+
+        # Runs after restore since post_processing copies p_set into Load p unscaled.
         if status == "ok":
-            n.optimize.assign_solution()
-            n.optimize.assign_duals(assign_all_duals)
-            n.optimize.post_processing()
+            n.optimize.post_processing(factors)
 
         if (
             condition == "infeasible"
@@ -898,7 +911,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
 
         return status, condition
 
-    def assign_solution(self) -> None:
+    def assign_solution(self, factors: Scaler | None = None) -> None:
         """Map solution to network components."""
         n = self._n
         m = n.model
@@ -933,6 +946,10 @@ class OptimizationAccessor(OptimizationAbstractMixin):
                 continue
             c = n.c[_c_name]
             df = _from_xarray(sol, c)
+
+            # Unscale primals back to original units
+            if factors is not None:
+                df = df * factors.variable_factor(attr)
 
             if "snapshot" in sol.dims:
                 if c.name in n.passive_branch_components and attr == "s":
@@ -991,12 +1008,15 @@ class OptimizationAccessor(OptimizationAbstractMixin):
 
         # If nominal capacity was no variable set optimal value to nominal
         for c_name, attr in lookup.query("nominal").index:
+            nom_factor = factors.variable_factor(attr) if factors is not None else 1.0
             c = n.components[c_name]
             fix_i = c.fixed
             if n.has_scenarios:
                 fix_i = pd.MultiIndex.from_product([n.scenarios, fix_i])
             if not fix_i.empty:
-                c.static.loc[fix_i, f"{attr}_opt"] = c.static.loc[fix_i, attr]
+                c.static.loc[fix_i, f"{attr}_opt"] = (
+                    c.static.loc[fix_i, attr] * nom_factor
+                )
 
         # Recalculate storageunit net dispatch
         storage_units = n.c.storage_units
@@ -1006,8 +1026,13 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             )
 
         n._objective = m.objective.value
+        if factors is not None:
+            n._objective *= factors.cost
+            n._objective_constant *= factors.cost
 
-    def assign_duals(self, assign_all_duals: bool = False) -> None:
+    def assign_duals(
+        self, assign_all_duals: bool = False, factors: Scaler | None = None
+    ) -> None:
         """Map dual values i.e. shadow prices to network components.
 
         Parameters
@@ -1015,9 +1040,13 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         assign_all_duals : bool, default False
             Whether to assign all dual values or only those that already
             have a designated place in the network.
+        factors : dict, optional
+            Numerical scaling factors used to unscale the duals back to
+            original units.
 
         """
-        m = self._n.model
+        n = self._n
+        m = n.model
         unassigned_constraints = []
 
         # Early return if no dual values are available
@@ -1039,6 +1068,10 @@ class OptimizationAccessor(OptimizationAbstractMixin):
                 unassigned_constraints.append(constraint_name)
                 continue
 
+            dual_factor = (
+                factors.dual_factor(prefix, suffix, n) if factors is not None else 1.0
+            )
+
             # Add placeholder for custom constraints, marked as GlobalConstraint
             # TODO This should go to an actual custom constraint
             if (
@@ -1058,7 +1091,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
             # Dynamic duals (constraints with snapshot dimension)
             if "snapshot" in constraint.dual.dims:
                 # Get dual from constraint as formatted pandas DataFrame
-                dual_df = _from_xarray(constraint.dual, c)
+                dual_df = _from_xarray(constraint.dual, c) * dual_factor
 
                 # Standard components: extract last part after final dash
                 # e.g., "Line-s-upper" -> "upper", "Generator-p-lower" -> "lower"
@@ -1096,7 +1129,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
                 if c.has_scenarios:
                     raise NotImplementedError()
 
-                c.static.loc[suffix, "mu"] = constraint.dual
+                c.static.loc[suffix, "mu"] = constraint.dual * dual_factor
 
         if unassigned_constraints:
             logger.info(
@@ -1104,7 +1137,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
                 ", ".join(unassigned_constraints),
             )
 
-    def post_processing(self) -> None:
+    def post_processing(self, factors: Scaler | None = None) -> None:
         """Post-process the optimized network.
 
         This calculates quantities derived from the optimized values such as
@@ -1137,6 +1170,9 @@ class OptimizationAccessor(OptimizationAbstractMixin):
         # line losses
         if "Line-loss" in n.model.variables:
             losses = n.model["Line-loss"].solution.to_pandas()
+            # Inputs are restored but this direct solution read is still scaled
+            if factors is not None:
+                losses = losses * factors.energy
             n.c.lines.dynamic.p0 += losses / 2
             n.c.lines.dynamic.p1 += losses / 2
 

--- a/pypsa/optimization/scaling.py
+++ b/pypsa/optimization/scaling.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 # - `emissions` (tCO2), default 1e6
 #
 # (energy, cost, emissions)
-_NOM = re.compile(r"(?!v_nom)\w+_nom(_min|_max|_set|_mod)?")
+_NOM = re.compile(r"(?!v_nom)(\w+_nom(_min|_max|_set|_mod)?|nom_(min|max)_\w+)")
 _COLUMN_EXPONENTS = {
     # power flows (MW), energy stocks (MWh), capacities (*_nom, MW/MWh)
     "p_set": (-1, 0, 0),
@@ -32,6 +32,9 @@ _COLUMN_EXPONENTS = {
     "e_set": (-1, 0, 0),
     "state_of_charge_initial": (-1, 0, 0),
     "state_of_charge_set": (-1, 0, 0),
+    "max_growth": (-1, 0, 0),
+    "e_sum_min": (-1, 0, 0),
+    "e_sum_max": (-1, 0, 0),
     _NOM: (-1, 0, 0),
     # cost per quantity (€/MW, €/MWh)
     "marginal_cost": (1, -1, 0),
@@ -140,9 +143,12 @@ class Scaler(NamedTuple):
             gc.loc[is_em, "constant"] /= self.emissions
             gc.loc[~(is_cost | is_em), "constant"] /= self.energy
 
+        # Expose the active factors so raw constants can be scaled (e.g. p_init)
+        n._scaling = self._asdict()
         try:
             yield
         finally:
+            n._scaling = {"energy": 1.0, "cost": 1.0, "emissions": 1.0}
             for (cname, col), original in static.items():
                 n.components[cname].static[col] = original
             for (cname, col), original in dynamic.items():

--- a/pypsa/optimization/scaling.py
+++ b/pypsa/optimization/scaling.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Numerical scaling helper."""
+
+from __future__ import annotations
+
+import re
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from pypsa import Network
+
+# - `energy` (MW / MWh), default 1e3
+# - `cost` (€), default 1e6
+# - `emissions` (tCO2), default 1e6
+#
+# (energy, cost, emissions)
+_NOM = re.compile(r"(?!v_nom)\w+_nom(_min|_max|_set|_mod)?")
+_COLUMN_EXPONENTS = {
+    # power flows (MW), energy stocks (MWh), capacities (*_nom, MW/MWh)
+    "p_set": (-1, 0, 0),
+    "q_set": (-1, 0, 0),
+    "inflow": (-1, 0, 0),
+    "p_dispatch_set": (-1, 0, 0),
+    "p_store_set": (-1, 0, 0),
+    "e_initial": (-1, 0, 0),
+    "e_set": (-1, 0, 0),
+    "state_of_charge_initial": (-1, 0, 0),
+    "state_of_charge_set": (-1, 0, 0),
+    _NOM: (-1, 0, 0),
+    # cost per quantity (€/MW, €/MWh)
+    "marginal_cost": (1, -1, 0),
+    "spill_cost": (1, -1, 0),
+    "marginal_cost_storage": (1, -1, 0),
+    "capital_cost": (1, -1, 0),
+    # cost on a dimensionless binaries
+    "start_up_cost": (0, -1, 0),
+    "shut_down_cost": (0, -1, 0),
+    "stand_by_cost": (0, -1, 0),
+    # quadratic cost
+    "marginal_cost_quadratic": (2, -1, 0),
+    # carrier emissions (tCO2/MWh)
+    "co2_emissions": (1, 0, -1),
+}
+
+
+class Scaler(NamedTuple):
+    """Energy, cost and emissions base-unit factors plus unscaling rules."""
+
+    energy: float
+    cost: float
+    emissions: float
+
+    @classmethod
+    def resolve(cls, scaling: bool | dict | None) -> Scaler | None:
+        """Resolve the `scaling` argument into a `Scaler` or `None`."""
+        if scaling is False or scaling is None:
+            return None
+        defaults = {
+            "energy": 1e3,
+            "cost": 1e6,
+            "emissions": 1e6,
+        }
+        if scaling is True:
+            return cls(**defaults)
+        if not isinstance(scaling, dict):
+            msg = f"scaling must be a bool or dict, got {type(scaling).__name__}"
+            raise TypeError(msg)
+        unknown = set(scaling) - set(defaults)
+        if unknown:
+            msg = (
+                f"unknown scaling factor(s) {sorted(unknown)}; "
+                f"valid keys are {sorted(defaults)}"
+            )
+            raise ValueError(msg)
+        for k, v in scaling.items():
+            if not isinstance(v, (int, float)):
+                msg = f"scaling factor {k!r} must be numeric, got {v!r}"
+                raise TypeError(msg)
+        return cls(**{k: float(scaling.get(k, d)) for k, d in defaults.items()})
+
+    def _factor(self, exponents: tuple[int, int, int]) -> float:
+        """Product of the base units raised to the given exponents."""
+        e, c, m = exponents
+        return self.energy**e * self.cost**c * self.emissions**m
+
+    def _column_factor(self, col: str) -> float | None:
+        """Multiplicative factor for an input column, or None to leave unchanged."""
+        exponents = _COLUMN_EXPONENTS.get(col) or (
+            _COLUMN_EXPONENTS[_NOM] if _NOM.fullmatch(col) else None
+        )
+        return self._factor(exponents) if exponents else None
+
+    def variable_factor(self, attr: str) -> float:
+        """Factor that converts a scaled solution variable back to original units."""
+        # Dimensionless variables (commitment status, module counts) stay unscaled.
+        dimensionless = {"status", "start_up", "shut_down", "n_mod"}
+        return 1.0 if attr in dimensionless else self.energy
+
+    def dual_factor(self, prefix: str, suffix: str, n: Network) -> float:
+        """Output factor for a constraint dual."""
+        if prefix == "GlobalConstraint":
+            gc = n.global_constraints
+            if suffix in gc.index:
+                gc_type = gc.at[suffix, "type"]
+                if gc_type == "transmission_expansion_cost_limit":
+                    return 1.0
+                if gc_type == "primary_energy":
+                    return self.cost / self.emissions
+        return self.cost / self.energy
+
+    @contextmanager
+    def applied(self, n: Network) -> Iterator[None]:
+        """Scale `n`'s inputs in place for the block, restoring exact originals on exit."""
+        static, dynamic, constant = {}, {}, None
+        for c in n.components:
+            for col in c.static.columns:
+                f = self._column_factor(col)
+                if f is not None:
+                    static[c.name, col] = c.static[col].copy()
+                    c.static[col] = c.static[col] * f
+            for col, df in c.dynamic.items():
+                f = self._column_factor(col)
+                if f is not None and df.shape[1]:
+                    dynamic[c.name, col] = df.copy()
+                    c.dynamic[col] = df * f
+
+        # Scale each GlobalConstraint RHS budget by its unit (as in dual_factor)
+        gc = n.global_constraints
+        if len(gc):
+            constant = gc["constant"].copy()
+            is_cost = gc["type"] == "transmission_expansion_cost_limit"
+            is_em = gc["type"] == "primary_energy"
+            gc.loc[is_cost, "constant"] /= self.cost
+            gc.loc[is_em, "constant"] /= self.emissions
+            gc.loc[~(is_cost | is_em), "constant"] /= self.energy
+
+        try:
+            yield
+        finally:
+            for (cname, col), original in static.items():
+                n.components[cname].static[col] = original
+            for (cname, col), original in dynamic.items():
+                n.components[cname].dynamic[col] = original
+            if constant is not None:
+                n.global_constraints["constant"] = constant

--- a/pypsa/optimization/scaling.py
+++ b/pypsa/optimization/scaling.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from pypsa import Network
 
 # - `energy` (MW / MWh), default 1e3
-# - `cost` (€), default 1e6
+# - `cost` (€), default 1e3
 # - `emissions` (tCO2), default 1e6
 #
 # (energy, cost, emissions)
@@ -63,7 +63,7 @@ class Scaler(NamedTuple):
             return None
         defaults = {
             "energy": 1e3,
-            "cost": 1e6,
+            "cost": 1e3,
             "emissions": 1e6,
         }
         if scaling is True:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -50,10 +50,12 @@ def no_warnings():
 
 
 @pytest.fixture(autouse=True)
-def _set_test_options():
+def _set_test_options(request):
     """Ensure test-specific options are set before each test."""
     pypsa.options.debug.runtime_verification = True
     pypsa.options.params.optimize.include_objective_constant = True
+    if request.config.getoption("--scaling"):
+        pypsa.options.params.optimize.scaling = True
     return
 
 
@@ -72,6 +74,12 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="Activate the new components API (options.api.new_components_api)",
+    )
+    parser.addoption(
+        "--scaling",
+        action="store_true",
+        default=False,
+        help="Enable optimization scaling by default (options.params.optimize.scaling)",
     )
     parser.addoption(
         "--test-docs",
@@ -95,12 +103,26 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     """Configure pytest session with custom options."""
+    config.addinivalue_line(
+        "markers",
+        "no_scaling: skip under the --scaling stress mode (test is incompatible "
+        "with model scaling, e.g. inspects raw model internals or runs on a "
+        "numerically ill-conditioned network).",
+    )
     if config.getoption("--new-components-api"):
         pypsa.options.api.new_components_api = True
+    if config.getoption("--scaling"):
+        pypsa.options.params.optimize.scaling = True
 
 
 def pytest_collection_modifyitems(config, items):
-    """Skip image comparison tests unless --run-plot-tests is given."""
+    """Skip image comparison and scaling-incompatible tests."""
+    if config.getoption("--scaling"):
+        skip_scaling = pytest.mark.skip(reason="incompatible with --scaling mode")
+        for item in items:
+            if "no_scaling" in item.keywords:
+                item.add_marker(skip_scaling)
+
     if config.getoption("--run-plot-tests"):
         return
     skip = pytest.mark.skip(

--- a/test/test_lopf_activity_mask.py
+++ b/test/test_lopf_activity_mask.py
@@ -34,6 +34,7 @@ def test_optimize(ac_dc_network):
     assert "DC link" not in n.model.constraints["Link-ext-p_nom-lower"].coords["name"]
 
 
+@pytest.mark.no_scaling  # scigrid_de
 def test_optimize_with_power_flow(scipy_network):
     """
     Test the functionality of the 'active' attribute in PyPSA components.

--- a/test/test_lopf_and_subsequent_power_flow.py
+++ b/test/test_lopf_and_subsequent_power_flow.py
@@ -2,7 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+import pytest
 
+
+@pytest.mark.no_scaling  # scigrid_de
 def test_optimize_with_power_flow(scipy_network):
     n = scipy_network
 

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -480,6 +480,7 @@ def test_nodal_balance_respects_load_sign():
     assert n.objective < TOLERANCE
 
 
+@pytest.mark.no_scaling  # asserts on the raw model RHS
 def test_nodal_balance_load_sign_rhs_values():
     """
     Verify the per-load contribution to the nodal balance RHS for both

--- a/test/test_lopf_basic_constraints.py
+++ b/test/test_lopf_basic_constraints.py
@@ -349,12 +349,12 @@ def test_define_fixed_operational_constraints_positive(mode):
 
     n.optimize()
 
-    assert n.c.generators.dynamic.p["gen2"].eq(8).all()
+    assert (n.c.generators.dynamic.p["gen2"] - 8).abs().lt(1e-6).all()
     if mode == "mixed":
-        assert n.c.generators.dynamic.p["gen1"].eq(1).all()
-        assert n.c.generators.dynamic.p["gen0"].eq(1).all()
+        assert (n.c.generators.dynamic.p["gen1"] - 1).abs().lt(1e-6).all()
+        assert (n.c.generators.dynamic.p["gen0"] - 1).abs().lt(1e-6).all()
     else:
-        assert n.c.generators.dynamic.p["gen0"].eq(2).all()
+        assert (n.c.generators.dynamic.p["gen0"] - 2).abs().lt(1e-6).all()
 
 
 @pytest.mark.parametrize("static", [False, True])

--- a/test/test_lopf_global_constraints.py
+++ b/test/test_lopf_global_constraints.py
@@ -81,6 +81,7 @@ def test_assign_all_duals(ac_dc_network, assign):
     assert ("mu_generation_limit_dynamic" in n.c.global_constraints.dynamic) == assign
 
 
+@pytest.mark.no_scaling  # compares the raw model dual against the network value
 def test_assign_duals_noname(ac_dc_network):
     """Test that dual values are correctly assigned back to network,
     also for a special case of constraints without component dimension."""

--- a/test/test_lopf_losses.py
+++ b/test/test_lopf_losses.py
@@ -5,6 +5,7 @@
 import pytest
 
 
+@pytest.mark.no_scaling  # scigrid_de
 @pytest.mark.parametrize("transmission_losses", [1, 2])
 def test_optimize_losses(scipy_network, transmission_losses):
     n = scipy_network

--- a/test/test_lopf_modularity.py
+++ b/test/test_lopf_modularity.py
@@ -79,7 +79,7 @@ def test_modular_committable_with_ramp_limits():
     p_nom_opt = n.c["Generator"].static.loc["modgen", "p_nom_opt"]
     p_nom_mod = n.c["Generator"].static.loc["modgen", "p_nom_mod"]
     assert p_nom_opt > 0
-    assert p_nom_opt % p_nom_mod == 0
+    assert np.isclose(p_nom_opt / p_nom_mod, round(p_nom_opt / p_nom_mod))
 
     p = n.c["Generator"].dynamic["p"]["modgen"]
     u = n.c["Generator"].dynamic["status"]["modgen"]

--- a/test/test_lopf_multiinvest.py
+++ b/test/test_lopf_multiinvest.py
@@ -369,11 +369,13 @@ def test_simple_network_store_cyclic(n_sts):
     assert status == "ok"
     assert cond == "optimal"
 
-    assert (n_sts.c.stores.dynamic.p.loc[[2050], "sto1-2020"] == 0).all()
+    assert (n_sts.c.stores.dynamic.p.loc[[2050], "sto1-2020"].abs() < 1e-6).all()
 
     e = n_sts.c.stores.dynamic.e
     p = n_sts.c.stores.dynamic.p
-    assert e.loc[idx[2040, 9], "sto1-2020"] == (e + p).loc[idx[2020, 0], "sto1-2020"]
+    assert e.loc[idx[2040, 9], "sto1-2020"] == pytest.approx(
+        (e + p).loc[idx[2020, 0], "sto1-2020"]
+    )
 
 
 def test_simple_network_store_cyclic_per_period(n_sts):
@@ -431,6 +433,7 @@ def test_global_constraint_primary_energy_store(n_sts):
     assert round(soc_diff @ emissions, 0) == 3000
 
 
+@pytest.mark.no_scaling  # asserts on the raw model RHS
 def test_global_constraint_primary_energy_storage_stochastic(n_sus):
     """
     Test global constraints with primary energy for storage in stochastic networks.

--- a/test/test_lopf_rolling_horizon.py
+++ b/test/test_lopf_rolling_horizon.py
@@ -51,14 +51,11 @@ def test_rolling_horizon(committable):
         assert status == "ok"
 
     ramping = n.c.generators.dynamic.p.diff().fillna(0)
-    assert (
-        (ramping <= n.c.generators.static.eval("ramp_limit_up * p_nom_opt")).all().all()
-    )
-    assert (
-        (ramping >= -n.c.generators.static.eval("ramp_limit_down * p_nom_opt"))
-        .all()
-        .all()
-    )
+    static = n.c.generators.static
+    ramp_up = static["ramp_limit_up"] * static["p_nom_opt"]
+    ramp_down = static["ramp_limit_down"] * static["p_nom_opt"]
+    assert (ramping <= ramp_up + 1e-5).all().all()
+    assert (ramping >= -ramp_down - 1e-5).all().all()
 
 
 @pytest.mark.parametrize("committable", [True, False])
@@ -75,14 +72,11 @@ def test_rolling_horizon_integrated(committable):
 
     n.optimize.optimize_with_rolling_horizon(horizon=3)
     ramping = n.c.generators.dynamic.p.diff().fillna(0)
-    assert (
-        (ramping <= n.c.generators.static.eval("ramp_limit_up * p_nom_opt")).all().all()
-    )
-    assert (
-        (ramping >= -n.c.generators.static.eval("ramp_limit_down * p_nom_opt"))
-        .all()
-        .all()
-    )
+    static = n.c.generators.static
+    ramp_up = static["ramp_limit_up"] * static["p_nom_opt"]
+    ramp_down = static["ramp_limit_down"] * static["p_nom_opt"]
+    assert (ramping <= ramp_up + 1e-5).all().all()
+    assert (ramping >= -ramp_down - 1e-5).all().all()
 
 
 def test_rolling_horizon_integrated_overlap():
@@ -101,14 +95,11 @@ def test_rolling_horizon_integrated_overlap():
 
     n.optimize.optimize_with_rolling_horizon(horizon=3, overlap=1)
     ramping = n.c.generators.dynamic.p.diff().fillna(0)
-    assert (
-        (ramping <= n.c.generators.static.eval("ramp_limit_up * p_nom_opt")).all().all()
-    )
-    assert (
-        (ramping >= -n.c.generators.static.eval("ramp_limit_down * p_nom_opt"))
-        .all()
-        .all()
-    )
+    static = n.c.generators.static
+    ramp_up = static["ramp_limit_up"] * static["p_nom_opt"]
+    ramp_down = static["ramp_limit_down"] * static["p_nom_opt"]
+    assert (ramping <= ramp_up + 1e-5).all().all()
+    assert (ramping >= -ramp_down - 1e-5).all().all()
 
 
 def test_rolling_horizon_committable_ramp_limits():
@@ -222,6 +213,7 @@ def test_rolling_horizon_committable_overlap_matches_full_run():
     assert (ramping >= -static.eval("ramp_limit_down * p_nom_opt")).all().all()
 
 
+@pytest.mark.no_scaling  # scigrid_de
 def test_rolling_horizon_linearized_uc_with_ramp_limits():
     """
     Test rolling horizon with linearized UC and ramp limits on committables.

--- a/test/test_lopf_storage.py
+++ b/test/test_lopf_storage.py
@@ -51,7 +51,7 @@ def test_storage_energy_marginal_cost():
         e_nom=10,
     )
     n.optimize()
-    assert n.objective == 2.6
+    assert n.objective == pytest.approx(2.6)
 
 
 def test_spill_cost():

--- a/test/test_lopf_unit_commitment.py
+++ b/test/test_lopf_unit_commitment.py
@@ -621,10 +621,10 @@ def test_dynamic_ramp_rates():
 
     n.optimize()
 
-    assert (n.c.generators.dynamic.p.diff().loc[0:6, "gen1"]).max() <= 0.5 * 80
-    assert (n.c.generators.dynamic.p.diff().loc[0:6, "gen1"]).min() >= -0.5 * 100
-    assert (n.c.generators.dynamic.p.diff().loc[6:, "gen1"]).max() <= 80
-    assert (n.c.generators.dynamic.p.diff().loc[6:, "gen1"]).min() >= -100
+    assert (n.c.generators.dynamic.p.diff().loc[0:6, "gen1"]).max() <= 0.5 * 80 + 1e-6
+    assert (n.c.generators.dynamic.p.diff().loc[0:6, "gen1"]).min() >= -0.5 * 100 - 1e-6
+    assert (n.c.generators.dynamic.p.diff().loc[6:, "gen1"]).max() <= 80 + 1e-6
+    assert (n.c.generators.dynamic.p.diff().loc[6:, "gen1"]).min() >= -100 - 1e-6
 
 
 @pytest.mark.parametrize("direction", ["up", "down"])

--- a/test/test_pf_distributed_slack.py
+++ b/test/test_pf_distributed_slack.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import pytest
 from numpy.testing import assert_array_almost_equal as equal
 
 
@@ -9,6 +10,7 @@ def normed(s):
     return s / s.sum()
 
 
+@pytest.mark.no_scaling  # scigrid_de
 def test_pf_distributed_slack(scipy_network):
     n = scipy_network
     n.set_snapshots(n.snapshots[:2])

--- a/test/test_sclopf_scigrid.py
+++ b/test/test_sclopf_scigrid.py
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 import pandas as pd
+import pytest
 from numpy.testing import assert_almost_equal as equal
 
 import pypsa
 
 
+@pytest.mark.no_scaling  # scigrid_de
 def test_optimize_security_constrained(scipy_network):
     """Test security-constrained optimization functionality and dual variable assignment."""
     n = scipy_network

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -1306,6 +1306,7 @@ def test_multiperiod_stochastic_coordinate_alignment():
         )
 
 
+@pytest.mark.no_scaling  # asserts on the raw model constraint RHS
 def test_storage_unit_energy_balance_scenario_sorting_bug():
     """Test that storage unit energy balance constraints have correct RHS values with scenarios.
 

--- a/test/test_transmission_losses.py
+++ b/test/test_transmission_losses.py
@@ -21,6 +21,7 @@ def test_transmission_losses_independent_of_s_nom_max():
     assert res.equals(res2)
 
 
+@pytest.mark.no_scaling  # asserts on the raw model solution
 def test_secant_losses_larger():
     n = pypsa.examples.ac_dc_meshed()
     n.lines["s_nom_max"] = 2000


### PR DESCRIPTION
Closes #309

## Changes proposed in this Pull Request
This is a quite unintrusive way to add unit scaling. After all discussions, again recently with @davidef and after @fneum's simplicity push, I played around again. Auto scaling will not work for various reasons. This needs to be handled opinionated PyPSA.

Currently, there is a new `scaling` argument in `n.optimize`. In the future, we could come up with an "auto scaler", which provides some values automatically or at least warns the user. It is turned off by default. You can scale just three units:
- `energy` (Where `power` is mixed in. My brain couldn't figure out whether a split here would help at all.)
- `cost`
- `emissions`

This is mapped to all our attributes. I am not sure if I missed any. This needs the deep thinking mode of our modelling brains. But since it is just the general non intrusive mapping here, it is easy to adjust.

And the full test suite already runs through with `scaling` turned on. I needed to add tolerances for some tests, and the `scigrid_de` example does not work because it has some numerical issues. There is a generator with a capacity of `2.15e8`, which we can probably also remove from the examples. Or update it.

Benchmarks, reasoning and how this compares to @davide-f s approach will follow. The HPC needs to recover from the heatwave for that. 

## Checklist
- [ ] Docs
- [ ] Some dedicated tests next to the full run
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [[Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.