### PR TITLE
Add PyPSA-CL model to the Americas list

### DIFF
--- a/docs/home/models.md
+++ b/docs/home/models.md
@@ -44,6 +44,7 @@ open source and actively maintained. Below is a list of some known models.
 - **[:flag_us: pypsa-illinois](https://github.com/ucsusa/pypsa-illinois)**: Using PyPSA to model the Illinois electricity system for storage requirement analysis maintained by Union of Concerned Scientists (UCS).
 - **[:flag_ar: PyPSA-AR](https://github.com/FTDT-PyPSA/PyPSA-AR)**: Reproducible model of the Argentine high-voltage power grid using PyPSA maintained by Fundación Torcuato Di Tella (FTDT).
 - **[:flag_ca: PyPSA-Canada](https://github.com/NRCan/pypsa-canada)**: used PyPSA for a workflow-based modeling framework for power system analysis in Canada maintained by Natural Resources Canada (NRCan).
+- **[:flag_cl: PyPSA-CL](https://github.com/paredes-vergara/PyPSA-CL)**: Capacity expansion model of the National Electric System used in the official Long-term Energy Planning process of Chile (PELP 2028-2032). Developed by the Planning and Climate Change Unit of the [Ministry of Energy of Chile](https://energia.gob.cl/pelp/repositorio) using entirely public data.
 
 ### Africa
 - **[:flag_za: PyPSA-RSA](https://github.com/MeridianEconomics/pypsa-rsa)**: South-African electricity model, maintained by [Meridian Economics](https://meridianeconomics.co.za/)


### PR DESCRIPTION
Added a description for the PyPSA-CL model used in Chile's official Long-term Energy Planning process (PELP 2028-2032), recently published on July 24th, 2026.

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
