### PR TITLE
fix: skip linearized unit commitment tightening for extendable committables

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -31,6 +31,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Bug Fixes
 
+- Fix [`n.optimize(linearized_unit_commitment=True)`][pypsa.optimization.OptimizationAccessor.__call__] excluding the integer optimum for components that are both committable and extendable. The relaxation tightening constraints are no longer applied to extendable committables, where `p_nom` is an optimization variable. (<!-- md:pr 1885 -->)
 - Fix [`system_cost`][pypsa.statistics.StatisticsAccessor.system_cost] omitting fixed operation and maintenance costs (`fom_cost`), which are part of the optimization objective. It now returns the sum of `capex`, `fom` and `opex`, consistent with the objective function.
 - Fix [`n.optimize()`][pypsa.optimization.OptimizationAccessor.__call__] failing for stochastic networks (see [`n.set_scenarios()`][pypsa.Network.set_scenarios]) containing components with ramp limits. (<!-- md:pr 1873 -->)
 - Fix [`n.optimize()`][pypsa.optimization.OptimizationAccessor.__call__] failing with a `KeyError` when a network contains inactive components alongside committable, modular or ramp-limited ones. (<!-- md:pr 1870 -->)

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -643,6 +643,11 @@ def define_operational_constraints_for_committables(
             "constraints for these. This might result in a longer "
             "solving time."
         )
+
+    # tightening is only valid for fixed-capacity committables, since it uses
+    # nominal as a parameter (for extendables p_nom is an optimization variable)
+    cost_equal = cost_equal & com_i.isin(com_fix_i)
+
     if n._linearized_uc and cost_equal.any():
         # dispatch limit for partly start up/shut down for t-1
         p_ce = p.loc[:, cost_equal]

--- a/test/test_lopf_unit_commitment.py
+++ b/test/test_lopf_unit_commitment.py
@@ -423,6 +423,41 @@ def test_linearized_unit_commitment():
     assert round(n.objective / MILP_objective, 2) == 1
 
 
+def test_linearized_unit_commitment_committable_extendable():
+    # linearized relaxation must not exclude the integer optimum for a
+    # committable extendable generator
+    n = pypsa.Network()
+    n.set_snapshots([0, 1, 2, 3])
+    n.add("Bus", "hub")
+    n.add(
+        "Generator",
+        "flex",
+        bus="hub",
+        committable=True,
+        p_nom_extendable=True,
+        p_min_pu=0.4,
+        p_nom_max=100.0,
+        marginal_cost=40.0,
+        capital_cost=100.0,
+    )
+    n.add(
+        "Generator",
+        "peak",
+        bus="hub",
+        p_nom_extendable=True,
+        p_nom_max=100.0,
+        marginal_cost=120.0,
+        capital_cost=50.0,
+    )
+    n.add("Load", "demand", bus="hub", p_set=[75, 30, 75, 0])
+
+    n.optimize()
+    integer_objective = n.objective
+
+    n.optimize(linearized_unit_commitment=True)
+    assert n.objective == pytest.approx(integer_objective)
+
+
 def test_link_unit_commitment():
     n = pypsa.Network()
 


### PR DESCRIPTION
Closes #1885 

## Changes proposed in this Pull Request
For committable extendable components, `linearized_unit_commitment=True` builds its tightening constraints from the static ` p_nom`. Which is 0 for unbuilt components, and therefore sets p ≤ 0. Now tightening is skipped for extendable committables, where `p_nom` is an optimization variable.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
