### PR TITLE
ci: run dependebot PRs only on direct deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,6 @@ updates:
     uv:
       patterns:
       - '*'
+      update-types:
+      - minor
+      - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
     interval: weekly
   cooldown:
     default-days: 7
+  # skip standalone PRs for transitive deps
+  allow:
+  - dependency-type: direct
   groups:
     uv:
       patterns:


### PR DESCRIPTION
This should remove the mass of dependabot PRs recently created. Those deps are now included in the weekly one