### PR TITLE
fix: raise TypeError when iterating a `Network`

### DIFF
--- a/pypsa/components/array.py
+++ b/pypsa/components/array.py
@@ -11,7 +11,7 @@ DataArray for each variable.
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 import numpy as np
 import pandas as pd
@@ -138,6 +138,11 @@ class _XarrayAccessor:
     def __getitem__(self, attr: str) -> xr.DataArray:
         """Access component attributes as xarray DataArrays via bracket notation."""
         return self._get_array(attr)
+
+    def __iter__(self) -> NoReturn:
+        """Raise a clear error, as XarrayAccessor objects are not iterable."""
+        msg = "XarrayAccessor objects are not iterable."
+        raise TypeError(msg)
 
     def __dir__(self) -> list[str]:
         """List available attributes for tab-completion."""

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import copy
 import logging
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 from weakref import ref
 
 from deprecation import deprecated
@@ -481,6 +481,11 @@ class Network(
                 raise NotImplementedError(msg)
 
             return self.slice_network(key)
+
+    def __iter__(self) -> NoReturn:
+        """Raise a clear error, as Network objects are not iterable."""
+        msg = "PyPSA Network objects are not iterable."
+        raise TypeError(msg)
 
     @property
     def stats(self) -> StatisticsAccessor:

--- a/test/test_components_array.py
+++ b/test/test_components_array.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray
 
 from pypsa.components.array import _from_xarray
@@ -290,3 +291,12 @@ def test_from_xarray_edge_cases():
     assert isinstance(result_2d, pd.DataFrame)
     # After name expansion, we have 3+ dimensions, so combined index is created
     assert len(result_2d.columns) == 4  # gen1*c1, gen1*c2, gen2*c1, gen2*c2
+
+
+def test_da_accessor_not_iterable(ac_dc_network):
+    da = ac_dc_network.c.generators.da
+
+    with pytest.raises(TypeError, match="not iterable"):
+        iter(da)
+    with pytest.raises(TypeError, match="not iterable"):
+        list(da)

--- a/test/test_network_index.py
+++ b/test/test_network_index.py
@@ -363,6 +363,17 @@ def test_getitem_index_methods():
             n[("Manchester", slice(0, 2))]
 
 
+def test_network_not_iterable():
+    n = pypsa.examples.ac_dc_meshed()
+
+    with pytest.raises(TypeError, match="not iterable"):
+        iter(n)
+    with pytest.raises(TypeError, match="not iterable"):
+        list(n)
+    with pytest.raises(TypeError, match="not iterable"):
+        a, b = n  # noqa: F841
+
+
 def test_set_snapshots_preserves_dynamic_multiindex_name():
     # Regression for #1741: re-setting MultiIndex snapshots must not drop the
     # "snapshot" index name on dynamic data, else its DataArray dim becomes "dim_0".


### PR DESCRIPTION
Closes #1780
Closes #1753
