### PR TITLE
fix: raise a clear TypeError when iterating a Network

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix [`supply`][pypsa.optimization.expressions.StatisticExpressionsAccessor.supply] and [`withdrawal`][pypsa.optimization.expressions.StatisticExpressionsAccessor.withdrawal] expressions dropping the charging contribution of `StorageUnit` components. The supply/withdrawal split now considers the effective coefficients of the operational variable, so the `p_store` term is correctly reported as a withdrawal. (<!-- md:pr 1760 -->)
 - Fix [`n.graph()`][pypsa.network.graph.NetworkGraphMixin.graph] building edges in a non-deterministic order, which could make results that depend on the network's cycles differ between runs. In particular, security-constrained optimization (SCLOPF) now returns consistent results. (<!-- md:pr 1764 -->)
+- Iterating over or tuple-unpacking a `Network` now raises a clear `TypeError` instead of an obscure `KeyError` from `__getitem__`. See [#1753](https://github.com/PyPSA/PyPSA/issues/1753).
 
 
 ## [**v1.2.4**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.4) <small>27th June 2026</small> { id="v1.2.4" }

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -315,6 +315,15 @@ class Network(
         """
         return self.equals(other)
 
+    def __iter__(self) -> None:
+        """Disallow iterating over a Network (would fall back to ``__getitem__``)."""
+        msg = (
+            f"'{type(self).__name__}' object is not iterable. To iterate over "
+            "components use `n.components` or `n.iterate_components()`; to select "
+            "a scenario, collection member or bus slice use `n[key]`."
+        )
+        raise TypeError(msg)
+
     def __getitem__(self, key: str) -> Network:
         """Return a shallow slice of the Network object.
 

--- a/test/test_network_index.py
+++ b/test/test_network_index.py
@@ -363,6 +363,21 @@ def test_getitem_index_methods():
             n[("Manchester", slice(0, 2))]
 
 
+def test_network_not_iterable():
+    """Regression for #1753: iterating a Network raises a clear TypeError."""
+    n = pypsa.Network()
+    n.add("Bus", "bus1")
+    n.add("Bus", "bus2")
+
+    with pytest.raises(TypeError, match="not iterable"):
+        list(n)
+    with pytest.raises(TypeError, match="not iterable"):
+        _a, _b = n  # tuple-unpacking, the #1656 footgun
+
+    # Slicing via __getitem__ must still work.
+    assert n["bus1"].equals(n.slice_network(buses="bus1"), log_mode="strict")
+
+
 def test_set_snapshots_preserves_dynamic_multiindex_name():
     # Regression for #1741: re-setting MultiIndex snapshots must not drop the
     # "snapshot" index name on dynamic data, else its DataArray dim becomes "dim_0".


### PR DESCRIPTION
Closes #1753.

`Network` defines `__getitem__` for scenario/collection/bus slicing but no `__iter__`. Iterating or tuple-unpacking a Network therefore fell back to Python's legacy sequence protocol (`n[0]`, `n[1]`, ...), and since `__getitem__` raises `KeyError`, users hit the obscure `KeyError: "Key '0' not found in scenarios, collection, or buses."` from deep inside `__getitem__`. This is the confusing trace behind #1656, where tuple-unpacking the `Network` returned by `optimize_with_rolling_horizon` (`ret, status = ...`) produced exactly that error.

This adds `__iter__` raising a clear `TypeError` pointing users at `n.components` / `n.iterate_components()` for component iteration and `n[key]` for slicing. `n[key]` slicing is unaffected.

Verified nothing internal iterates a Network: the full test suite and mypy pass.

## Checklist

- [x] Code changes are sufficiently documented.
- [x] Unit tests were added (`test_network_not_iterable`).
- [x] A release-notes note is included.
- [x] I consent to the release of this PR's code under the MIT license.
