### PR TITLE
Remove reliance on linopy internals in optimization module

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Speed up [`create_model()`][pypsa.optimization.OptimizationAccessor.create_model] for large networks by computing the bus membership filter in `define_nodal_balance_constraints` with a pandas hash join instead of `xarray.isin` over object-dtype arrays. (<!-- md:pr 1770 -->)
 
+- Removed the remaining reliance on linopy-internal representation (the `-1`/`FILL_VALUE` dead-slot sentinel, the private `_term` dimension, the raw `.data` backing `Dataset`, and low-level constructors/import paths) in the optimization module, using public linopy API (`LinearExpression.has_terms`, `LinearExpression.from_constant`, `Variable.roll`/`.where`, top-level imports) instead. The minimum linopy version is now `0.8.0`. (<!-- md:pr 1718 -->)
+
 ### Bug Fixes
 
 - Fixed spurious infeasibility in [`optimize_with_rolling_horizon()`][pypsa.optimization.OptimizationAccessor.optimize_with_rolling_horizon] when a network mixed committable and non-committable generators with ramp limits. At a window seam, non-committable components (which carry no commitment status) were assigned `status=0`, corrupting their start-up/shut-down ramp terms. (<!-- md:pr 1644 -->)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,8 +18,6 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Speed up [`create_model()`][pypsa.optimization.OptimizationAccessor.create_model] for large networks by computing the bus membership filter in `define_nodal_balance_constraints` with a pandas hash join instead of `xarray.isin` over object-dtype arrays. (<!-- md:pr 1770 -->)
 
-- Removed the remaining reliance on linopy-internal representation (the `-1`/`FILL_VALUE` dead-slot sentinel, the private `_term` dimension, the raw `.data` backing `Dataset`, and low-level constructors/import paths) in the optimization module, using public linopy API (`LinearExpression.has_terms`, `LinearExpression.from_constant`, `Variable.roll`/`.where`, top-level imports) instead. The minimum linopy version is now `0.8.0`. (<!-- md:pr 1718 -->)
-
 ### Bug Fixes
 
 - Fixed spurious infeasibility in [`optimize_with_rolling_horizon()`][pypsa.optimization.OptimizationAccessor.optimize_with_rolling_horizon] when a network mixed committable and non-committable generators with ramp limits. At a window seam, non-committable components (which carry no commitment status) were assigned `status=0`, corrupting their start-up/shut-down ramp terms. (<!-- md:pr 1644 -->)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pandas>=2.0",
     "xarray",
     "netcdf4",
-    "linopy>=0.7.0",
+    "linopy>=0.8.0",
     "matplotlib!=3.11.0", # faceted plots crash on 3.11.0, see matplotlib#31881
     "plotly",
     "pydeck>=0.6",

--- a/pypsa/optimization/common.py
+++ b/pypsa/optimization/common.py
@@ -11,11 +11,13 @@ from typing import TYPE_CHECKING
 import pandas as pd
 import xarray as xr
 from deprecation import deprecated
-from numpy import hstack, ravel, zeros
+from numpy import hstack, ravel, roll, zeros
 
 from pypsa.constants import RE_PORTS
 
 if TYPE_CHECKING:
+    from linopy import Variable
+
     from pypsa import Network
 
 
@@ -29,13 +31,13 @@ def _period_start_mask(sns: pd.Index) -> xr.DataArray:
     return xr.DataArray(is_start, coords=[sns])
 
 
