### PR TITLE
ci: pin github actions to commit shas

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
   directory: /
   schedule:
     interval: monthly
+  # actions are pinned to commit SHAs, so every release needs an explicit bump.
+  # all of them land in the single monthly pull-request below.
   groups:
     # open a single pull-request for all GitHub actions updates
     github-actions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,11 +59,11 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -91,6 +91,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     name: Publish example networks to bucket
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - uses: actions/setup-python@v7
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: 3.12
 
@@ -102,16 +102,16 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: hynek/build-and-inspect-python-package@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
 
   release:
     name: Create GitHub release
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: softprops/action-gh-release@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
         body: |
           Revised release notes are available in the [documentation](https://docs.pypsa.org/latest/release-notes/).
@@ -128,8 +128,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Packages
         path: dist
-    - uses: pypa/gh-action-pypi-publish@release/v1
+    - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -40,9 +40,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - uses: dorny/paths-filter@v4
+    - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
       id: filter
       with:
         filters: |
@@ -67,7 +67,7 @@ jobs:
         echo "Final disk space"
         df -h
 
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       if: steps.filter.outputs.src == 'true' || github.event_name == 'schedule'
       with:
         repository: PyPSA/pypsa-eur
@@ -82,7 +82,7 @@ jobs:
 
     - name: Setup Pixi
       if: steps.filter.outputs.src == 'true' || github.event_name == 'schedule'
-      uses: prefix-dev/setup-pixi@v0.10.0
+      uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
       with:
         pixi-version: v0.68.1
         cache: true
@@ -105,7 +105,7 @@ jobs:
             echo "pinned=false" >> $GITHUB_ENV
         fi
 
-    - uses: actions/cache@v6
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       if: (steps.filter.outputs.src == 'true' || github.event_name == 'schedule') && env.pinned == 'false'
       with:
         path: |
@@ -138,7 +138,7 @@ jobs:
 
     - name: Upload artifacts
       if: (steps.filter.outputs.src == 'true' || github.event_name == 'schedule') && env.pinned == 'false'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: results-pypsa-eur-${{ matrix.version }}
         path: |
@@ -167,7 +167,7 @@ jobs:
   #       shell: bash -l {0}
 
   #   steps:
-  #   - uses: actions/checkout@v7
+  #   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
   #     with:
   #       repository: PyPSA/pypsa-de
   #       ref: main
@@ -193,7 +193,7 @@ jobs:
   #           echo "pinned=false" >> $GITHUB_ENV
   #       fi
 
-  #   - uses: actions/cache@v6
+  #   - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
   #     if: env.pinned == 'false'
   #     with:
   #       path: |
@@ -202,7 +202,7 @@ jobs:
   #         resources/ariadne_database.csv
   #       key: data-cutouts-pypsa-de-${{ env.WEEK }}
 
-  #   - uses: conda-incubator/setup-miniconda@v3
+  #   - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
   #     if: env.pinned == 'false'
   #     with:
   #       miniforge-version: latest
@@ -211,7 +211,7 @@ jobs:
 
   #   - name: Cache Conda env
   #     if: env.pinned == 'false'
-  #     uses: actions/cache@v6
+  #     uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
   #     with:
   #       path: ${{ env.CONDA }}/envs
   #       key: conda-pypsa-de-${{ env.WEEK }}-${{ hashFiles('envs/linux-64.lock.yaml') }}
@@ -240,7 +240,7 @@ jobs:
 
   #   - name: Upload artifacts
   #     if: env.pinned == 'false'
-  #     uses: actions/upload-artifact@v7
+  #     uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
   #     with:
   #       name: results-pypsa-de-${{ matrix.version }}
   #       path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,10 @@ jobs:
     name: Build and verify package
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0   # Needed for setuptools_scm
-    - uses: hynek/build-and-inspect-python-package@v2
+    - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
       id: baipp
 
     - name: Compute reduced PR python versions
@@ -68,12 +68,12 @@ jobs:
     env:
       MPLBACKEND: Agg # https://github.com/orgs/community/discussions/26434
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0   # Needed for setuptools_scm
 
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -87,7 +87,7 @@ jobs:
         brew install hdf5
 
     - name: Download package
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Packages
         path: dist
@@ -134,7 +134,7 @@ jobs:
 
     - name: Upload code coverage report
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: >
@@ -145,7 +145,7 @@ jobs:
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: >
@@ -163,17 +163,17 @@ jobs:
     env:
       MPLBACKEND: Agg # https://github.com/orgs/community/discussions/26434
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0   # Needed for setuptools_scm
 
     - name: Set up Python 3.13
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: 3.13
 
     - name: Download package
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Packages
         path: dist
@@ -191,7 +191,7 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: results-plotting
         path: |
@@ -205,17 +205,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0   # Needed for setuptools_scm
 
     - name: Set up Python 3.13
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: 3.13
 
     - name: Download package
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Packages
         path: dist
@@ -236,7 +236,7 @@ jobs:
     - name: Check external links
       # Flaky external hosts, run on the daily schedule only, not PRs/master
       if: ${{ !cancelled() && github.event_name == 'schedule' }}
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
       with:
         args: "--config .lychee.toml --no-progress './**/*.md'"
         fail: true
@@ -245,7 +245,7 @@ jobs:
 
     - name: Upload code coverage report
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: >
@@ -256,7 +256,7 @@ jobs:
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: >
@@ -271,17 +271,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0   # Needed for setuptools_scm
 
     - name: Set up Python 3.13
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: 3.13
 
     - name: Download package
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Packages
         path: dist


### PR DESCRIPTION
 Pin every action to a commit SHA with the release as a trailing comment, which dependabot keeps up to date. Dependabot already groups github-actions into a single monthly pull-request, so the bumps this adds stay bounded to one PR per month.
