### PR TITLE
ci: run flaky external link checks only on scheduled daily runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,8 @@ jobs:
         && uv run coverage xml
 
     - name: Check external links
-      if: ${{ !cancelled() }}
+      # Flaky external hosts, run on the daily schedule only, not PRs/master
+      if: ${{ !cancelled() && github.event_name == 'schedule' }}
       uses: lycheeverse/lychee-action@v2
       with:
         args: "--config .lychee.toml --no-progress './**/*.md'"

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -34,5 +34,5 @@ exclude = [
 exclude_path = ["docs/release-notes.md"]
 
 timeout = 30
-max_retries = 2
+max_retries = 5
 max_redirects = 10


### PR DESCRIPTION
The external link checker recently merges is currently flaky. It's enough to have those failing on daily scheduled runs only. Not on PRs/ master. And maybe the increased max_retries helps

 