### PR TITLE
docs: render pre-executed notebooks instead of executing on every build

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: PyPSA Contributors
+#
+# SPDX-License-Identifier: MIT
+
+name: Build docs (execute notebooks)
+
+on:
+  schedule:
+  - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: build-docs
+  cancel-in-progress: true
+
+permissions:
+  contents: write   # to push docs-notebooks branch
+
+jobs:
+  execute-notebooks:
+    name: Execute notebooks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: 3.13
+
+    - name: Install dependencies
+      run: |
+        python -m pip install uv
+        uv sync --extra docs --upgrade
+
+    - name: Gurobi license
+      run: |
+        printf '%b' "$GUROBI_LIC" > $HOME/gurobi.lic
+        python -c "p='$HOME/gurobi.lic';open(p,'w').write(open(p).read().replace(chr(39),''))"
+      env:
+        GUROBI_LIC: ${{ secrets.GUROBI_LIC }}
+
+    - name: Execute notebooks
+      run: |
+        PYPSA_PARAMS__OPTIMIZE__SOLVER_NAME=gurobi \
+          uv run jupyter nbconvert --to notebook --execute --inplace \
+          $(git ls-files 'docs/**/*.ipynb')
+
+    - name: Publish to docs-notebooks branch
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git switch -C docs-notebooks
+        git add -f $(git ls-files -c -o 'docs/**/*.ipynb')
+        git commit -m "docs: execute notebooks [skip ci]"
+        git push -f origin docs-notebooks

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,7 +26,7 @@ build:
     - PYPSA_PARAMS__OPTIMIZE__SOLVER_NAME=gurobi uv run pytest test/test_docs.py --test-docs
       # Overlay pre-executed notebooks from the docs-notebooks branch (built daily by build-docs.yml)
     - git fetch origin docs-notebooks || true
-    - git checkout origin/docs-notebooks -- ':(glob)docs/**/*.ipynb' || true
+    - git checkout origin/docs-notebooks -- 'docs/*.ipynb' || true
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,6 +24,9 @@ build:
     - python -c "p=\"$HOME/gurobi.lic\";t=open(p).read().replace(chr(39),\"\");open(p,\"w\").write(t)"
       # To create all doctest files
     - PYPSA_PARAMS__OPTIMIZE__SOLVER_NAME=gurobi uv run pytest test/test_docs.py --test-docs
+      # Overlay pre-executed notebooks from the docs-notebooks branch (built daily by build-docs.yml)
+    - git fetch origin docs-notebooks || true
+    - git checkout origin/docs-notebooks -- ':(glob)docs/**/*.ipynb' || true
 
 mkdocs:
   configuration: mkdocs.yml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -382,10 +382,10 @@ plugins:
               - pypsa.plot.statistics.plotter.InteractiveStatisticPlotter.violin
               - pypsa.plot.statistics.plotter.InteractiveStatisticPlotter.histogram
 
-# This will rebuild and execute the notebooks during any modifications when running `mkdocs serve`
-# For local development, this can be commented out/ filtered to only include the notebooks of interest
+# Notebooks are pre-executed by the build-docs GitHub Action and stored on the
+# `docs-notebooks` branch. For local development set execute: true to run on serve.
 - mkdocs-jupyter:
-    execute: true
+    execute: false
     include: ["*.ipynb"]
     allow_errors: false
     include_source: true


### PR DESCRIPTION
The readthedocs build takes ~40 mins, is triggered on every commit on all branches, and still times out from time to time. Most of those ~40 mins is the execution of notebooks.

This PR:
- Takes the burden from readthedocs. readthedocs builds still happen on every commit, but no longer execute notebooks.
- Notebooks are executed on demand and every night, and their output is stored in `docs-notebooks`. The `master` branch stays clean. Every readthedocs build simply picks up the notebook docs build from docs-notebooks.

New notebooks are now not checked with execution in the PR, but only every night on master. This is similar to the other general test matrix changes we introduced recently and I think it's a trade off which is worth it