### PR TITLE
perf: improve nodal balance constraint building

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,10 @@ SPDX-License-Identifier: CC-BY-4.0
     next update! If you would like to use these features in the meantime, you will need
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
 
+### Enhancements
+
+- Speed up [`create_model()`][pypsa.optimization.OptimizationAccessor.create_model] for large networks by computing the bus membership filter in `define_nodal_balance_constraints` with a pandas hash join instead of `xarray.isin` over object-dtype arrays. (<!-- md:pr 1770 -->)
+
 ### Bug Fixes
 
 - Fix [`supply`][pypsa.optimization.expressions.StatisticExpressionsAccessor.supply] and [`withdrawal`][pypsa.optimization.expressions.StatisticExpressionsAccessor.withdrawal] expressions dropping the charging contribution of `StorageUnit` components. The supply/withdrawal split now considers the effective coefficients of the operational variable, so the `p_store` term is correctly reported as a withdrawal. (<!-- md:pr 1760 -->)

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1092,12 +1092,16 @@ def define_nodal_balance_constraints(
         # Only keep the first scenario if there are multiple
         if n.has_scenarios:
             cbuses = cbuses.isel(scenario=0, drop=True)
-        cbuses = cbuses[cbuses.isin(buses)].rename("Bus")
 
-        if not cbuses.size:
+        # `numpy.isin` on object arrays scales poorly; use pandas hashing instead
+        mask = pd.Index(cbuses.data).isin(buses)
+
+        if not mask.any():
             continue
 
-        #  drop non-existent multiport buses which are ''
+        cbuses = cbuses[mask].rename("Bus")
+
+        # drop non-existent multiport buses which are ''
         if (
             c.name in n.controllable_branch_components
             and isinstance(c, _Multiport)
@@ -1134,11 +1138,16 @@ def define_nodal_balance_constraints(
             cbuses = cbuses.sel(name=names)
             if n.has_scenarios:
                 cbuses = cbuses.isel(scenario=0, drop=True)
-            cbuses = cbuses[cbuses.isin(buses)].rename("Bus")
-            cbuses = cbuses[cbuses != ""]
 
-            if not cbuses.size:
+            # `numpy.isin` on object arrays scales poorly; use pandas hashing.
+            # Also drop non-existent multiport buses, which are "".
+            labels = pd.Index(cbuses.data)
+            mask = labels.isin(buses) & (labels != "")
+
+            if not mask.any():
                 continue
+
+            cbuses = cbuses[mask].rename("Bus")
 
             expr = expr.sel(name=cbuses.coords["name"].values)
             if expr.size:


### PR DESCRIPTION
While working on [GLADE](https://github.com/Sustainable-Solutions-Lab/GLADE) I've run into several performance issues with PyPSA that are relatively minor but turned out to be significant enough in the slightly unusual context of GLADE to be worth fixing; I thought it'd be nice to upstream the fixes.

This PR is a little subtle; it turns out that a single `.isin` in `define_nodal_balance_constraints` could end up taking quite a lot of time. This `.isin` was run on a numpy array, which I guess in this case led to an O(n) search. By constructing a pandas index, we get ~O(1) performance (presumably through hashing).

This is behaviour-preserving (same constraints, same results); it only changes how the bus mask is computed.

For typical power system networks, this PR leads to a mild performance improvement. In a typical GLADE network (which has lots of components but only a single snapshot), I've seen this fix cut down constraint building time from ~400s to ~10s.

The following benchmark on a PyPSA example network was conducted by Claude Code:

### Benchmark

Reproducible on the stock `carbon_management` example (2164 buses, 6830
links, 168 snapshots):

```python
import time, warnings, pypsa
warnings.filterwarnings("ignore")

n = pypsa.examples.carbon_management()
n.optimize.create_model()  # warm-up, not timed

times = []
for _ in range(3):
    t0 = time.perf_counter()
    n.optimize.create_model()
    times.append(time.perf_counter() - t0)
print(f"create_model(): min={min(times):.3f}s mean={sum(times)/len(times):.3f}s")
```

Result (`create_model()`, full model build):

| | min | mean |
|---|---|---|
| before | 9.68 s | 9.71 s |
| after  | 7.87 s | 8.24 s |

~19 % faster on this stock network; the relative speedup grows with the
number of components (the nodal-balance filter is a larger share of build
time on bigger networks).
## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
