### PR TITLE
[Do Not Merge] linopy 0.9 backwards compat

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -123,7 +123,10 @@ jobs:
         # Allow upgrading internal packages without exclude-newer cap
         sed -i '/^exclude-newer\s*=/d' pixi.toml
         pixi remove ${{ env.PACKAGE_NAME }}
-        pixi upgrade linopy
+        # Install linopy from the v1 PR branch (matches PyPSA's [tool.uv.sources]);
+        # conda-forge linopy pins 0.8.0 and conflicts with PyPSA's git requirement
+        pixi remove linopy
+        pixi add --pypi --git https://github.com/PyPSA/linopy.git linopy --branch feat/arithmetic-convention
         pixi add --pypi --git https://github.com/${{ github.repository }}.git ${{ github.event.repository.name }} --rev ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
     - name: Run snakemake test workflows

--- a/docs/user-guide/optimization/stochastic.md
+++ b/docs/user-guide/optimization/stochastic.md
@@ -241,7 +241,7 @@ Constraints:
  * StorageUnit-ext-p_store-upper (scenario, name, snapshot)
  * StorageUnit-ext-state_of_charge-lower (scenario, name, snapshot)
  * StorageUnit-ext-state_of_charge-upper (scenario, name, snapshot)
- * Bus-nodal_balance (name, scenario, snapshot)
+ * Bus-nodal_balance (scenario, name, snapshot)
  * StorageUnit-energy_balance (scenario, name, snapshot)
  * Store-energy_balance (scenario, name, snapshot)
 <BLANKLINE>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,8 @@ filterwarnings = [
     # Ignore linopy warnings
     "default:Coordinates across variables not equal. Perform outer join.:UserWarning",
     "ignore:In a future version of xarray the default value for join will change:FutureWarning",
+    # linopy v1-semantics forward-looking warnings (legacy behavior unchanged); migrate when v1 ships
+    "ignore::linopy.config.LinopySemanticsWarning",
 
     # Ignore pandas<3.0.3 usage of the deprecated `locs` attribute of matplotlib>=3.11
     "ignore:The locs attribute was deprecated:DeprecationWarning",
@@ -288,3 +290,6 @@ ignore = [
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.
 ban-relative-imports = "all"
+
+[tool.uv.sources]
+linopy = { git = "https://github.com/PyPSA/linopy.git", branch = "feat/arithmetic-convention" }

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -675,7 +675,7 @@ class Network(
         * Line-ext-s-upper (snapshot, name)
         * Link-ext-p-lower (snapshot, name)
         * Link-ext-p-upper (snapshot, name)
-        * Bus-nodal_balance (name, snapshot)
+        * Bus-nodal_balance (snapshot, name)
         * Kirchhoff-Voltage-Law (snapshot, cycle)
         * GlobalConstraint-co2_limit
         <BLANKLINE>

--- a/uv.lock
+++ b/uv.lock
@@ -1884,8 +1884,8 @@ wheels = [
 
 [[package]]
 name = "linopy"
-version = "0.8.0.post1.dev133+g8ce901e03"
-source = { git = "https://github.com/PyPSA/linopy.git?branch=feat%2Farithmetic-convention#8ce901e03b8a133f86a4d77c5661284c71605076" }
+version = "0.8.0.post1.dev136+gc48dafdd6"
+source = { git = "https://github.com/PyPSA/linopy.git?branch=feat%2Farithmetic-convention#c48dafdd66798b132cf9920bd4bf9de5bafcccd4" }
 dependencies = [
     { name = "bottleneck" },
     { name = "dask" },

--- a/uv.lock
+++ b/uv.lock
@@ -1884,8 +1884,8 @@ wheels = [
 
 [[package]]
 name = "linopy"
-version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.8.0.post1.dev133+g8ce901e03"
+source = { git = "https://github.com/PyPSA/linopy.git?branch=feat%2Farithmetic-convention#8ce901e03b8a133f86a4d77c5661284c71605076" }
 dependencies = [
     { name = "bottleneck" },
     { name = "dask" },
@@ -1898,10 +1898,6 @@ dependencies = [
     { name = "toolz" },
     { name = "tqdm" },
     { name = "xarray" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/7f/80c12a3bba2a2bd8c17777fb272a37ccd16e65e53dc81d0d137fabd29241/linopy-0.8.0.tar.gz", hash = "sha256:566ede05d6134abf978fb4c1e18e0e5b67cd1acf0b26e9d80adcada3632d9c02", size = 1453088, upload-time = "2026-06-10T09:48:45.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/a9/987a9f2ad9a0b846147092edf0071b0f96b84c0e5933ac354192d8a3836d/linopy-0.8.0-py3-none-any.whl", hash = "sha256:107f9dcb63943bb02e457693f639e4adceea265040d76f8949bad8b496558304", size = 184634, upload-time = "2026-06-10T09:48:43.147Z" },
 ]
 
 [[package]]
@@ -3842,7 +3838,7 @@ requires-dist = [
     { name = "highspy" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.1.1" },
     { name = "levenshtein", specifier = ">=0.27.1" },
-    { name = "linopy", specifier = ">=0.8.0" },
+    { name = "linopy", git = "https://github.com/PyPSA/linopy.git?branch=feat%2Farithmetic-convention" },
     { name = "matplotlib", specifier = "!=3.11.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = "<3.11" },
     { name = "mkdocs-autolinks-plugin", marker = "extra == 'docs'" },


### PR DESCRIPTION
DO NOT MERGE THIS PR. 


This pr is solely used for tracking the backwards compatibility of linopy on new semantics https://github.com/PyPSA/linopy/pull/717 in legacy mode. It is not meant to be merged at any time. Its purpose is to ease tracking the backwards compatibility with large upcoming changes in linopy v0.9. The latter would raise a `LinopySemanticsWarning` wherever the semantics change when opting-in to "v1" mode as well as linopy `v1.0`. 