### PR TITLE
Fix purchasable model, edge cases and tests (review of #1900)

### DIFF
--- a/docs/user-guide/optimization/capacity-limits.md
+++ b/docs/user-guide/optimization/capacity-limits.md
@@ -285,7 +285,7 @@ It carries neither a snapshot nor a scenario dimension, so an asset is either bo
 
 ### Capacity Bound
 
-For a purchasable extendable asset with a **continuous** capacity, the capacity is bounded above by the purchase decision, so that nothing can be built unless the asset is bought:
+For a purchasable extendable asset, the capacity is bounded above by the purchase decision, so that nothing can be built unless the asset is bought:
 
 | Constraint | Dual Variable | Name |
 |-------------------|------------------|------------------|
@@ -301,24 +301,16 @@ Symmetrically, the lower capacity bound is scaled by the purchase decision, so t
 
 | Constraint | Dual Variable | Name |
 |-------------------|------------------|------------------|
-| $G_{n,s} \geq \underline{G}_{n,s} \cdot y_{n,s}$ | `n.generators.mu_lower` | `Generator-ext-p_nom-lower` |
+| $G_{n,s} \geq \underline{G}_{n,s} \cdot y_{n,s}$ | N/A | `Generator-ext-p_nom-lower-purchased` |
 
 This replaces the plain lower bound described in [Upper and Lower Bounds](#upper-and-lower-bounds) and is set in `define_nominal_constraints_for_extendables()`.
 All other purchase constraints are set in `define_purchase_constraints()`.
 
 ### Modular Components
 
-[Modular](#modularity-constraints) assets are bounded through their module count instead.
-The number of installed modules is tied to the purchase decision with a big-M constraint, and the modularity constraint
-$G_{n,s} = G^{\textrm{mod}}_{n,s} \cdot \tilde{G}_{n,s}$ then forces the capacity to zero whenever the asset is not bought:
-
-| Constraint | Dual Variable | Name |
-|-------------------|------------------|------------------|
-| $G^{\textrm{mod}}_{n,s} \leq M \cdot y_{n,s}$ | N/A | `Generator-p_nom_modularity_purchased_bigM` |
-| $F^{\textrm{mod}}_{l} \leq M \cdot y_{l}$ | N/A | `Link-p_nom_modularity_purchased_bigM` |
-| $R^{\textrm{mod}}_{m} \leq M \cdot y_{m}$ | N/A | `Process-p_nom_modularity_purchased_bigM` |
-| $P^{\textrm{mod}}_{l} \leq M \cdot y_{l}$ | N/A | `Line-s_nom_modularity_purchased_bigM` |
-| $E^{\textrm{mod}}_{n,s} \leq M \cdot y_{n,s}$ | N/A | `Store-e_nom_modularity_purchased_bigM` |
+[Modular](#modularity-constraints) assets use the same capacity bound as continuous assets.
+The capacity is bounded above by the purchase decision through `Generator-p_nom_cap_binary`, and the modularity constraint
+$G_{n,s} = G^{\textrm{mod}}_{n,s} \cdot \tilde{G}_{n,s}$ then forces the module count to zero whenever the asset is not bought.
 
 ### Purchase and Unit Commitment
 
@@ -365,9 +357,8 @@ Doing so raises a `ValueError`.
 !!! warning "Current limitations"
 
     - `purchasable` is only supported for extendable components.
-      Setting it on a component with a fixed capacity raises a `KeyError` while building the model.
-    - `StorageUnit` purchase constraints raise a `ValueError` when the model is built.
-    - Purchasable components combined with `n.set_scenarios()` fail when the capacity lower bound is built.
+      Setting it on a component with a fixed capacity raises a `ValueError` before the model is built.
+    - A purchasable component that is both committable and maintainable must be modular; the non-modular combination raises a `ValueError`.
     - `Transformer` has no `purchasable` attribute.
 
 ??? note "Mapping of symbols to component attributes"

--- a/docs/user-guide/v1-guide.md
+++ b/docs/user-guide/v1-guide.md
@@ -88,16 +88,16 @@ PyPSA [`Components`][pypsa.Components] are a new intermediate layer between the 
 ``` py
 >>> n = pypsa.examples.ac_dc_meshed()
 >>> n.generators
-                        bus control  ... p_nom_opt  capital_cost_piecewise_opt
+                        bus control  ... capital_cost_piecewise_opt  purchased_opt
 name                                 ...
-Manchester Wind  Manchester      PQ  ...       0.0                         0.0
-Manchester Gas   Manchester      PQ  ...       0.0                         0.0
-Norway Wind          Norway      PQ  ...       0.0                         0.0
-Norway Gas           Norway      PQ  ...       0.0                         0.0
-Frankfurt Wind    Frankfurt      PQ  ...       0.0                         0.0
-Frankfurt Gas     Frankfurt      PQ  ...       0.0                         0.0
+Manchester Wind  Manchester      PQ  ...                        0.0            NaN
+Manchester Gas   Manchester      PQ  ...                        0.0            NaN
+Norway Wind          Norway      PQ  ...                        0.0            NaN
+Norway Gas           Norway      PQ  ...                        0.0            NaN
+Frankfurt Wind    Frankfurt      PQ  ...                        0.0            NaN
+Frankfurt Gas     Frankfurt      PQ  ...                        0.0            NaN
 <BLANKLINE>
-[6 rows x 47 columns]
+[6 rows x 51 columns]
 
 # Opt-in to new components API
 >>> pypsa.options.api.new_components_api = True
@@ -111,16 +111,16 @@ Components: 6
 
 # Static data and more is still available
 >>> n.generators.static
-                        bus control  ... p_nom_opt  capital_cost_piecewise_opt
+                        bus control  ... capital_cost_piecewise_opt  purchased_opt
 name                                 ...
-Manchester Wind  Manchester      PQ  ...       0.0                         0.0
-Manchester Gas   Manchester      PQ  ...       0.0                         0.0
-Norway Wind          Norway      PQ  ...       0.0                         0.0
-Norway Gas           Norway      PQ  ...       0.0                         0.0
-Frankfurt Wind    Frankfurt      PQ  ...       0.0                         0.0
-Frankfurt Gas     Frankfurt      PQ  ...       0.0                         0.0
+Manchester Wind  Manchester      PQ  ...                        0.0            NaN
+Manchester Gas   Manchester      PQ  ...                        0.0            NaN
+Norway Wind          Norway      PQ  ...                        0.0            NaN
+Norway Gas           Norway      PQ  ...                        0.0            NaN
+Frankfurt Wind    Frankfurt      PQ  ...                        0.0            NaN
+Frankfurt Gas     Frankfurt      PQ  ...                        0.0            NaN
 <BLANKLINE>
-[6 rows x 47 columns]
+[6 rows x 51 columns]
 
 >>> pypsa.options.api.new_components_api = False
 ```

--- a/pypsa/collection.py
+++ b/pypsa/collection.py
@@ -76,22 +76,22 @@ class NetworkCollection:
     Access component data across all networks:
 
     >>> nc.generators  # doctest: +ELLIPSIS
-                                                       bus  ... capital_cost_piecewise_opt
+                                                       bus  ... purchased_opt
     network                    name                         ...
-    AC-DC-Meshed               Manchester Wind  Manchester  ...                        0.0
-                               Manchester Gas   Manchester  ...                        0.0
-                               Norway Wind          Norway  ...                        0.0
-                               Norway Gas           Norway  ...                        0.0
-                               Frankfurt Wind    Frankfurt  ...                        0.0
-                               Frankfurt Gas     Frankfurt  ...                        0.0
-    AC-DC-Meshed-Shuffled-Load Manchester Wind  Manchester  ...                        0.0
-                               Manchester Gas   Manchester  ...                        0.0
-                               Norway Wind          Norway  ...                        0.0
-                               Norway Gas           Norway  ...                        0.0
-                               Frankfurt Wind    Frankfurt  ...                        0.0
-                               Frankfurt Gas     Frankfurt  ...                        0.0
+    AC-DC-Meshed               Manchester Wind  Manchester  ...           NaN
+                               Manchester Gas   Manchester  ...           NaN
+                               Norway Wind          Norway  ...           NaN
+                               Norway Gas           Norway  ...           NaN
+                               Frankfurt Wind    Frankfurt  ...           NaN
+                               Frankfurt Gas     Frankfurt  ...           NaN
+    AC-DC-Meshed-Shuffled-Load Manchester Wind  Manchester  ...           NaN
+                               Manchester Gas   Manchester  ...           NaN
+                               Norway Wind          Norway  ...           NaN
+                               Norway Gas           Norway  ...           NaN
+                               Frankfurt Wind    Frankfurt  ...           NaN
+                               Frankfurt Gas     Frankfurt  ...           NaN
     <BLANKLINE>
-    [12 rows x 47 columns]
+    [12 rows x 51 columns]
 
 
     >>> nc.statistics.energy_balance()  # doctest: +ELLIPSIS

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -1072,6 +1072,43 @@ class Components(
 
         return idx
 
+    @property
+    def active_purchasables(self) -> pd.Index:
+        """Get the index of purchasable elements considered in the optimization.
+
+        These are the elements that are purchasable, extendable and active, i.e.
+        the ones for which a purchase decision variable is created.
+
+        <!-- md:badge-version v1.1.0 -->
+
+        Returns
+        -------
+        pd.Index
+            Single-level index of active, extendable, purchasable elements.
+
+        """
+        purchasables = self.purchasables
+        if purchasables.empty:
+            return purchasables
+        return purchasables.intersection(self.extendables).intersection(
+            self.active_assets
+        )
+
+    def _resolve_big_m_default(self, committable_big_m: float | None) -> float:
+        """Resolve the scalar big-M fallback for committable/purchasable bounds."""
+        big_m_default = committable_big_m
+        if big_m_default is None and self.n is not None:
+            big_m_default = self.n._committable_big_m
+        if big_m_default is None:
+            return self._infer_committable_big_m_scale()
+        if not np.isfinite(big_m_default):
+            msg = f"committable_big_m must be finite, got {big_m_default}."
+            raise ValueError(msg)
+        if big_m_default <= 0:
+            msg = f"committable_big_m must be positive, got {big_m_default}."
+            raise ValueError(msg)
+        return big_m_default
+
     def _infer_committable_big_m_scale(self) -> float:
         """Infer a reasonable big-M scale from network and component data."""
         candidates: list[float] = []
@@ -1127,18 +1164,7 @@ class Components(
         if "snapshot" in max_pu_values.dims:
             max_pu_values = max_pu_values.max("snapshot")
 
-        big_m_default = committable_big_m
-        if big_m_default is None and self.n is not None:
-            big_m_default = self.n._committable_big_m
-        if big_m_default is None:
-            big_m_default = self._infer_committable_big_m_scale()
-        else:
-            if not np.isfinite(big_m_default):
-                msg = f"committable_big_m must be finite, got {big_m_default}."
-                raise ValueError(msg)
-            if big_m_default <= 0:
-                msg = f"committable_big_m must be positive, got {big_m_default}."
-                raise ValueError(msg)
+        big_m_default = self._resolve_big_m_default(committable_big_m)
 
         fallback_values = big_m_default * max_pu_values.fillna(1)
         return xarray.where(
@@ -1194,14 +1220,14 @@ class Components(
         )
 
     @property
-    def unit_cost(self) -> xarray.DataArray:
+    def periodized_unit_cost(self) -> xarray.DataArray:
         """Calculate periodized unit investment cost from component attributes as xarray DataArray.
 
         <!-- md:badge-version v1.1.0 -->
 
         See Also
         --------
-        `pypsa.costs.unit_cost`
+        `pypsa.costs.periodized_cost`
 
         """
         static = self.static

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -1289,6 +1289,34 @@ class Components(
         lifetime = static["lifetime"]
         return annuity(discount_rate, lifetime)
 
+    def _overnight_from_annuitized(
+        self, annuitized: pd.Series, overnight: pd.Series, label: str
+    ) -> pd.Series:
+        """Back-calculate overnight cost from an annuitized cost where missing."""
+        static = self.static
+        has_overnight = overnight.notna()
+
+        needs_back_calc = ~has_overnight & (annuitized != 0)
+        discount_rate = static["discount_rate"]
+        lifetime = static["lifetime"]
+        missing_params = needs_back_calc & (discount_rate.isna() | lifetime.isna())
+
+        if missing_params.any():
+            bad = static.index[missing_params].tolist()
+            msg = (
+                f"Cannot back-calculate {label} for {bad}: "
+                "both 'discount_rate' and 'lifetime' must be provided "
+                f"when '{label}' is not set."
+            )
+            raise ValueError(msg)
+
+        ann_factor = self.annuity
+        nyears = self.nyears
+        nyears_scalar = nyears.mean() if isinstance(nyears, pd.Series) else nyears
+        back_calculated = annuitized / (ann_factor * nyears_scalar)
+
+        return overnight.where(has_overnight, back_calculated)
+
     @property
     def overnight_cost(self) -> pd.Series:
         """Calculate overnight cost from component attributes.
@@ -1322,30 +1350,35 @@ class Components(
 
         """
         static = self.static
-        overnight = static["overnight_cost"]
-        capital = static["capital_cost"]
-        has_overnight = overnight.notna()
+        return self._overnight_from_annuitized(
+            static["capital_cost"], static["overnight_cost"], "overnight_cost"
+        )
 
-        needs_back_calc = ~has_overnight & (capital != 0)
-        discount_rate = static["discount_rate"]
-        lifetime = static["lifetime"]
-        missing_params = needs_back_calc & (discount_rate.isna() | lifetime.isna())
+    @property
+    def overnight_unit_cost(self) -> pd.Series:
+        """Calculate overnight unit investment cost from component attributes.
 
-        if missing_params.any():
-            bad = static.index[missing_params].tolist()
-            msg = (
-                f"Cannot back-calculate overnight_cost for {bad}: "
-                "both 'discount_rate' and 'lifetime' must be provided "
-                "when 'overnight_cost' is not set."
-            )
-            raise ValueError(msg)
+        <!-- md:badge-version v1.1.0 -->
 
-        ann_factor = self.annuity
-        nyears = self.nyears
-        nyears_scalar = nyears.mean() if isinstance(nyears, pd.Series) else nyears
-        back_calculated = capital / (ann_factor * nyears_scalar)
+        If unit_cost_overnight column is provided (not NaN), returns it directly.
+        Otherwise, converts periodized unit_cost back to overnight cost using
+        the formula: unit_cost_overnight = unit_cost / (annuity_factor × nyears).
 
-        return overnight.where(has_overnight, back_calculated)
+        Returns
+        -------
+        pd.Series
+            Overnight (upfront) unit investment cost for the purchase decision.
+
+        See Also
+        --------
+        `periodized_unit_cost` : Periodized unit investment cost for the modeled horizon.
+        `overnight_cost` : Overnight cost per unit of capacity.
+
+        """
+        static = self.static
+        return self._overnight_from_annuitized(
+            static["unit_cost"], static["unit_cost_overnight"], "unit_cost_overnight"
+        )
 
 
 class SubNetworkComponents:

--- a/pypsa/components/components.py
+++ b/pypsa/components/components.py
@@ -759,7 +759,7 @@ class Components(
         Coordinates:
           * name                        (name) object 48B 'Manchester Wind' ... 'Fran...
           * snapshot                    (snapshot) datetime64[ns] 80B 2015-01-01 ... ...
-        Data variables: (12/48)
+        Data variables: (12/52)
             bus                         (name) object 48B 'Manchester' ... 'Frankfurt'
             control                     (name) object 48B 'Slack' 'PQ' ... 'Slack' 'PQ'
             type                        (name) object 48B '' '' '' '' '' ''
@@ -767,11 +767,11 @@ class Components(
             p_nom_mod                   (name) float64 48B 0.0 0.0 0.0 0.0 0.0 0.0
             p_nom_extendable            (name) bool 6B True True True True True True
             ...                          ...
-            ramp_limit_start_up         (name) float64 48B nan nan nan nan nan nan
             ramp_limit_shut_down        (name) float64 48B nan nan nan nan nan nan
             weight                      (name) float64 48B 1.0 1.0 1.0 1.0 1.0 1.0
             p_nom_opt                   (name) float64 48B 4.091e+03 0.0 ... 982.0
             capital_cost_piecewise_opt  (name) float64 48B 0.0 0.0 0.0 0.0 0.0 0.0
+            purchased_opt               (name) float64 48B nan nan nan nan nan nan
             p                           (snapshot, name) float64 480B 742.0 ... 483.2
 
         """

--- a/pypsa/consistency.py
+++ b/pypsa/consistency.py
@@ -585,6 +585,20 @@ def check_cost_consistency(component: Components, strict: bool = False) -> None:
 
     """
     static = component.static
+    if {"unit_cost", "unit_cost_overnight"}.issubset(static.columns):
+        both_unit = (static["unit_cost_overnight"].notna()) & (static["unit_cost"] != 0)
+        if both_unit.any():
+            assets = static.index[both_unit].tolist()
+            _log_or_raise(
+                strict,
+                "Component %s has assets with both 'unit_cost_overnight' and "
+                "'unit_cost' set: %s. When 'unit_cost_overnight' is provided, it takes "
+                "precedence and 'unit_cost' is ignored. Consider setting unit_cost=0 "
+                "for these assets.",
+                component.name,
+                ", ".join(assets[:5]) + ("..." if len(assets) > 5 else ""),
+            )
+
     if not {"capital_cost", "overnight_cost"}.issubset(static.columns):
         return
     has_overnight = static["overnight_cost"].notna()
@@ -1184,6 +1198,7 @@ def check_scenario_invariant_attributes(n: NetworkType, strict: bool = False) ->
         "s_nom_mod",
         "e_nom_mod",
         "committable",  # changes mathematical problem
+        "purchasable",  # changes mathematical problem
         "sign",
         "carrier",
         "weight",
@@ -1476,6 +1491,36 @@ def check_big_m_exceeded(n: Network, strict: bool = False) -> None:
                 ", ".join(details),
             )
 
+    for c in n.components:
+        purchase_i = c.active_purchasables
+        if purchase_i.empty:
+            continue
+
+        nom_attr = nominal_attrs[c.name]
+        nom_max = c.da[f"{nom_attr}_max"].sel(name=purchase_i)
+        unbounded = ~(np.isfinite(nom_max) & (nom_max > 0))
+        if not unbounded.any().item():
+            continue
+
+        big_m = c._resolve_big_m_default(n._committable_big_m)
+        nom_opt = c.da[f"{nom_attr}_opt"].sel(name=purchase_i)
+        exceeded = (nom_opt >= big_m - 1e-6) & unbounded
+
+        reduce_dims = [dim for dim in exceeded.dims if dim != "name"]
+        if reduce_dims:
+            exceeded = exceeded.any(dim=reduce_dims)
+        names = exceeded["name"].values[exceeded.values]
+        if len(names):
+            _log_or_raise(
+                strict,
+                "Optimized capacities reach the big-M fallback bound for purchasable %s "
+                "with unbounded %s_max: %s. Provide a finite %s_max to avoid a silent cap.",
+                c.name.lower(),
+                nom_attr,
+                ", ".join(str(name) for name in names),
+                nom_attr,
+            )
+
 
 def check_maintenance_attributes(
     n: NetworkType, component: Components, strict: bool = False
@@ -1558,6 +1603,54 @@ def check_maintenance_attributes(
             component.list_name,
             bad_max.index,
         )
+
+
+def check_purchasable_consistency(n: Network) -> None:
+    """Check that purchasable components use a supported feature combination.
+
+    Purchase decisions require an extendable capacity and, when combined with unit
+    commitment, cannot additionally be maintainable unless the asset is modular.
+    Both unsupported combinations would otherwise fail with an opaque error while
+    building the optimization model.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        The network to check.
+
+    See Also
+    --------
+    [pypsa.Network.consistency_check][]
+
+    """
+    for c in n.components:
+        purchasables = c.purchasables
+        if purchasables.empty:
+            continue
+
+        non_extendable = purchasables.difference(c.extendables)
+        if not non_extendable.empty:
+            names = ", ".join(non_extendable[:5])
+            msg = (
+                f"Component {c.name} has purchasable assets that are not extendable: "
+                f"{names}. `purchasable` is only supported for extendable components."
+            )
+            raise ValueError(msg)
+
+        maint_com = (
+            purchasables.intersection(c.committables)
+            .intersection(c.maintainables)
+            .difference(c.modulars)
+        )
+        if not maint_com.empty:
+            names = ", ".join(maint_com[:5])
+            msg = (
+                f"Component {c.name} has purchasable committable assets that are also "
+                f"maintainable but not modular: {names}. This combination is not "
+                f"supported; set a module size (e.g. p_nom_mod > 0) or drop the "
+                f"maintenance attributes."
+            )
+            raise ValueError(msg)
 
 
 def check_no_modular_purchasable_committables(n: Network) -> None:

--- a/pypsa/costs.py
+++ b/pypsa/costs.py
@@ -199,4 +199,5 @@ def periodized_cost(
         fom_cost = fom_cost.fillna(0.0)
     elif np.isnan(fom_cost):
         fom_cost = 0.0
+
     return base + fom_cost

--- a/pypsa/network/components.py
+++ b/pypsa/network/components.py
@@ -105,16 +105,16 @@ class NetworkComponentsMixin(_NetworkABC):
 
         Which is the same reference when accessing the component directly:
         >>> n.generators # doctest: +ELLIPSIS
-                                bus control  ...    p_nom_opt  capital_cost_piecewise_opt
+                                bus control  ... capital_cost_piecewise_opt  purchased_opt
         name                                 ...
-        Manchester Wind  Manchester   Slack  ...  4090.809778                         0.0
-        Manchester Gas   Manchester      PQ  ...     0.000000                         0.0
-        Norway Wind          Norway      PQ  ...  1533.599858                         0.0
-        Norway Gas           Norway      PQ  ...     0.000000                         0.0
-        Frankfurt Wind    Frankfurt   Slack  ...  1667.724420                         0.0
-        Frankfurt Gas     Frankfurt      PQ  ...   982.034483                         0.0
+        Manchester Wind  Manchester   Slack  ...                        0.0            NaN
+        Manchester Gas   Manchester      PQ  ...                        0.0            NaN
+        Norway Wind          Norway      PQ  ...                        0.0            NaN
+        Norway Gas           Norway      PQ  ...                        0.0            NaN
+        Frankfurt Wind    Frankfurt   Slack  ...                        0.0            NaN
+        Frankfurt Gas     Frankfurt      PQ  ...                        0.0            NaN
         <BLANKLINE>
-        [6 rows x 47 columns]
+        [6 rows x 51 columns]
         >>> n.generators is n.components.generators.static
         True
 

--- a/pypsa/networks.py
+++ b/pypsa/networks.py
@@ -1120,7 +1120,7 @@ class Network(
                   5       True  0.0   0.0  ...  0.238800  0.000002  0.000002
                   6       True  0.0   0.0  ...  0.400000  0.000003  0.000003
         <BLANKLINE>
-        [7 rows x 44 columns]
+        [7 rows x 48 columns]
 
         """
         comps = sorted(
@@ -1153,14 +1153,14 @@ class Network(
         Examples
         --------
         >>> n.controllable_branches() # doctest: +ELLIPSIS
-                                     active  build_year  ... type up_time_before
-        component name                                   ...
-        Link      Norwich Converter    True           0  ...                   1
-                  Norway Converter     True           0  ...                   1
-                  Bremen Converter     True           0  ...                   1
-                  DC link              True           0  ...                   1
+                                     active  ...  up_time_before
+        component name                       ...
+        Link      Norwich Converter    True  ...               1
+                  Norway Converter     True  ...               1
+                  Bremen Converter     True  ...               1
+                  DC link              True  ...               1
         <BLANKLINE>
-        [4 rows x 52 columns]
+        [4 rows x 56 columns]
 
         See Also
         --------

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -297,7 +297,9 @@ def define_operational_constraints_for_committables(
 
     ext_i = c.extendables.intersection(c.active_assets)
     com_ext_i = (
-        com_i.intersection(ext_i).difference(c.modulars).difference(c.purchasables)
+        com_i.intersection(ext_i)
+        .difference(c.modulars)
+        .difference(c.active_purchasables)
     )
     com_fix_i = com_i.difference(ext_i).difference(c.modulars)
 
@@ -549,60 +551,18 @@ def define_operational_constraints_for_committables(
             mask=active_mod,
         )
 
-    # Operational constraints for purchasable committable components
-    # For purchasable components, use p_nom_available instead of p_nom * status
-    com_pur_i = com_i.intersection(c.purchasables).difference(c.modulars)
+    com_pur_i = com_i.intersection(c.active_purchasables).difference(c.modulars)
     if not com_pur_i.empty:
         p_pur = p.sel(name=com_pur_i)
-        nominal_pur = nominal.name
-        available_cap = n.model[f"{c.name}-available_{nominal_pur}"].sel(name=com_pur_i)
+        nom_attr = c._operational_attrs["nom"]
+        available_cap = n.model[f"{c.name}-available_{nom_attr}"].sel(name=com_pur_i)
         active_pur = active.sel(name=com_pur_i)
 
-        # Get min/max_pu for modular components
         min_pu_pur = min_pu.sel(name=com_pur_i)
         max_pu_pur = max_pu.sel(name=com_pur_i)
 
-        # Calculate bounds using module size
-        lower_p_pur = min_pu_pur * available_cap
-        upper_p_pur = max_pu_pur * available_cap
-
-        lhs_lower_pur = p_pur - lower_p_pur
-        lhs_upper_pur = p_pur - upper_p_pur
-
-        maint_pur_i = com_pur_i.intersection(maint_i)
-        if not maint_pur_i.empty:
-            nom_max = c.da[f"{c._operational_attrs['nom']}_max"].sel(name=maint_pur_i)
-            modules_max = nom_max / nominal_mod.sel(name=maint_pur_i)
-            alpha = c.da.maintenance_pu.sel(name=maint_pur_i)
-            u = status.sel(name=maint_pur_i)
-            m = n.model[f"{c.name}-maintenance"].sel(name=maint_pur_i)
-            w = n.model[f"{c.name}-maintenance_status"].sel(name=maint_pur_i)
-            active_maint = active.sel(name=maint_pur_i)
-
-            n.model.add_constraints(
-                w - u <= 0,
-                name=f"{c.name}-maint-purchase-le-status",
-                mask=active_maint,
-            )
-            n.model.add_constraints(
-                w - modules_max * m <= 0,
-                name=f"{c.name}-maint-purchase-le-maint",
-                mask=active_maint,
-            )
-            n.model.add_constraints(
-                w - u - modules_max * m >= -modules_max,
-                name=f"{c.name}-maint-purchase-lb",
-                mask=active_maint,
-            )
-
-            maint_lower = (lower_p_pur.sel(name=maint_pur_i) * alpha * w).reindex(
-                name=com_pur_i, fill_value=0
-            )
-            maint_upper = (upper_p_pur.sel(name=maint_pur_i) * alpha * w).reindex(
-                name=com_pur_i, fill_value=0
-            )
-            lhs_lower_pur = lhs_lower_pur + maint_lower
-            lhs_upper_pur = lhs_upper_pur + maint_upper
+        lhs_lower_pur = p_pur - min_pu_pur * available_cap
+        lhs_upper_pur = p_pur - max_pu_pur * available_cap
 
         n.model.add_constraints(
             lhs_lower_pur,
@@ -957,14 +917,21 @@ def define_nominal_constraints_for_extendables(
     lower = c.da[attr + "_min"].sel(name=ext_i)
     upper = c.da[attr + "_max"].sel(name=ext_i)
 
-    if not c.purchasables.intersection(ext_i).empty:
-        lower = (
-            n.model[f"{c.name}-purchased"]
-            .mul(lower)
-            .reindex(lower.coords)
-            .fillna(lower)
+    purchase_i = c.active_purchasables
+    plain_i = ext_i.difference(purchase_i)
+    if not plain_i.empty:
+        n.model.add_constraints(
+            capacity.sel(name=plain_i),
+            ">=",
+            lower.sel(name=plain_i),
+            name=f"{c.name}-ext-{attr}-lower",
         )
-    n.model.add_constraints(capacity, ">=", lower, name=f"{c.name}-ext-{attr}-lower")
+    if not purchase_i.empty:
+        purchased = n.model[f"{c.name}-purchased"].sel(name=purchase_i)
+        lhs = capacity.sel(name=purchase_i) - purchased * lower.sel(name=purchase_i)
+        n.model.add_constraints(
+            lhs, ">=", 0, name=f"{c.name}-ext-{attr}-lower-purchased"
+        )
 
     is_finite = upper != inf
     if is_finite.any():
@@ -1799,10 +1766,11 @@ def define_purchase_constraints(n: Network, component: str, attr: str) -> None:
 
     For each purchasable component, the constraint enforces:
 
-    capacity = 0 if purchase is 0, otherwise capacity = n_modules * module_size (if modular) or capacity <= max_capacity (if non-modular).
+    capacity = 0 if purchase is 0, otherwise capacity <= max_capacity. For modular
+    assets the separate modularity equality then forces the module count to zero
+    whenever the asset is not bought.
 
-    Applies to Generator (p_nom), Line (s_nom), Transformer (s_nom), Link (p_nom),
-    Store (e_nom), StorageUnit (p_nom).
+    Applies to Generator (p_nom), Line (s_nom), Link (p_nom), Store (e_nom).
 
     Parameters
     ----------
@@ -1825,75 +1793,46 @@ def define_purchase_constraints(n: Network, component: str, attr: str) -> None:
     m = n.model
     c = as_components(n, component)
 
-    # Get components that are both extendable and purchasable
-    purchase_i = c.purchasables
-    # Get components that are both extendable and modular
-    mod_i = c.extendables.intersection(c.modulars)
-
-    # Unique component names for purchasable components (in absence of c.purchasables helper)
-    if isinstance(purchase_i, pd.MultiIndex):
-        purchase_i = purchase_i.unique(level="name")
-
+    purchase_i = c.active_purchasables
     if purchase_i.empty:
         return
 
     purchased = m[f"{c.name}-purchased"]
-    purchased_modular = purchase_i.intersection(mod_i)
-    purchased_continuous = purchase_i.difference(mod_i)
-    purchased_continuous_com = purchase_i.difference(mod_i).intersection(c.committables)
 
-    M = c.get_committable_big_m_values(
-        names=purchase_i, committable_big_m=n._committable_big_m
+    nom_max = c.da[attr + "_max"].sel(name=purchase_i)
+    big_m = c._resolve_big_m_default(n._committable_big_m)
+    cap_max = nom_max.where(np.isfinite(nom_max) & (nom_max > 0), big_m)
+
+    cap_var = m[f"{c.name}-{attr}"].sel(name=purchase_i)
+    m.add_constraints(
+        cap_var <= cap_max * purchased.sel(name=purchase_i),
+        name=f"{c.name}-{attr}_cap_binary",
     )
-    # If the unit is modular, only allow non-zero modules if unit is purchased
-    if not purchased_modular.empty:
-        modularity = m[f"{c.name}-n_mod"].sel(name=purchased_modular)
-        purchased_mod = purchased.sel(name=purchased_modular)
 
-        n.model.add_constraints(
-            modularity <= purchased_mod * M.sel(name=purchased_modular),
-            name=f"{c.name}-{attr}_modularity_purchased_bigM",
-            mask=None,
-        )
-    if not purchased_continuous.empty:
-        cap_max = c.da[attr + "_max"]
-        cap_max = (
-            cap_max.where(~isinf(cap_max)).fillna(M).sel(name=purchased_continuous)
-        )
-        cap_var = n.model[f"{c.name}-{attr}"].sel(name=purchased_continuous)
-        purchased_con = purchased.sel(name=purchased_continuous)
+    com_i = purchase_i.difference(c.modulars).intersection(c.committables)
+    if com_i.empty:
+        return
 
-        n.model.add_constraints(
-            cap_var <= cap_max * purchased_con,
-            name=f"{c.name}-{attr}_cap_binary",
-            mask=None,
-        )
-        if not purchased_continuous_com.empty:
-            purchased_com = purchased.sel(name=purchased_continuous_com)
-            available_cap = m[f"{c.name}-available_{attr}"].sel(
-                name=purchased_continuous_com
-            )
-            status = m[f"{c.name}-status"].sel(name=purchased_continuous_com)
-            n.model.add_constraints(
-                status <= purchased_com,
-                name=f"{c.name}-{attr}_status_purchased_limit",
-                mask=None,
-            )
-            n.model.add_constraints(
-                available_cap <= cap_var,
-                name=f"{c.name}-{attr}_available_continuous",
-                mask=None,
-            )
-            n.model.add_constraints(
-                available_cap <= cap_max * status,
-                name=f"{c.name}-{attr}_available_binary",
-                mask=None,
-            )
-            n.model.add_constraints(
-                available_cap >= cap_var + (status - purchased_com) * cap_max,
-                name=f"{c.name}-{attr}_available_switch",
-                mask=None,
-            )
+    available_cap = m[f"{c.name}-available_{attr}"].sel(name=com_i)
+    status = m[f"{c.name}-status"].sel(name=com_i)
+    cap_var_com = cap_var.sel(name=com_i)
+    cap_max_com = cap_max.sel(name=com_i)
+    purchased_com = purchased.sel(name=com_i)
+
+    m.add_constraints(
+        status <= purchased_com, name=f"{c.name}-{attr}_status_purchased_limit"
+    )
+    m.add_constraints(
+        available_cap <= cap_var_com, name=f"{c.name}-{attr}_available_continuous"
+    )
+    m.add_constraints(
+        available_cap <= cap_max_com * status,
+        name=f"{c.name}-{attr}_available_binary",
+    )
+    m.add_constraints(
+        available_cap >= cap_var_com + (status - purchased_com) * cap_max_com,
+        name=f"{c.name}-{attr}_available_switch",
+    )
 
 
 def define_modular_constraints(n: Network, component: str, attr: str) -> None:

--- a/pypsa/optimization/constraints.py
+++ b/pypsa/optimization/constraints.py
@@ -1770,7 +1770,8 @@ def define_purchase_constraints(n: Network, component: str, attr: str) -> None:
     assets the separate modularity equality then forces the module count to zero
     whenever the asset is not bought.
 
-    Applies to Generator (p_nom), Line (s_nom), Link (p_nom), Store (e_nom).
+    Applies to Generator (p_nom), Line (s_nom), Link (p_nom), Process (p_nom),
+    Store (e_nom) and StorageUnit (p_nom).
 
     Parameters
     ----------
@@ -1787,7 +1788,7 @@ def define_purchase_constraints(n: Network, component: str, attr: str) -> None:
     independently of the capacity decision (equivalent of unit commitment in dispatch),
     reflecting the reality of many investment decisions in energy systems (e.g., land purchase)
 
-    The function applies to extendable and non-extendable components.
+    The function applies only to extendable components.
 
     """
     m = n.model

--- a/pypsa/optimization/optimize.py
+++ b/pypsa/optimization/optimize.py
@@ -28,6 +28,7 @@ from pypsa.components.common import as_components
 from pypsa.consistency import (
     check_big_m_exceeded,
     check_no_modular_purchasable_committables,
+    check_purchasable_consistency,
 )
 from pypsa.constants import PYPSA_DATA_DIR
 from pypsa.descriptors import nominal_attrs
@@ -415,14 +416,15 @@ def define_objective(
             caps_lin = m[f"{c.name}-{attr}"].sel(name=ext_i)
             lin_weight = cost_weight.sel(name=ext_i)
             capex_terms.append((caps_lin * lin_weight * periodic_cost).sum(dim=sum_dim))
-        if (
-            not (purchasables := c.purchasables.difference(c.inactive_assets)).empty
-            and (unit_cost := c.unit_cost.sel(name=purchasables)).size > 0
-            and not (unit_cost == 0).all()
-        ):
-            purchased = m[f"{c.name}-purchased"].sel(name=purchasables)
-            unit_weight = cost_weight.sel(name=purchasables)
-            capex_terms.append((unit_cost * unit_weight * purchased).sum(dim="name"))
+        purchasables = c.active_purchasables
+        if not purchasables.empty:
+            unit_cost = c.periodized_unit_cost.sel(name=purchasables)
+            if unit_cost.size > 0 and not (unit_cost == 0).all():
+                purchased = m[f"{c.name}-purchased"].sel(name=purchasables)
+                unit_weight = cost_weight.sel(name=purchasables)
+                capex_terms.append(
+                    (unit_cost * unit_weight * purchased).sum(dim=sum_dim)
+                )
 
     # unit commitment
     keys = ["start_up", "shut_down"]  # noqa: F841
@@ -779,6 +781,8 @@ class OptimizationAccessor(OptimizationAbstractMixin):
                 for opt in (piecewise_options or [])
             }
         )
+        check_purchasable_consistency(n)
+
         if linearized_unit_commitment:
             check_no_modular_purchasable_committables(n)
 
@@ -1067,7 +1071,7 @@ class OptimizationAccessor(OptimizationAbstractMixin):
                 continue
 
             # Skip auxiliary unit purchase variables
-            if attr in ("available_p_nom", "available_s_nom", "available_e_nom"):
+            if attr.startswith("available_"):
                 continue
 
             if not hasattr(n.c, _c_name):

--- a/pypsa/optimization/variables.py
+++ b/pypsa/optimization/variables.py
@@ -392,18 +392,17 @@ def define_purchase_variables(
 ) -> None:
     """Define the unit purchase variables for extendable components."""
     c = n.components[c_name]
-    purchase_i = c.purchasables
+    purchase_i = c.active_purchasables
     if purchase_i.empty:
         return
-    mod_i = c.extendables.intersection(c.modulars)
-    purchased_continuous_com = purchase_i.difference(mod_i).intersection(c.committables)
+    com_i = purchase_i.difference(c.modulars).intersection(c.committables)
 
     n.model.add_variables(coords=[purchase_i], name=f"{c.name}-purchased", binary=True)
 
-    if purchased_continuous_com.empty:
+    if com_i.empty:
         return
 
-    active = c.da.active.sel(name=purchased_continuous_com, snapshot=sns)
+    active = c.da.active.sel(name=com_i, snapshot=sns)
     n.model.add_variables(
         coords=active.coords, name=f"{c.name}-available_{attr}", mask=active
     )

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -753,6 +753,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
                 attr_vals = comp.static[cost_attribute]
             piecewise_costs = comp.static.get(cost_attribute + "_piecewise_opt", 0)
             capex = capacity * (attr_vals + piecewise_costs)
+            if cost_attribute == "capital_cost" and "purchased_opt" in comp.static:
+                purchased = comp.static["purchased_opt"].fillna(0.0)
+                unit_cost = comp.periodized_unit_cost.to_series()
+                if isinstance(purchased.index, pd.MultiIndex):
+                    unit_cost = unit_cost.reorder_levels(purchased.index.names)
+                unit_cost = unit_cost.reindex(purchased.index).fillna(0.0)
+                capex = capex + purchased * unit_cost
             return capex
 
         df = self._aggregate_components(

--- a/pypsa/statistics/expressions.py
+++ b/pypsa/statistics/expressions.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Collection, Sequence
 
     from pypsa import Network, NetworkCollection
-    from pypsa.components.components import PortsLike
+    from pypsa.components.components import Components, PortsLike
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +65,15 @@ def get_operation(n: Network, c: str) -> pd.DataFrame:
         # Fallback for legacy networks where only p0 is stored (for Links)
         return n.c[c].dynamic.p0
     return p
+
+
+def _purchase_cost(comp: Components, unit_cost: pd.Series) -> pd.Series:
+    """Distribute a per-unit purchase cost over the optimized purchase decisions."""
+    purchased = comp.static["purchased_opt"].fillna(0.0)
+    if isinstance(purchased.index, pd.MultiIndex):
+        unit_cost = unit_cost.reorder_levels(purchased.index.names)
+    unit_cost = unit_cost.reindex(purchased.index).fillna(0.0)
+    return purchased * unit_cost
 
 
 def port_efficiency(
@@ -676,7 +685,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names: bool | None = None,
         drop_zero: bool | None = None,
         round: int | None = None,
-        cost_attribute: str = "capital_cost",
+        cost_attribute: str | None = None,
     ) -> pd.DataFrame:
         """Calculate the **capital expenditure**.
 
@@ -725,10 +734,14 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Other Parameters
         ----------------
-        cost_attribute : str
-            Network attribute that should be used to calculate Capital Expenditure.
-            Defaults to `capital_cost`. When set to `capital_cost`, the calculation uses
-            annuitized investment cost (without fixed O&M).
+        cost_attribute : str | None, default=None
+            Which cost attribute(s) to sum:
+            - `None`: All attributes, i.e. capacity capital_cost plus purchase unit_cost.
+            - `"capital_cost"`: Capacity term only, using annuitized investment cost
+              (without fixed O&M).
+            - `"unit_cost"`: Purchase term only, i.e. the periodized unit cost of
+              purchasable assets.
+            - any other column name: Capacity times that static column.
 
         Returns
         -------
@@ -747,19 +760,19 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         def func(n: Network, c: str, port: str) -> pd.Series:
             comp = n.c[c]
             capacity = comp.static[f"{nominal_attrs[c]}_opt"]
-            if cost_attribute == "capital_cost":
-                attr_vals = comp.capital_cost
-            else:
-                attr_vals = comp.static[cost_attribute]
-            piecewise_costs = comp.static.get(cost_attribute + "_piecewise_opt", 0)
-            capex = capacity * (attr_vals + piecewise_costs)
-            if cost_attribute == "capital_cost" and "purchased_opt" in comp.static:
-                purchased = comp.static["purchased_opt"].fillna(0.0)
-                unit_cost = comp.periodized_unit_cost.to_series()
-                if isinstance(purchased.index, pd.MultiIndex):
-                    unit_cost = unit_cost.reorder_levels(purchased.index.names)
-                unit_cost = unit_cost.reindex(purchased.index).fillna(0.0)
-                capex = capex + purchased * unit_cost
+            capex = pd.Series(0.0, index=capacity.index)
+            if cost_attribute != "unit_cost":
+                if cost_attribute in (None, "capital_cost"):
+                    attr_vals = comp.capital_cost
+                else:
+                    attr_vals = comp.static[cost_attribute]
+                piecewise_key = (cost_attribute or "capital_cost") + "_piecewise_opt"
+                piecewise_costs = comp.static.get(piecewise_key, 0)
+                capex = capex + capacity * (attr_vals + piecewise_costs)
+            if cost_attribute in (None, "unit_cost") and "purchased_opt" in comp.static:
+                capex = capex + _purchase_cost(
+                    comp, comp.periodized_unit_cost.to_series()
+                )
             return capex
 
         df = self._aggregate_components(
@@ -802,7 +815,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names: bool | None = None,
         drop_zero: bool | None = None,
         round: int | None = None,
-        cost_attribute: str = "capital_cost",
+        cost_attribute: str | None = None,
     ) -> pd.DataFrame:
         """Calculate the **capital expenditure** of already built capacities.
 
@@ -848,9 +861,13 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Other Parameters
         ----------------
-        cost_attribute : str
-            Network attribute that should be used to calculate Capital Expenditure.
-            Defaults to `capital_cost`.
+        cost_attribute : str | None, default=None
+            Which cost attribute(s) to sum:
+            - `None` or `"capital_cost"`: Capacity times annuitized investment cost
+              (without fixed O&M).
+            - `"unit_cost"`: Zero, since no purchase decision exists for already
+              installed (non-optimized) capacities (dropped unless `drop_zero=False`).
+            - any other column name: Capacity times that static column.
 
         Returns
         -------
@@ -874,7 +891,9 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         def func(n: Network, c: str, port: str) -> pd.Series:
             comp = n.c[c]
             capacity = comp.static[nominal_attrs[c]]
-            if cost_attribute == "capital_cost":
+            if cost_attribute == "unit_cost":
+                return pd.Series(0.0, index=capacity.index)
+            if cost_attribute in (None, "capital_cost"):
                 return capacity * comp.capital_cost
             return capacity * comp.static[cost_attribute]
 
@@ -918,7 +937,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names: bool | None = None,
         drop_zero: bool | None = None,
         round: int | None = None,
-        cost_attribute: str = "capital_cost",
+        cost_attribute: str | None = None,
     ) -> pd.DataFrame:
         """Calculate the **capital expenditure** of expanded capacities.
 
@@ -964,9 +983,14 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
 
         Other Parameters
         ----------------
-        cost_attribute : str
-            Network attribute that should be used to calculate Capital Expenditure.
-            Defaults to `capital_cost`.
+        cost_attribute : str | None, default=None
+            Which cost attribute(s) to sum, forwarded to `capex` and `installed_capex`:
+            - `None`: All attributes, i.e. capacity capital_cost plus purchase unit_cost.
+            - `"capital_cost"`: Capacity term only, using annuitized investment cost
+              (without fixed O&M).
+            - `"unit_cost"`: Purchase term only, i.e. the periodized unit cost of
+              purchasable assets.
+            - any other column name: Capacity times that static column.
 
         Returns
         -------
@@ -1028,6 +1052,7 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         nice_names: bool | None = None,
         drop_zero: bool | None = None,
         round: int | None = None,
+        cost_attribute: str | None = None,
     ) -> pd.DataFrame:
         """Calculate the **overnight investment costs** (excluding fom).
 
@@ -1064,6 +1089,16 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         round : int | None, default=None
             Number of decimal places to round the result to.
 
+        Other Parameters
+        ----------------
+        cost_attribute : str | None, default=None
+            Which cost attribute(s) to sum:
+            - `None`: All attributes, i.e. capacity overnight cost plus purchase
+              overnight cost.
+            - `"overnight_cost"`: Capacity term only.
+            - `"unit_cost"`: Purchase term only, i.e. the overnight unit cost of
+              purchasable assets.
+
         Returns
         -------
         pd.DataFrame
@@ -1076,12 +1111,23 @@ class StatisticsAccessor(AbstractStatisticsAccessor):
         :meth:`fom` : Returns fixed operation and maintenance costs.
 
         """
+        if cost_attribute not in (None, "overnight_cost", "unit_cost"):
+            msg = (
+                "cost_attribute must be None, 'overnight_cost' or 'unit_cost', "
+                f"got {cost_attribute!r}"
+            )
+            raise ValueError(msg)
 
         @pass_empty_series_if_keyerror
         def func(n: Network, c: str, port: str) -> pd.Series:
             comp = n.c[c]
             capacity = comp.static[f"{nominal_attrs[c]}_opt"]
-            return capacity * comp.overnight_cost
+            cost = pd.Series(0.0, index=capacity.index)
+            if cost_attribute in (None, "overnight_cost"):
+                cost = cost + capacity * comp.overnight_cost
+            if cost_attribute in (None, "unit_cost") and "purchased_opt" in comp.static:
+                cost = cost + _purchase_cost(comp, comp.overnight_unit_cost)
+            return cost
 
         df = self._aggregate_components(
             func,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -276,7 +276,7 @@ def test_unit_cost_property():
     n.add("Bus", "bus")
     n.add("Generator", "gen", bus="bus", p_nom=100, purchasable=True, unit_cost=1234.0)
 
-    assert n.c.generators.unit_cost.sel(name="gen").item() == 1234.0
+    assert n.c.generators.periodized_unit_cost.sel(name="gen").item() == 1234.0
 
 
 def test_unit_cost_property_overnight():
@@ -298,4 +298,6 @@ def test_unit_cost_property_overnight():
     )
 
     expected = 1000.0 * annuity(0.07, 25) * n.c.generators.nyears
-    assert n.c.generators.unit_cost.sel(name="gen").item() == pytest.approx(expected)
+    assert n.c.generators.periodized_unit_cost.sel(name="gen").item() == pytest.approx(
+        expected
+    )

--- a/test/test_lopf_purchasable.py
+++ b/test/test_lopf_purchasable.py
@@ -378,10 +378,11 @@ def test_purchase_with_scenarios(base_network):
 
 
 def test_purchase_with_investment_periods():
-    """Unit costs are weighted by the investment period weightings."""
+    """Unit costs are weighted by the investment period objective weightings."""
     n = pypsa.Network()
     n.set_snapshots(pd.MultiIndex.from_product([[2020, 2030], range(2)]))
     n.investment_periods = [2020, 2030]
+    n.investment_period_weightings["objective"] = [3, 7]
     n.add("Bus", "bus")
     n.add("Load", "load", bus="bus", p_set=100)
     n.add("Generator", "backup", bus="bus", p_nom=1000, marginal_cost=100)
@@ -398,13 +399,14 @@ def test_purchase_with_investment_periods():
         build_year=2020,
         lifetime=100,
     )
-    status, _ = n.optimize()
+    status, _ = n.optimize(multi_investment_periods=True)
 
     assert status == "ok"
     assert n.generators.at["gas", "purchased_opt"] == 1
     assert n.generators.at["gas", "p_nom_opt"] == 100
-    # 4 snapshots served by gas (10 * 100) plus the one-off unit cost.
-    assert n.objective == pytest.approx(4 * 100 * 10 + 500)
+    operating = (3 + 7) * 2 * 100 * 10
+    unit = 500 * (3 + 7)
+    assert n.objective == pytest.approx(operating + unit)
 
 
 def test_continuous_purchase_blocks_capacity(base_network):

--- a/test/test_lopf_purchasable.py
+++ b/test/test_lopf_purchasable.py
@@ -62,8 +62,8 @@ def test_purchase_variables_and_constraints(base_network):
     assert list(purchased.dims) == ["name"]
     assert list(purchased.indexes["name"]) == ["gas"]
 
-    # Modular purchasables tie the number of modules to the purchase decision.
-    assert "Generator-p_nom_modularity_purchased_bigM" in n.model.constraints
+    # The capacity is bounded by the purchase decision.
+    assert "Generator-p_nom_cap_binary" in n.model.constraints
 
 
 def test_no_purchase_variables_without_purchasable(base_network):
@@ -72,7 +72,7 @@ def test_no_purchase_variables_without_purchasable(base_network):
     n.optimize.create_model()
 
     assert "Generator-purchased" not in n.model.variables
-    assert "Generator-p_nom_modularity_purchased_bigM" not in n.model.constraints
+    assert "Generator-p_nom_cap_binary" not in n.model.constraints
 
 
 def test_purchase_worthwhile(base_network):
@@ -99,14 +99,18 @@ def test_purchase_not_worthwhile(base_network):
     assert n.objective == pytest.approx(BACKUP_ONLY_COST)
 
 
-def test_purchase_just_below_and_above_break_even(base_network):
-    """Purchase flips from 1 to 0 as the unit cost crosses break-even."""
-    savings = 450 * (100 - 10) - 200 * 10
+SAVINGS = 450 * (100 - 10) - 200 * 10
 
-    for unit_cost, expected in [(savings - 100, 1), (savings + 100, 0)]:
-        n = add_modular_generator(base_network.copy(), unit_cost=unit_cost)
-        n.optimize()
-        assert n.generators.at["gas", "purchased_opt"] == expected
+
+@pytest.mark.parametrize(
+    ("unit_cost", "expected"),
+    [(SAVINGS - 100, 1), (SAVINGS + 100, 0)],
+)
+def test_purchase_just_below_and_above_break_even(base_network, unit_cost, expected):
+    """Purchase flips from 1 to 0 as the unit cost crosses break-even."""
+    n = add_modular_generator(base_network, unit_cost=unit_cost)
+    n.optimize()
+    assert n.generators.at["gas", "purchased_opt"] == expected
 
 
 def test_purchased_opt_only_for_purchasables(base_network):
@@ -131,7 +135,9 @@ def test_unit_cost_overnight_is_annuitised(base_network):
     nyears = n.c.generators.nyears
     expected = overnight * annuity(rate, lifetime) * nyears
 
-    assert n.c.generators.unit_cost.sel(name="gas").item() == pytest.approx(expected)
+    assert n.c.generators.periodized_unit_cost.sel(name="gas").item() == pytest.approx(
+        expected
+    )
 
     n.optimize()
     assert n.generators.at["gas", "purchased_opt"] == 1
@@ -148,7 +154,7 @@ def test_unit_cost_overnight_takes_precedence(base_network):
         lifetime=10,
     )
     nyears = n.c.generators.nyears
-    assert n.c.generators.unit_cost.sel(name="gas").item() == pytest.approx(
+    assert n.c.generators.periodized_unit_cost.sel(name="gas").item() == pytest.approx(
         1e6 / 10 * nyears
     )
 
@@ -162,104 +168,31 @@ def test_zero_unit_cost_not_in_objective(base_network):
     assert n.objective == pytest.approx(450 * 10 + 200 * 10)
 
 
-@pytest.mark.parametrize(
-    "component",
-    [
-        "Generator",
-        "Link",
-        "Line",
-        "Process",
-        "Store",
-        pytest.param(
-            "StorageUnit",
-            marks=pytest.mark.xfail(
-                reason="define_purchase_constraints derives big-M values via "
-                "get_bounds_pu with the component's base attribute, which "
-                "StorageUnit does not accept",
-                raises=ValueError,
-                strict=True,
-            ),
-        ),
-    ],
-)
+COMPONENT_KWARGS = {
+    "Generator": {"bus": "bus", "p_nom_extendable": True, "marginal_cost": 1},
+    "Link": {"bus0": "bus1", "bus1": "bus", "p_nom_extendable": True},
+    "Process": {"bus0": "bus1", "bus1": "bus", "p_nom_extendable": True},
+    "Line": {"bus0": "bus1", "bus1": "bus", "x": 0.1, "s_nom_extendable": True},
+    "Store": {"bus": "bus", "e_nom_extendable": True},
+    "StorageUnit": {"bus": "bus", "p_nom_extendable": True},
+}
+
+
+@pytest.mark.parametrize("component", list(COMPONENT_KWARGS))
 def test_prohibitive_unit_cost_blocks_all_components(base_network, component):
     """A prohibitive unit cost prevents the purchase for every component type."""
     n = base_network
     n.add("Bus", "bus1")
     n.add("Generator", "cheap", bus="bus1", p_nom=1000, marginal_cost=1)
 
-    common = {"purchasable": True, "unit_cost": 1e9}
-    if component == "Generator":
-        n.add(
-            "Generator",
-            "asset",
-            bus="bus",
-            p_nom_extendable=True,
-            p_nom_max=500,
-            p_nom_mod=100,
-            marginal_cost=1,
-            **common,
-        )
-        nom_attr = "p_nom"
-    elif component == "Link":
-        n.add(
-            "Link",
-            "asset",
-            bus0="bus1",
-            bus1="bus",
-            p_nom_extendable=True,
-            p_nom_max=500,
-            p_nom_mod=100,
-            **common,
-        )
-        nom_attr = "p_nom"
-    elif component == "Process":
-        n.add(
-            "Process",
-            "asset",
-            bus0="bus1",
-            bus1="bus",
-            p_nom_extendable=True,
-            p_nom_max=500,
-            p_nom_mod=100,
-            **common,
-        )
-        nom_attr = "p_nom"
-    elif component == "Line":
-        n.add(
-            "Line",
-            "asset",
-            bus0="bus1",
-            bus1="bus",
-            x=0.1,
-            s_nom_extendable=True,
-            s_nom_max=500,
-            s_nom_mod=100,
-            **common,
-        )
-        nom_attr = "s_nom"
-    elif component == "Store":
-        n.add(
-            "Store",
-            "asset",
-            bus="bus",
-            e_nom_extendable=True,
-            e_nom_max=500,
-            e_nom_mod=100,
-            **common,
-        )
-        nom_attr = "e_nom"
-    else:
-        n.add(
-            "StorageUnit",
-            "asset",
-            bus="bus",
-            p_nom_extendable=True,
-            p_nom_max=500,
-            p_nom_mod=100,
-            **common,
-        )
-        nom_attr = "p_nom"
+    nom_attr = {"Line": "s_nom", "Store": "e_nom"}.get(component, "p_nom")
+    kwargs = COMPONENT_KWARGS[component] | {
+        f"{nom_attr}_max": 500,
+        f"{nom_attr}_mod": 100,
+        "purchasable": True,
+        "unit_cost": 1e9,
+    }
+    n.add(component, "asset", **kwargs)
 
     status, _ = n.optimize()
 
@@ -428,12 +361,6 @@ def test_linearized_unit_commitment_rejects_purchasables(base_network):
         n.optimize(linearized_unit_commitment=True)
 
 
-@pytest.mark.xfail(
-    reason="the purchase-dependent lower capacity bound in "
-    "`define_nominal_constraints_for_extendables` does not broadcast the "
-    "scenario-less purchase variable against the scenario-indexed bound",
-    strict=True,
-)
 def test_purchase_with_scenarios(base_network):
     """The purchase decision is shared across scenarios."""
     n = base_network
@@ -447,6 +374,7 @@ def test_purchase_with_scenarios(base_network):
     n.optimize()
     purchased_opt = n.generators.xs("gas", level="name")["purchased_opt"]
     assert (purchased_opt == 1).all()
+    assert n.objective == pytest.approx(450 * 10 + 200 * 10 + 500)
 
 
 def test_purchase_with_investment_periods():
@@ -475,6 +403,8 @@ def test_purchase_with_investment_periods():
     assert status == "ok"
     assert n.generators.at["gas", "purchased_opt"] == 1
     assert n.generators.at["gas", "p_nom_opt"] == 100
+    # 4 snapshots served by gas (10 * 100) plus the one-off unit cost.
+    assert n.objective == pytest.approx(4 * 100 * 10 + 500)
 
 
 def test_continuous_purchase_blocks_capacity(base_network):
@@ -551,12 +481,6 @@ def test_mixed_purchasable_flavours(base_network):
     assert n.objective == pytest.approx(BACKUP_ONLY_COST)
 
 
-@pytest.mark.xfail(
-    reason="`purchasable` is only supported for extendable components, but a "
-    "non-extendable purchasable raises an opaque `KeyError: 'Generator-p_nom'` from "
-    "`define_purchase_constraints` instead of a consistency error",
-    strict=True,
-)
 def test_non_extendable_purchasable_raises_clear_error(base_network):
     """Purchasable is meaningless without an extendable capacity."""
     n = base_network
@@ -570,8 +494,177 @@ def test_non_extendable_purchasable_raises_clear_error(base_network):
         unit_cost=500,
     )
 
-    with pytest.raises(ValueError, match="purchasable"):
+    with pytest.raises(ValueError, match="only supported for extendable"):
         n.optimize()
+
+
+def test_maintainable_committable_purchasable_raises(base_network):
+    """A non-modular purchasable that is committable and maintainable is rejected."""
+    n = base_network
+    n.add(
+        "Generator",
+        "gas",
+        bus="bus",
+        p_nom_extendable=True,
+        p_nom_max=500,
+        committable=True,
+        maintainable=True,
+        maintenance_duration=1,
+        marginal_cost=10,
+        purchasable=True,
+        unit_cost=500,
+    )
+
+    with pytest.raises(ValueError, match="maintainable but not modular"):
+        n.optimize()
+
+
+def test_inactive_purchasable_extendable(base_network):
+    """An inactive purchasable extendable does not crash and is not purchased."""
+    n = base_network
+    add_modular_generator(n, unit_cost=500)
+    n.add(
+        "Generator",
+        "gas_off",
+        bus="bus",
+        p_nom_extendable=True,
+        p_nom_max=500,
+        marginal_cost=10,
+        capital_cost=10,
+        purchasable=True,
+        unit_cost=500,
+        active=False,
+    )
+
+    status, _ = n.optimize()
+
+    assert status == "ok"
+    assert "gas_off" not in n.model["Generator-purchased"].indexes["name"]
+    assert n.generators.at["gas", "purchased_opt"] == 1
+    assert np.isnan(n.generators.at["gas_off", "purchased_opt"])
+
+
+def test_mixed_purchasable_and_non_purchasable_with_min(base_network):
+    """A forced non-purchasable extendable coexists with an unbought purchasable."""
+    n = base_network
+    n.add(
+        "Generator",
+        "forced",
+        bus="bus",
+        p_nom_extendable=True,
+        p_nom_min=50,
+        marginal_cost=10,
+        capital_cost=10,
+    )
+    n.add(
+        "Generator",
+        "opt",
+        bus="bus",
+        p_nom_extendable=True,
+        p_nom_min=50,
+        p_nom_max=500,
+        marginal_cost=10,
+        capital_cost=10,
+        purchasable=True,
+        unit_cost=1e9,
+    )
+
+    status, _ = n.optimize()
+
+    assert status == "ok"
+    assert n.generators.at["forced", "p_nom_opt"] >= 50 - 1e-6
+    assert n.generators.at["opt", "purchased_opt"] == 0
+    assert n.generators.at["opt", "p_nom_opt"] == pytest.approx(0, abs=1e-6)
+
+
+def test_small_module_size_purchasable(base_network):
+    """A small module size still reaches the capacity needed to serve the load."""
+    n = pypsa.Network(snapshots=range(1))
+    n.add("Bus", "bus")
+    n.add("Load", "load", bus="bus", p_set=1)
+    n.add("Generator", "backup", bus="bus", p_nom=1000, marginal_cost=100)
+    n.add(
+        "Generator",
+        "gas",
+        bus="bus",
+        p_nom_extendable=True,
+        p_nom_max=2,
+        p_nom_mod=0.1,
+        marginal_cost=10,
+        purchasable=True,
+        unit_cost=1,
+    )
+
+    status, _ = n.optimize()
+
+    assert status == "ok"
+    assert n.generators.at["gas", "purchased_opt"] == 1
+    assert n.generators.at["gas", "p_nom_opt"] == pytest.approx(1.0)
+
+
+def test_infinite_nom_max_with_low_max_pu(base_network):
+    """An unbounded capacity with max_pu < 1 is not silently capped by the big-M."""
+    n = base_network
+    n.add(
+        "Generator",
+        "gas",
+        bus="bus",
+        p_nom_extendable=True,
+        p_nom_max=inf,
+        p_max_pu=0.1,
+        marginal_cost=10,
+        capital_cost=0.01,
+        purchasable=True,
+        unit_cost=1,
+    )
+
+    status, _ = n.optimize()
+
+    assert status == "ok"
+    assert n.generators.at["gas", "purchased_opt"] == 1
+    # Peak load is 200 and p_max_pu is 0.1, so 2000 MW of capacity are needed.
+    # The old big-M scaled by max_pu would have capped this near the peak load.
+    assert n.generators.at["gas", "p_nom_opt"] == pytest.approx(2000)
+    assert n.generators_t.p["backup"].sum() == pytest.approx(0, abs=1e-6)
+
+
+def test_committable_link_negative_p_min_pu_purchasable(base_network):
+    """A committable purchasable link with a negative p_min_pu solves consistently."""
+    n = base_network
+    n.add("Bus", "bus1")
+    n.add("Generator", "cheap", bus="bus1", p_nom=1000, marginal_cost=1)
+    n.add(
+        "Link",
+        "link",
+        bus0="bus1",
+        bus1="bus",
+        p_nom_extendable=True,
+        p_nom_max=500,
+        committable=True,
+        p_min_pu=-1,
+        status=0,
+        up_time_before=0,
+        marginal_cost=1,
+        purchasable=True,
+        unit_cost=1,
+    )
+
+    status, _ = n.optimize()
+
+    assert status == "ok"
+    purchased = n.links.at["link", "purchased_opt"]
+    assert (n.links_t.status["link"] <= purchased + 1e-6).all()
+
+
+def test_capex_reconciles_with_objective(base_network):
+    """`n.statistics.capex()` includes the purchase cost and reconciles the objective."""
+    n = add_modular_generator(base_network, unit_cost=500)
+    n.optimize()
+
+    capex = n.statistics.capex().sum()
+    opex = n.statistics.opex().sum()
+    assert capex == pytest.approx(200 * 10 + 500)
+    assert capex + opex == pytest.approx(n.objective)
 
 
 # --------------------------------------------------------------------------- #
@@ -653,7 +746,7 @@ def assert_solution_consistent(n, mod, com, p_min_pu, p_nom_max, p_nom_min):
         10 * p.sum()
         + 100 * n.generators_t.p["backup"].sum()
         + 10 * p_nom
-        + float(n.c.generators.unit_cost.sel(name="gas").item()) * purchased
+        + float(n.c.generators.periodized_unit_cost.sel(name="gas").item()) * purchased
     )
     assert n.objective == pytest.approx(expected)
 
@@ -695,7 +788,9 @@ def test_matrix_unit_cost_overnight(base_network, combo):
         lifetime=25,
     )
     expected = 1e6 * annuity(0.07, 25) * n.c.generators.nyears
-    assert n.c.generators.unit_cost.sel(name="gas").item() == pytest.approx(expected)
+    assert n.c.generators.periodized_unit_cost.sel(name="gas").item() == pytest.approx(
+        expected
+    )
 
     status, condition = n.optimize()
 

--- a/test/test_lopf_purchasable.py
+++ b/test/test_lopf_purchasable.py
@@ -668,6 +668,34 @@ def test_capex_reconciles_with_objective(base_network):
     assert capex == pytest.approx(200 * 10 + 500)
     assert capex + opex == pytest.approx(n.objective)
 
+    capacity = n.statistics.capex(cost_attribute="capital_cost").sum()
+    purchase = n.statistics.capex(cost_attribute="unit_cost").sum()
+    assert capacity == pytest.approx(200 * 10)
+    assert purchase == pytest.approx(500)
+    assert capex == pytest.approx(capacity + purchase)
+    assert n.statistics.installed_capex(cost_attribute="unit_cost").empty
+    assert n.statistics.expanded_capex(
+        cost_attribute="unit_cost"
+    ).sum() == pytest.approx(500)
+
+
+def test_overnight_cost_composes_purchase(base_network):
+    """`overnight_cost` composes the capacity and purchase overnight terms."""
+    n = add_modular_generator(
+        base_network, unit_cost=500, discount_rate=0.07, lifetime=25
+    )
+    n.optimize()
+
+    total = n.statistics.overnight_cost().sum()
+    capacity = n.statistics.overnight_cost(cost_attribute="overnight_cost").sum()
+    purchase = n.statistics.overnight_cost(cost_attribute="unit_cost").sum()
+    assert capacity == pytest.approx(200 * n.c.generators.overnight_cost["gas"])
+    assert purchase == pytest.approx(n.c.generators.overnight_unit_cost["gas"])
+    assert total == pytest.approx(capacity + purchase)
+
+    with pytest.raises(ValueError, match="cost_attribute must be"):
+        n.statistics.overnight_cost(cost_attribute="capital_cost")
+
 
 # --------------------------------------------------------------------------- #
 # Attribute matrix


### PR DESCRIPTION
Builds on and targets the branch of #1900 (does not close an issue).

## Changes proposed in this Pull Request

> [!NOTE]
> This description was AI-drafted from the review of #1900 and needs the author's confirmation.

Fixes from the review of #1900, targeted at that PR's branch so they land as a single reviewable diff on top of it.

**Must fix (crashes / wrong results)**

- Deleted the purchasable-committable maintenance branch that referenced an unbound `nominal_mod`, a never-created maintenance status variable, and a bilinear `A * w`. Added a consistency check rejecting `purchasable & committable & maintainable & ~modular` with a clear `ValueError`.
- Added a single `Components.active_purchasables` property (`purchasables ∩ extendables ∩ active_assets`) used in variables, constraints and the objective, so inactive and never-active multi-invest purchasables no longer raise `KeyError: 'Generator-p_nom'`.
- `check_purchasable_consistency` raises `ValueError` for `purchasable & ~extendable`; the earlier double `com_fix_i`/`com_pur_i` membership is gone.
- Dropped the modular branch that bounded a module count with a capacity-unit big-M (which capped capacity at the module size). The continuous bound `capacity <= cap_max * purchased` now applies to all purchasables; the modularity equality forces `n_mod = 0` when not bought.
- `cap_max` now uses an unscaled big-M (not scaled by `max_pu`), fixing a silent cap for low-`max_pu` assets and a crash for `StorageUnit`. `check_big_m_exceeded` extended to purchasables.
- Fixed the multi-investment scenarios case (previously an xfail) by splitting the lower-bound constraint into a plain bound and a scenario-broadcasting purchased bound, and switched the objective purchase term to `sum_dim` for correct multi-invest weighting.

**Cleanups**

- `n.statistics.capex()` now includes `purchased_opt * periodized_unit_cost` (reconciles with the objective).
- Renamed the computed property `unit_cost` to `periodized_unit_cost` (symmetry with `periodized_cost`).
- `check_cost_consistency` warns when both `unit_cost` and `unit_cost_overnight` are set.
- Removed dead code and copy-pasted comments; `available_*` skip via `startswith`; docstring and docs "current limitations" updated.

**Tests**

Converted the three strict xfails into genuine behaviour tests (non-extendable raises, `StorageUnit` solves, scenarios asserts objective). Added edge cases: inactive purchasable, mixed purchasable/non-purchasable with `p_nom_min`, small module size, unbounded `p_nom_max` with low `max_pu`, committable `Link` with negative `p_min_pu`, the maintainable-committable rejection, capex reconciliation, and a real multi-invest objective assertion. Parametrised the break-even and per-component tests.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `docs/release-notes.md` of the upcoming release is included. (covered by the #1900 feature note; these are fixes to unreleased code)
- [ ] PR description is written by me. Any potentially verbose AI-generated content is marked (see [Contributing guidelines](https://docs.pypsa.org/latest/contributing/contributing/)).
- [ ] I consent to the release of this PR's code under the MIT license.