-def _roll_within_periods(da: xr.DataArray) -> xr.DataArray:
-    """Cyclically roll ``da`` by one snapshot within each investment period."""
-    rolled = [
-        da.sel(snapshot=(period, slice(None))).roll(snapshot=1)
-        for period in da.get_index("snapshot").unique("period")
-    ]
-    return xr.concat(rolled, dim="snapshot")
+def _roll_within_periods(v: Variable) -> Variable:
+    """Cyclically roll ``v`` by one snapshot within each investment period."""
+    sns = v.indexes["snapshot"]
+    positions = pd.Series(range(len(sns)), index=sns)
+    roll_index = positions.groupby(level="period").transform(lambda s: roll(s, 1))
+    coords = xr.Coordinates.from_pandas_multiindex(sns, "snapshot")
+    return v.isel(snapshot=roll_index.to_numpy()).assign_coords(coords)
 
 
 @deprecated(

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-import linopy
 import pandas as pd
 import xarray as xr
-from linopy import merge
+from linopy import LinearExpression, merge
 from numpy import inf, isfinite, isinf, maximum, sqrt, tile
 from xarray import DataArray, where
 
@@ -820,7 +819,7 @@ def define_ramp_limit_constraints(
     if is_com_fix.any():
         com_main_names = idx[is_com_fix]
         status = status.where(~is_com_fix, 0)
-        status = linopy.LinearExpression(status, m)
+        status = LinearExpression.from_constant(m, status)
         status_var = m[f"{c.name}-status"].sel(name=com_main_names)
         status = (status + status_var).loc[:, status.indexes["name"]]
 
@@ -862,8 +861,8 @@ def define_ramp_limit_constraints(
         else:
             s_init_ext = (c.da.up_time_before.sel(name=ext_main_names) > 0) * 1.0
         sp_ext = (1 - filter_first_sn) + s_init_ext * filter_first_sn
-        if not isinstance(rhs, linopy.LinearExpression):
-            rhs = linopy.LinearExpression(rhs, m)
+        if not isinstance(rhs, LinearExpression):
+            rhs = LinearExpression.from_constant(m, rhs)
         rhs = rhs + limit_up.sel(name=ext_main_names) * p_nom_ext_var * sp_ext
         if is_com_fix.any():
             ds_ext = filter_first_sn * (1 - s_init_ext)
@@ -878,8 +877,8 @@ def define_ramp_limit_constraints(
     if is_com_fix.any():
         rhs = rhs - limit_shut * p_nom * (status_prev - status)
     if p_nom_ext_var is not None:
-        if not isinstance(rhs, linopy.LinearExpression):
-            rhs = linopy.LinearExpression(rhs, m)
+        if not isinstance(rhs, LinearExpression):
+            rhs = LinearExpression.from_constant(m, rhs)
         rhs = rhs - limit_down.sel(name=ext_main_names) * p_nom_ext_var
         if is_com_fix.any():
             ds_ext = filter_first_sn * (1 - s_init_ext)
@@ -1185,7 +1184,7 @@ def define_nodal_balance_constraints(
             .reindex(name=buses, fill_value=0)
         )
 
-    empty_nodal_balance = (lhs.vars == -1).all("_term")
+    empty_nodal_balance = ~lhs.has_terms
 
     if empty_nodal_balance.any():
         if (empty_nodal_balance & (rhs != 0)).any().item():
@@ -1725,7 +1724,7 @@ def define_storage_unit_constraints(n: Network, sns: pd.Index) -> None:
         ) | c.da.state_of_charge_initial_per_period.sel(name=c.active_assets)
 
         # We calculate the previous soc per period while cycling within a period
-        previous_soc_pp = _roll_within_periods(soc.data)
+        previous_soc_pp = _roll_within_periods(soc)
 
         # We create a mask `include_previous_soc_pp` which determines when to include
         # previous state of charge from within the period:
@@ -1747,9 +1746,7 @@ def define_storage_unit_constraints(n: Network, sns: pd.Index) -> None:
                 previous_soc_pp = previous_soc_pp.transpose(*expected_dims)
 
         # We take values still to handle internal xarray multi-index difficulties
-        previous_soc_pp = previous_soc_pp.where(
-            include_previous_soc_pp.values, linopy.variables.FILL_VALUE
-        )
+        previous_soc_pp = previous_soc_pp.where(include_previous_soc_pp.values)
 
         # update the previous_soc variables and right hand side
         previous_soc = previous_soc.where(~per_period, previous_soc_pp)
@@ -1903,7 +1900,7 @@ def define_store_constraints(n: Network, sns: pd.Index) -> None:
         per_period = per_period.sel(name=c.active_assets)
 
         # We calculate the previous e per period while cycling within a period
-        previous_e_pp = _roll_within_periods(e.data)
+        previous_e_pp = _roll_within_periods(e)
 
         # We create a mask `include_previous_e_pp` which determines when to include
         # previous energy from within the period:
@@ -1918,9 +1915,7 @@ def define_store_constraints(n: Network, sns: pd.Index) -> None:
         )
 
         # We take values still to handle internal xarray multi-index difficulties
-        previous_e_pp = previous_e_pp.where(
-            include_previous_e_pp.values, linopy.variables.FILL_VALUE
-        )
+        previous_e_pp = previous_e_pp.where(include_previous_e_pp.values)
 
         # update previous_e variables and rhs
         previous_e = previous_e.where(~per_period, previous_e_pp)

--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -125,7 +125,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
         self, res: dict[str, LinearExpression], is_one_component: bool
     ) -> LinearExpression:
         if res == {}:
-            return LinearExpression(None, self._n.model)
+            return LinearExpression.from_constant(self._n.model, 0)
         if is_one_component:
             first_key = next(iter(res))
             return res[first_key].loc[first_key]
@@ -161,7 +161,9 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
         m = self._n.model
 
         if c == "Load":
-            return LinearExpression(self._n.get_switchable_as_dense(c, "p_set"), m)
+            return LinearExpression.from_constant(
+                m, self._n.get_switchable_as_dense(c, "p_set")
+            )
         attr = lookup.query("not nominal and not handle_separately").loc[c].index
         if c == "StorageUnit":
             return m.variables[f"{c}-p_dispatch"] - m.variables[f"{c}-p_store"]
@@ -216,7 +218,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             if var_name in m.variables:
                 capacity = m.variables[var_name] + non_ext_capacity
             elif not non_ext_capacity.empty:
-                capacity = LinearExpression(non_ext_capacity, m)
+                capacity = LinearExpression.from_constant(m, non_ext_capacity)
             else:
                 return None
 
@@ -288,7 +290,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             if var_name in m.variables:
                 capacity = m.variables[var_name] + non_ext_capacity
             elif not non_ext_capacity.empty:
-                capacity = LinearExpression(non_ext_capacity, m)
+                capacity = LinearExpression.from_constant(m, non_ext_capacity)
             else:
                 return None
 
@@ -685,7 +687,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
             if var_name in m.variables:
                 capacity = m.variables[var_name] + non_ext_capacity
             elif not non_ext_capacity.empty:
-                capacity = LinearExpression(non_ext_capacity, m)
+                capacity = LinearExpression.from_constant(m, non_ext_capacity)
             else:
                 return None
 

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -12,7 +12,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 import pandas as pd
-from linopy.expressions import merge
+from linopy import merge
 from numpy import isnan
 from xarray import DataArray
 
@@ -264,7 +264,7 @@ def define_growth_limit(n: Network, sns: pd.Index) -> None:
         return
 
     lhs = merge(lhs_list)
-    rhs = max_absolute_growth.reindex_like(lhs.data)
+    rhs = max_absolute_growth.reindex(lhs.indexes)
 
     m.add_constraints(lhs, "<=", rhs, name="Carrier-growth_limit")
 

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -13,8 +13,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pandas as pd
 import xarray as xr
-from linopy import Model, merge
-from linopy.solvers import available_solvers
+from linopy import Model, available_solvers, merge
 
 from pypsa._options import options
 from pypsa.common import UnexpectedError, as_index

--- a/uv.lock
+++ b/uv.lock
@@ -3820,7 +3820,7 @@ requires-dist = [
     { name = "highspy" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.1.1" },
     { name = "levenshtein", specifier = ">=0.27.1" },
-    { name = "linopy", specifier = ">=0.7.0" },
+    { name = "linopy", specifier = ">=0.8.0" },
     { name = "matplotlib", specifier = "!=3.11.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = "<3.11" },
     { name = "mkdocs-autolinks-plugin", marker = "extra == 'docs'" },


### PR DESCRIPTION
closes #1718 

## Changes proposed in this Pull Request

- remove reliance on linopy's internal representation and use its public API instead, including adjustments to the rolling logic
- bump minimum linopy to 0.8.0.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included. -> Defered, not user facing
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
