### PR TITLE
fix: apply tech_capacity_expansion_limit when not passing investment_period

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -45,6 +45,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fix a large memory spike when reading netCDF networks that store `Shape` geometries by reading variable-length string variables as object arrays via the `netCDF4` backend. (<!-- md:pr 1830 -->)
 
+- Fix a `tech_capacity_expansion_limit` global constraint being ignored when no `investment_period` was given. The limit was silently skipped and `n.optimize()` could return capacities above it without warning. (<!-- md:pr 1884 -->)
+
 
 ## [**v1.2.4**](https://github.com/PyPSA/PyPSA/releases/tag/v1.2.4) <small>27th June 2026</small> { id="v1.2.4" }
 

--- a/pypsa/optimization/global_constraints.py
+++ b/pypsa/optimization/global_constraints.py
@@ -48,7 +48,7 @@ def define_tech_capacity_expansion_limit(n: Network, sns: Sequence) -> None:
         raise NotImplementedError(msg)
 
     for (carrier, sense, period), glcs_group in glcs.groupby(
-        ["carrier_attribute", "sense", "investment_period"]
+        ["carrier_attribute", "sense", "investment_period"], dropna=False
     ):
         period = None if isnan(period) else int(period)
         sign = "=" if sense == "==" else sense

--- a/test/test_lopf_global_constraints.py
+++ b/test/test_lopf_global_constraints.py
@@ -193,6 +193,38 @@ def test_1449():
     assert status == "ok"
 
 
+def test_1884():
+    """
+    A tech_capacity_expansion_limit with no investment_period must still apply.
+    See https://github.com/PyPSA/PyPSA/issues/1884.
+    """
+    n = pypsa.Network(snapshots=range(2))
+    n.add("Bus", "b")
+    n.add("Carrier", ["wind", "gas"])
+    n.add("Load", "l", bus="b", p_set=100)
+    # cheap wind is capped at 50, so expensive gas must cover the rest
+    n.add(
+        "Generator",
+        ["wind", "gas"],
+        bus="b",
+        carrier=["wind", "gas"],
+        p_nom_extendable=True,
+        capital_cost=1,
+        marginal_cost=[1, 100],
+    )
+    n.add(
+        "GlobalConstraint",
+        "wind_limit",
+        type="tech_capacity_expansion_limit",
+        carrier_attribute="wind",
+        sense="<=",
+        constant=50,
+    )
+
+    n.optimize()
+    assert n.generators.p_nom_opt["wind"] == pytest.approx(50)
+
+
 def test_transmission_cost_limit_overnight_cost():
     n = pypsa.Network()
     n.snapshot_weightings.loc[:, :] = 8760.0

--- a/test/test_lopf_global_constraints.py
+++ b/test/test_lopf_global_constraints.py
@@ -222,7 +222,7 @@ def test_1884():
     )
 
     n.optimize()
-    assert n.generators.p_nom_opt["wind"] == pytest.approx(50)
+    assert n.c.generators.static.p_nom_opt["wind"] == pytest.approx(50)
 
 
 def test_transmission_cost_limit_overnight_cost():


### PR DESCRIPTION
Closes #1884 

## Changes proposed in this Pull Request
- Groupby removes by default all nan values, which is the default when not setting `investment_period` in `tech_capacity_expansion_limit` GlobalConstraint. Which means the constraint is then not set at all.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
