### PR TITLE
Fix line loss post-processing with scenarios

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,7 +6,6 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Release Notes
 
-<!--
 ## Upcoming Release
 
 !!! info "Upcoming Release"
@@ -14,7 +13,10 @@ SPDX-License-Identifier: CC-BY-4.0
     The features listed below have not yet been released, but will be included in the
     next update! If you would like to use these features in the meantime, you will need
     to install the `master` branch, e.g. `pip install git+https://github.com/pypsa/pypsa`.
--->
+
+### Bug Fixes
+
+- Fix [`n.optimize(transmission_losses=True)`][pypsa.optimization.OptimizationAccessor.__call__] failing for stochastic networks (see [`n.set_scenarios()`][pypsa.Network.set_scenarios]) when assigning line losses during post-processing. (<!-- md:pr 1892 -->)
 
 ## [**v1.3.0**](https://github.com/PyPSA/PyPSA/releases/tag/v1.3.0) <small>19th August 2026</small> { id="v1.3.0" }
 

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -1268,7 +1268,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
 
         # line losses
         if "Line-loss" in n.model.variables:
-            losses = n.model["Line-loss"].solution.to_pandas()
+            losses = _from_xarray(n.model["Line-loss"].solution, n.c["Line"])
             n.c.lines.dynamic.p0 += losses / 2
             n.c.lines.dynamic.p1 += losses / 2
 

--- a/test/test_transmission_losses.py
+++ b/test/test_transmission_losses.py
@@ -70,7 +70,6 @@ def test_secant_input_variants(kwargs):
 def test_transmission_losses_with_scenarios(ac_dc_stochastic):
     n = ac_dc_stochastic
     n.lines["s_nom_max"] = 2000
-    n.transformers["s_nom_max"] = 2000
 
     status, _ = n.optimize(transmission_losses=True)
 

--- a/test/test_transmission_losses.py
+++ b/test/test_transmission_losses.py
@@ -67,6 +67,19 @@ def test_secant_input_variants(kwargs):
     assert status == "ok"
 
 
+def test_transmission_losses_with_scenarios(ac_dc_stochastic):
+    n = ac_dc_stochastic
+    n.lines["s_nom_max"] = 2000
+    n.transformers["s_nom_max"] = 2000
+
+    status, _ = n.optimize(transmission_losses=True)
+
+    assert status == "ok"
+    assert not n.lines_t.p0.isna().any().any()
+    assert not n.lines_t.p1.isna().any().any()
+    assert n.lines_t.p0.columns.equals(n.lines_t.p1.columns)
+
+
 def test_invalid_params_raise():
     n = pypsa.examples.ac_dc_meshed()
     n.lines["s_nom_max"] = 2000


### PR DESCRIPTION
Use the existing scenario-aware xarray conversion when assigning line losses during post-processing. This prevents stochastic optimizations with transmission losses from failing on a three-dimensional solution.

Adds regression coverage for successful optimization and populated line flows.

Tests: `pytest test/test_stochastic.py test/test_lopf_losses.py test/test_transmission_losses.py`

Fixes #1819