### PR TITLE
fix: deterministic edge order in n.graph()

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,13 @@ SPDX-License-Identifier: CC-BY-4.0
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
 -->
 
+## Upcoming Release
+
+### Bug Fixes
+
+- Fix [`n.graph()`][pypsa.network.graph.NetworkGraphMixin.graph] building edges in a non-deterministic order, which could make results that depend on the network's cycles differ between runs. In particular, security-constrained optimization (SCLOPF) now returns consistent results. (<!-- md:pr 1764 -->)
+
+
 ## [**v1.2.4**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.4) <small>27th June 2026</small> { id="v1.2.4" }
 
 ### Bug Fixes

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,7 +6,6 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Release Notes
 
-<!--
 ## Upcoming Release
 
 !!! info "Upcoming Release"
@@ -14,9 +13,6 @@ SPDX-License-Identifier: CC-BY-4.0
     The features listed below have not yet been released, but will be included in the
     next update! If you would like to use these features in the meantime, you will need
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
--->
-
-## Upcoming Release
 
 ### Bug Fixes
 

--- a/pypsa/network/graph.py
+++ b/pypsa/network/graph.py
@@ -83,6 +83,8 @@ class NetworkGraphMixin:
         else:
             msg = "graph must be called with a Network or a SubNetwork"
             raise TypeError(msg)
+        # sort for a hash-seed-independent edge order (and cycle basis); see GH #1356
+        branch_components = sorted(branch_components)
 
         buses_i = n.c.buses.static.index
 

--- a/test/test_sclopf_scigrid.py
+++ b/test/test_sclopf_scigrid.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import numpy as np
 import pandas as pd
 from numpy.testing import assert_almost_equal as equal
 
@@ -41,17 +42,15 @@ def test_optimize_security_constrained(scipy_network):
     n.c.generators.dynamic.p_set = n.c.generators.dynamic.p.copy()
     n.c.storage_units.dynamic.p_set = n.c.storage_units.dynamic.p.copy()
 
-    # TODO see https://github.com/PyPSA/PyPSA/issues/1356
+    # Check no lines are overloaded with the linear contingency analysis
+    p0_test = n.lpf_contingency(n.snapshots[0], branch_outages=branch_outages)
 
-    # # Check no lines are overloaded with the linear contingency analysis
-    # p0_test = n.lpf_contingency(n.snapshots[0], branch_outages=branch_outages)
+    # Check loading as per unit of s_nom in each contingency
+    max_loading = (
+        abs(p0_test.divide(n.passive_branches().s_nom, axis=0)).describe().loc["max"]
+    )
 
-    # # Check loading as per unit of s_nom in each contingency
-    # max_loading = (
-    #     abs(p0_test.divide(n.passive_branches().s_nom, axis=0)).describe().loc["max"]
-    # )
-
-    # arr_equal(max_loading, np.ones(len(max_loading)), decimal=4)
+    equal(max_loading, np.ones(len(max_loading)), decimal=4)
     equal(n.objective, 339758.4578, decimal=1)
 
     # === Dual variable assignment checks ===


### PR DESCRIPTION
Closes #1356

## Changes proposed in this Pull Request

Sort branch components so the cycle basis is hash-seed independent, fixing SCLOPF intermittently admitting post-contingency overloads. Re-enable commented test sections in SCLOPF test.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
