### PR TITLE
ci: consolidate uv dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,13 +22,9 @@ updates:
     interval: weekly
   cooldown:
     default-days: 7
-  # skip standalone PRs for transitive deps
   allow:
-  - dependency-type: direct
+  - dependency-type: all
   groups:
     uv:
       patterns:
       - '*'
-      update-types:
-      - minor
-      - patch


### PR DESCRIPTION
@FabianHofmann Getting extra PRs just for major versions of direct deps seems not to work with `uv`. So its a single PR instead now