### PR TITLE
fix: bounds for fixed modular committables

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Bug Fixes
 
+- Fix fixed-capacity modular committable components receiving contradictory operating bounds based on both nominal capacity and module size. (<!-- md:pr XXXX -->)
 - Fix [`n.optimize(transmission_losses=True)`][pypsa.optimization.OptimizationAccessor.__call__] failing for stochastic networks (see [`n.set_scenarios()`][pypsa.Network.set_scenarios]) when assigning line losses during post-processing. (<!-- md:pr 1892 -->)
 
 ## [**v1.3.0**](https://github.com/PyPSA/PyPSA/releases/tag/v1.3.0) <small>19th August 2026</small> { id="v1.3.0" }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,7 +16,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Bug Fixes
 
-- Fix fixed-capacity modular committable components receiving contradictory operating bounds based on both nominal capacity and module size. (<!-- md:pr XXXX -->)
+- Fix infeasibility for fixed-capacity modular committable components, which were given operating bounds based on both nominal capacity and module size. (<!-- md:pr 1901 -->)
 - Fix [`n.optimize(transmission_losses=True)`][pypsa.optimization.OptimizationAccessor.__call__] failing for stochastic networks (see [`n.set_scenarios()`][pypsa.Network.set_scenarios]) when assigning line losses during post-processing. (<!-- md:pr 1892 -->)
 
 ## [**v1.3.0**](https://github.com/PyPSA/PyPSA/releases/tag/v1.3.0) <small>19th August 2026</small> { id="v1.3.0" }

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -297,7 +297,7 @@ def define_operational_constraints_for_committables(
 
     ext_i = c.extendables.intersection(c.active_assets)
     com_ext_i = com_i.intersection(ext_i).difference(c.modulars)
-    com_fix_i = com_i.difference(ext_i)
+    com_fix_i = com_i.difference(ext_i).difference(c.modulars)
 
     # parameters
     nominal = c.da[c._operational_attrs["nom"]].sel(name=com_i)

--- a/test/test_lopf_modularity.py
+++ b/test/test_lopf_modularity.py
@@ -97,3 +97,26 @@ def test_modular_committable_with_ramp_limits():
         shutdown = max(0, u_prev - u_cur)
         assert delta <= ru * p_nom_mod * u_prev + 1.0 * p_nom_mod * startup + 1e-6
         assert delta >= -rd * p_nom_mod * u_cur - 1.0 * p_nom_mod * shutdown - 1e-6
+
+
+def test_modular_fixed_committable_dispatch():
+    """Regression test for https://github.com/PyPSA/PyPSA/issues/1899."""
+    n = pypsa.Network(snapshots=range(2))
+    n.add("Bus", "bus")
+    n.add("Load", "load", bus="bus", p_set=150)
+    n.add(
+        "Generator",
+        "modgen",
+        bus="bus",
+        p_nom=300,
+        p_nom_mod=100,
+        committable=True,
+        p_min_pu=0.4,
+        marginal_cost=1,
+    )
+
+    status, _ = n.optimize(solver_name="highs")
+
+    assert status == "ok"
+    assert (n.c.generators.dynamic.p["modgen"] == 150).all()
+    assert "Generator-com-p-lower" not in n.model.constraints


### PR DESCRIPTION
Closes #1899

## Changes proposed in this Pull Request
Fix infeasibility for fixed-capacity modular committable components, which were given operating bounds based on both nominal capacity and module size

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `docs/release-notes.md` of the upcoming release is included.
- [x] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [x] I consent to the release of this PR's code under the MIT license.
