### PR TITLE
opt: align statistics grouper to expression name order

### DIFF
--- a/pypsa/optimization/expressions.py
+++ b/pypsa/optimization/expressions.py
@@ -107,6 +107,7 @@ class StatisticExpressionsAccessor(AbstractStatisticsAccessor):
         agg: Callable | str,
         c: str,
     ) -> pd.DataFrame:
+        grouping = grouping.reindex(vals.indexes["name"])
         return vals.groupby(grouping).sum()
 
     def _aggregate_components_concat_values(


### PR DESCRIPTION
## Changes proposed in this Pull Request

Use explicit ordering ordering of name coords in optimization expressions. Needed for compatibility with `linopy>=v0.9`. Fully backwards compatible. I decided against adding a release note as this is not user facing.  

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
