### PR TITLE
perf: import and export speedup

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,10 @@ SPDX-License-Identifier: CC-BY-4.0
     next update! If you would like to use these features in the meantime, you will need
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
 
+### Enhancements
+
+- Speed up netCDF I/O for networks with many components. [`export_to_netcdf()`][pypsa.Network.export_to_netcdf] avoids a costly `stack()` when writing dynamic data, and import avoids per-column boxing when coercing string dtypes. The on-disk format and round-trip behaviour are unchanged. (<!-- md:pr 1771 -->)
+
 ### Bug Fixes
 
 - Fix [`supply`][pypsa.optimization.expressions.StatisticExpressionsAccessor.supply] and [`withdrawal`][pypsa.optimization.expressions.StatisticExpressionsAccessor.withdrawal] expressions dropping the charging contribution of `StorageUnit` components. The supply/withdrawal split now considers the effective coefficients of the operational variable, so the `p_store` term is correctly reported as a withdrawal. (<!-- md:pr 1760 -->)

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1065,11 +1065,19 @@ class _ExporterNetCDF(_Exporter):
         new_col_name = list_name + "_t_" + attr + "_i"
         if isinstance(df.columns, pd.MultiIndex):  # stochastic
             df = df.rename_axis(index="snapshots", columns=["scenario", new_col_name])
+            self.ds[list_name + "_t_" + attr] = df.stack(
+                level=df.columns.names, future_stack=True
+            ).to_xarray()
         else:
-            df = df.rename_axis(index="snapshots", columns=new_col_name)
-        self.ds[list_name + "_t_" + attr] = df.stack(
-            level=df.columns.names, future_stack=True
-        ).to_xarray()
+            # Fast path: create DataArray directly from 2D values
+            self.ds[list_name + "_t_" + attr] = xr.DataArray(
+                df.values,
+                dims=["snapshots", new_col_name],
+                coords={
+                    "snapshots": ("snapshots", df.index.values),
+                    new_col_name: (new_col_name, df.columns.values),
+                },
+            )
 
     def set_compression_encoding(self) -> None:
         """Set compression encoding for all variables."""

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1066,9 +1066,6 @@ class _ExporterNetCDF(_Exporter):
         """Save a dynamic components data."""
         new_col_name = list_name + "_t_" + attr + "_i"
         snapshots = ("snapshots", df.index.values)
-        # Build the DataArray directly from the values, avoiding the expensive
-        # pandas stack() which is costly for wide DataFrames (many columns, few
-        # rows). See https://github.com/PyPSA/PyPSA/pull/1771.
         if isinstance(df.columns, pd.MultiIndex):  # stochastic
             scenarios = np.sort(df.columns.get_level_values(0).unique().values)
             names = np.sort(df.columns.get_level_values(1).unique().values)

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -74,9 +74,11 @@ def _coerce_string_dtypes(df: pd.DataFrame) -> pd.DataFrame:
 
     df.index = _coerce_axis(df.index)
     df.columns = _coerce_axis(df.columns)
-    for col in df.columns:
-        if isinstance(df[col].dtype, pd.StringDtype):
-            df[col] = df[col].astype(object)
+    str_cols = [
+        col for col, dtype in df.dtypes.items() if isinstance(dtype, pd.StringDtype)
+    ]
+    if str_cols:
+        df[str_cols] = df[str_cols].astype(object)
     return df
 
 

--- a/pypsa/network/io.py
+++ b/pypsa/network/io.py
@@ -1065,21 +1065,34 @@ class _ExporterNetCDF(_Exporter):
     def save_series(self, list_name: str, attr: str, df: pd.DataFrame) -> None:
         """Save a dynamic components data."""
         new_col_name = list_name + "_t_" + attr + "_i"
+        snapshots = ("snapshots", df.index.values)
+        # Build the DataArray directly from the values, avoiding the expensive
+        # pandas stack() which is costly for wide DataFrames (many columns, few
+        # rows). See https://github.com/PyPSA/PyPSA/pull/1771.
         if isinstance(df.columns, pd.MultiIndex):  # stochastic
-            df = df.rename_axis(index="snapshots", columns=["scenario", new_col_name])
-            self.ds[list_name + "_t_" + attr] = df.stack(
-                level=df.columns.names, future_stack=True
-            ).to_xarray()
-        else:
-            # Fast path: create DataArray directly from 2D values
-            self.ds[list_name + "_t_" + attr] = xr.DataArray(
-                df.values,
-                dims=["snapshots", new_col_name],
-                coords={
-                    "snapshots": ("snapshots", df.index.values),
-                    new_col_name: (new_col_name, df.columns.values),
-                },
+            scenarios = np.sort(df.columns.get_level_values(0).unique().values)
+            names = np.sort(df.columns.get_level_values(1).unique().values)
+            grid = pd.MultiIndex.from_product([scenarios, names])
+            values = df.reindex(columns=grid).values.reshape(
+                len(df.index), len(scenarios), len(names)
             )
+            dims = ["snapshots", "scenario", new_col_name]
+            coords = {
+                "snapshots": snapshots,
+                "scenario": ("scenario", scenarios),
+                new_col_name: (new_col_name, names),
+            }
+        else:
+            values = df.values
+            dims = ["snapshots", new_col_name]
+            coords = {
+                "snapshots": snapshots,
+                new_col_name: (new_col_name, df.columns.values),
+            }
+
+        self.ds[list_name + "_t_" + attr] = xr.DataArray(
+            values, dims=dims, coords=coords
+        )
 
     def set_compression_encoding(self) -> None:
         """Set compression encoding for all variables."""


### PR DESCRIPTION
While work on [GLADE](https://github.com/Sustainable-Solutions-Lab/GLADE) I've uncovered and fixed a couple of performance issues in PyPSA which I thought it would be nice to bring back upstream. See also #1770.

This PR bundles two relatively simple changes related to IO. Now, I know that it's on the roadmap to move to a different format, I still thought that these fixes might have enough value in the mean time to submit as a PR.

## Changes proposed in this Pull Request

1. In importing a network, a simple change to vectorize coercing string type columns. Performance issues are often obscure; it turns out that calling `df[col] = df[col].astype(object)` one column at a time is a real hot-path. On the `carbon_management` example network, vectorizing this loop cuts down import time by a factor of 4!
2. In exporting to netCDF, `.stack` (which is used to export stochastic networks) is expensive; this PR introduces a fast-path in the case where this stack isn't necessary.

The below benchmark was generated by Claude Code:

### Benchmark

Reproducible on the stock `carbon_management` (2164 buses, 6830 links,
168 snapshots) and `scigrid_de` examples:

```python
import tempfile, time, warnings
from pathlib import Path
import pypsa
warnings.filterwarnings("ignore")

def t(fn, r=3):
    xs = []
    for _ in range(r):
        t0 = time.perf_counter(); fn(); xs.append(time.perf_counter() - t0)
    return min(xs)

for name in ["carbon_management", "scigrid_de"]:
    n = pypsa.examples.__dict__[name]()
    p = Path(tempfile.mkdtemp()) / f"{name}.nc"
    print(name,
          "export", round(t(lambda: n.export_to_netcdf(p)), 3),
          "import", round(t(lambda: pypsa.Network(p)), 3))
```

Result (min of 3, seconds):

| network | export before | export after | import before | import after |
|---|---|---|---|---|
| carbon_management | 12.36 | **1.17** (~10×) | 2.82 | **0.70** (~4×) |
| scigrid_de | 0.62 | **0.13** (~4.6×) | 0.22 | **0.17** (~1.3×) |

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
