### PR TITLE
fix(docs): use thread pool in GSA example for cross-platform builds

### DIFF
--- a/docs/examples/gsa.ipynb
+++ b/docs/examples/gsa.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "## Import Required Libraries\n",
     "\n",
-    "We'll need PyPSA for energy system modelling and SALib for global sensitivity analysis functions. We'll also use multiprocessing to speed up the evaluation of multiple scenarios."
+    "We'll need PyPSA for energy system modelling and SALib for global sensitivity analysis functions. We'll also use a thread pool to evaluate scenarios in parallel — threads work reliably in notebooks on every operating system, and the solver still runs in parallel because it releases the GIL during optimisation."
    ]
   },
   {
@@ -51,9 +51,10 @@
    "outputs": [],
    "source": [
     "import logging\n",
-    "import multiprocessing as mp\n",
     "import warnings\n",
     "from functools import partial\n",
+    "from multiprocessing import cpu_count\n",
+    "from multiprocessing.pool import ThreadPool\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -62,7 +63,7 @@
     "\n",
     "import pypsa\n",
     "\n",
-    "THREADS = min(mp.cpu_count(), 15)\n",
+    "THREADS = min(cpu_count(), 15)\n",
     "\n",
     "# Set to True for interaction effects\n",
     "SECOND = False\n",
@@ -187,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with mp.Pool(processes=THREADS) as pool:\n",
+    "with ThreadPool(processes=THREADS) as pool:\n",
     "    func = partial(evaluate, n=n)\n",
     "    results = np.array(pool.map(func, samples))\n",
     "display(results[:4])"


### PR DESCRIPTION
Closes #1756

## Changes proposed in this Pull Request

`mp.Pool` relies on the OS-default start method, which is spawn on macOS/Windows. spawn cannot pickle the notebook-defined evaluate function, so the docs build failed there. Switch to `ThreadPool`: no pickling, works on all platforms, and the solver still runs in parallel since it releases the GIL during optimisation.

Note, the release note was skipped as this is to a large part non-user facing. 

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [] ~A note for the release notes `docs/release-notes.md` of the upcoming release is included.~
- [ ] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
