### PR TITLE
fix: support ramp limits under set_scenarios

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,6 +30,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Bug Fixes
 
+- Fix [`n.optimize()`][pypsa.optimization.OptimizationAccessor.__call__] failing for stochastic networks (see [`n.set_scenarios()`][pypsa.Network.set_scenarios]) containing components with ramp limits. (<!-- md:pr 1873 -->)
 - Fix [`n.optimize()`][pypsa.optimization.OptimizationAccessor.__call__] failing with a `KeyError` when a network contains inactive components alongside committable, modular or ramp-limited ones. (<!-- md:pr 1870 -->)
 - [`c.active_assets`][pypsa.Components.active_assets] and [`c.inactive_assets`][pypsa.Components.inactive_assets] are now guaranteed to be mutually exclusive, also for stochastic networks. (<!-- md:pr 1870 -->)
 - The fixed `phase_shift` on `Transformer` components is now included in the cycle-based Kirchhoff Voltage Law constraint in `n.optimize()`. Previously the phase shift was not considered in LOPF (only `n.lpf()` and `n.pf()` respected it), causing optimisation results to diverge from subsequent non-linear power-flow verification. (<!-- md:pr 1661 -->)

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -924,8 +924,8 @@ def _define_ramp_limit_big_m(
 
     if is_rolling_horizon:
         start_i = n.snapshots.get_loc(sns[0]) - 1
-        p_init = c.da[hist_attr][start_i].sel(name=idx)
-        s_init = c.da.status[start_i].sel(name=idx).fillna(1)
+        p_init = c.da[hist_attr].isel(snapshot=start_i).sel(name=idx)
+        s_init = c.da.status.isel(snapshot=start_i).sel(name=idx).fillna(1)
     else:
         initially_up = c.da.up_time_before.sel(name=idx) > 0
         p_init = c.da.p_init.sel(name=idx).where(initially_up, 0)
@@ -1017,9 +1017,10 @@ def define_ramp_limit_constraints(
         return
 
     idx = c.active_assets
-    is_ext = idx.isin(c.extendables)
-    is_com = idx.isin(c.committables)
-    is_modular = idx.isin(c.modulars)
+    # Label-indexed on name so masks broadcast against the scenario arrays.
+    is_ext = DataArray(idx.isin(c.extendables), coords=[idx])
+    is_com = DataArray(idx.isin(c.committables), coords=[idx])
+    is_modular = DataArray(idx.isin(c.modulars), coords=[idx])
     is_com_ext = is_com & is_ext & ~is_modular
     is_com_ext_mod = is_com & is_ext & is_modular
     is_com_fix = is_com & ~is_com_ext
@@ -1051,12 +1052,12 @@ def define_ramp_limit_constraints(
     is_ext_main = is_ext & ~is_com_ext & ~is_com_ext_mod
     p_nom_ext_var = None
     if is_ext_main.any():
-        ext_main_names = idx[is_ext_main]
+        ext_main_names = idx[is_ext_main.values]
         p_nom_ext_var = m[f"{c.name}-{nom_attr}"].sel(name=ext_main_names)
 
     status = DataArray(1, coords=[sns, idx])
     if is_com_fix.any():
-        com_main_names = idx[is_com_fix]
+        com_main_names = idx[is_com_fix.values]
         status = status.where(~is_com_fix, 0)
         status = LinearExpression.from_constant(m, status)
         status_var = m[f"{c.name}-status"].sel(name=com_main_names)
@@ -1064,13 +1065,18 @@ def define_ramp_limit_constraints(
 
     if is_rolling_horizon:
         start_i = n.snapshots.get_loc(sns[0]) - 1
-        p_init = c.da[hist_attr][start_i].sel(name=idx)
-        s_init = c.da.status[start_i].where(c.da.committable, 1).fillna(1).sel(name=idx)
+        p_init = c.da[hist_attr].isel(snapshot=start_i).sel(name=idx)
+        s_init = (
+            c.da.status.isel(snapshot=start_i)
+            .where(c.da.committable, 1)
+            .fillna(1)
+            .sel(name=idx)
+        )
     else:
         initially_up = c.da.up_time_before.sel(name=idx) > 0
         p_init = c.da.p_init.sel(name=idx).where(initially_up, 0)
         s_init = initially_up
-        mask[0] = p_init.notnull()
+        mask.loc[{"snapshot": sns[0]}] = p_init.notnull()
 
     # skip starts of periods except the first where p_init is used
     boundary = _period_start_mask(sns)

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1052,12 +1052,12 @@ def define_ramp_limit_constraints(
     is_ext_main = is_ext & ~is_com_ext & ~is_com_ext_mod
     p_nom_ext_var = None
     if is_ext_main.any():
-        ext_main_names = idx[is_ext_main.values]
+        ext_main_names = idx[is_ext_main]
         p_nom_ext_var = m[f"{c.name}-{nom_attr}"].sel(name=ext_main_names)
 
     status = DataArray(1, coords=[sns, idx])
     if is_com_fix.any():
-        com_main_names = idx[is_com_fix.values]
+        com_main_names = idx[is_com_fix]
         status = status.where(~is_com_fix, 0)
         status = LinearExpression.from_constant(m, status)
         status_var = m[f"{c.name}-status"].sel(name=com_main_names)

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -1727,3 +1727,26 @@ def test_ramp_limit_stochastic_optimization_bug():
     for scenario in n.scenarios:
         diff = p[scenario].diff().dropna()
         assert (diff.abs() <= ramp * p_nom + tol).all()
+
+
+def test_active_inactive_assets_per_scenario():
+    """Per-scenario activeness keeps active/inactive assets mutually exclusive."""
+    n = pypsa.Network(snapshots=range(3))
+    n.add("Bus", "bus")
+    n.add("Generator", "g", bus="bus", p_nom_extendable=True)
+    n.add("Generator", "h", bus="bus", p_nom_extendable=True)
+    n.set_scenarios({"a": 0.5, "b": 0.5})
+
+    # Deactivate g only in scenario "b" (do not run consistency_check).
+    n.c.generators.static.loc[("b", "g"), "active"] = False
+
+    c = n.c.generators
+    active, inactive = c.active_assets, c.inactive_assets
+
+    # g is active in at least one scenario, so it must not be inactive.
+    assert "g" in active
+    assert "g" not in inactive
+    # Documented invariant: the two sets partition the names.
+    assert active.intersection(inactive).empty
+    # Model index must keep g (pre-fix it was dropped via .difference).
+    assert "g" in c.extendables.difference(inactive)

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -1690,3 +1690,40 @@ def test_1472():
     n.set_scenarios({"a": 0.5, "b": 0.5})
     status, _ = n.optimize()
     assert status == "ok"
+
+
+def test_ramp_limit_stochastic_optimization_bug():
+    """Ramp-limit constraints must build and hold under scenarios."""
+    p_nom = 10.0
+    ramp = 0.3
+
+    n = pypsa.Network()
+    n.set_snapshots(range(5))
+    n.add("Bus", "bus")
+    n.add(
+        "Load",
+        "load",
+        bus="bus",
+        p_set=[0.0, 3.0, 6.0, 2.0, 5.0],
+    )
+    n.add("Generator", "slack", bus="bus", p_nom=100, marginal_cost=100)
+    n.add(
+        "Generator",
+        "g",
+        bus="bus",
+        p_nom=p_nom,
+        marginal_cost=1,
+        ramp_limit_up=ramp,
+        ramp_limit_down=ramp,
+    )
+
+    n.set_scenarios({"a": 0.5, "b": 0.5})
+    status, condition = n.optimize(solver_name="highs")
+    assert status == "ok"
+    assert condition == "optimal"
+
+    p = n.c["Generator"].dynamic["p"].xs("g", axis=1, level="name")
+    tol = 1e-6
+    for scenario in n.scenarios:
+        diff = p[scenario].diff().dropna()
+        assert (diff.abs() <= ramp * p_nom + tol).all()

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -1724,9 +1724,8 @@ def test_ramp_limit_stochastic_optimization_bug():
 
     p = n.c["Generator"].dynamic["p"].xs("g", axis=1, level="name")
     tol = 1e-6
-    for scenario in n.scenarios:
-        diff = p[scenario].diff().dropna()
-        assert (diff.abs() <= ramp * p_nom + tol).all()
+    diff = p.diff().dropna()
+    assert (diff.abs() <= ramp * p_nom + tol).all().all()
 
 
 def test_active_inactive_assets_per_scenario():


### PR DESCRIPTION
Ramp limits for stochastic networks currently break.

`c.da` dims under scenarios:
```
plain:      ('snapshot', 'name')
scenarios:  ('scenario', 'name', 'snapshot')
```
Fixes:
1. dim 0 was snapshot, becomes scenario -> isel./.loc select to right axis
2. `idx.isin(...)` is raw numpy, so xarray falls back to numpy broadcasting, which right aligns dims. `name` was last, with scenarios `snapshot` is. Which means the mask lands on the wrong axis. Wrapping in `DataArray(..., coords=[idx])` aligns by name label instead.